### PR TITLE
feat: pipeline execution (Phase 1 MVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,17 @@ For ambiguous cases, Lua hooks can call a small/cheap LLM (`ctx.llm()`) for ligh
 
 ### State and context persistence
 
-When `state.data_dir` is set, conversation and rules persist across restarts using SQLite (`state.db`). The app uses the **pure-Go** driver [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite), so no system SQLite library is required—it's a normal Go dependency and is compiled into the binary. **General** rules (shared) and **per-actor** rules (per user) are stored as memories so multiple users get shared context plus their own. The LLM receives general context (config rules, general stored rules, tools), user/actor context (that actor’s stored rules), and the **session** (conversation history). Sessions are one per channel/conversation or thread; optional **summarization** after N messages compresses history into a summary and keeps only the last few messages, so token usage stays bounded. See [docs/design/channels.md](docs/design/channels.md) (State and memory) and `config.example.yaml` (`state.session`) for details.
+When `state.data_dir` is set, conversation and rules persist across restarts using SQLite (`state.db`). The app uses the **pure-Go** driver [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite), so no system SQLite library is required—it’s a normal Go dependency and is compiled into the binary. **General** rules (shared) and **per-actor** rules (per user) are stored as memories so multiple users get shared context plus their own. The LLM receives general context (config rules, general stored rules, tools), user/actor context (that actor’s stored rules), and the **session** (conversation history). Sessions are one per channel/conversation or thread; optional **summarization** after N messages compresses history into a summary and keeps only the last few messages, so token usage stays bounded. Pipeline state is currently in-memory only — persistence is planned for Phase 4. See [docs/design/channels.md](docs/design/channels.md) (State and memory) and `config.example.yaml` (`state.session`) for details.
 
 ```
-User message ──▶ Pre-hooks (Lua / Go / small LLM) ──▶ Main LLM ──▶ Post-hooks (Lua / Go) ──▶ Response
-                  │  zero tokens for rules                │              │
-                  │  cheap tokens for small LLM           │              │  enforce vocabulary
-                  │  full power via gRPC plugins          │              │  compliance, transform
+User message ──▶ Pre-hooks (Lua / Go / small LLM) ──▶ Planner ──▶ Main LLM ──▶ Post-hooks (Lua / Go) ──▶ Response
+                  │  zero tokens for rules                │            │              │
+                  │  cheap tokens for small LLM           │            │              │  enforce vocabulary
+                  │  full power via gRPC plugins           │            │              │  compliance, transform
+                                                          │            │
+                                                   multi-step?         │
+                                                    ├─ yes ──▶ Pipeline Executor ──▶ Results
+                                                    └─ no  ──▶ Agent Loop ─────────┘
 ```
 
 ### Stability
@@ -243,6 +247,7 @@ All three categories share the same set of extension points:
 - [Storage backends](docs/design/state.md)
 - [Notification channels](#channel-plugins-grpc--http--ws--any-language)
 - [Scheduled tasks](#scheduler)
+- [Pipeline execution](#pipeline-execution) (multi-step orchestration)
 - Custom API endpoints (inbound via [channels](#channel-plugins-grpc--http--ws--any-language), outbound via [tool plugins](#tool-plugins-grpc--any-language))
 
 ### Developer Experience
@@ -380,6 +385,75 @@ Users can also create jobs by talking to the LLM:
 - **Approvers** — when configured, only designated users can create, update, or delete dynamic jobs
 - **Per-user limits** — `max_jobs_per_user` prevents any single user from creating excessive jobs
 - **Full CRUD** — list, pause, resume, update, and delete jobs through the LLM or directly via the scheduler API
+
+## Pipeline Execution
+
+When a user request involves multiple steps (e.g. "check the bug in AppSignal, create a Jira ticket, and open a merge request"), OpenTalon's pipeline planner decomposes it into a structured plan, asks for confirmation, and executes each step with built-in retry and error reporting.
+
+```mermaid
+flowchart LR
+    User["User Message"] --> Planner["Planner (LLM)"]
+    Planner -->|"multi-step"| Plan["Plan + Confirm"]
+    Plan -->|"approved"| Executor["Pipeline Executor"]
+    Executor --> Results["Results"]
+    Planner -->|"single-step"| AgentLoop["Agent Loop"]
+    AgentLoop --> Results
+```
+
+### How it works
+
+1. **Planner** — a separate LLM call decomposes the user prompt into a DAG of steps with dependencies. If the prompt is a simple single-step request, the normal agent loop handles it (safe degradation).
+2. **Confirmation** — the plan is presented to the user via their channel (Slack, console, etc.). The user approves (`y`/`yes`) or rejects. Nothing executes without explicit approval.
+3. **Executor** — walks the step DAG in dependency order. Each step calls a plugin action via gRPC. Per-step retry with exponential backoff, per-step timeout, and fail-fast or continue-on-error behavior.
+4. **Results** — on completion (or failure), the user sees what succeeded, what failed, and how many retries were attempted. All tool calls and results are recorded in the session history.
+
+### Example conversation
+
+> **User:** _"Check bug #4521 in AppSignal, then create a Jira ticket and open a GitLab MR with the fix"_
+>
+> **OpenTalon:**
+> ```
+> I've created a plan with the following steps:
+>
+> 1. Check bug in AppSignal
+>    Action: appsignal.get_error (error_id=4521)
+> 2. Create Jira bug ticket
+>    Action: jira.create_issue
+>    Depends on: 1
+> 3. Create MR with fix
+>    Action: gitlab.create_mr
+>    Depends on: 1, 2
+>
+> Proceed? (y)es / (n)o
+> ```
+>
+> **User:** _"y"_
+>
+> **OpenTalon:** _"Pipeline complete — 3/3 steps succeeded."_
+
+### Configuration
+
+```yaml
+orchestrator:
+  pipeline:
+    enabled: true          # default false
+    max_step_retries: 3    # retries per step before giving up (default 3)
+    step_timeout: "60s"    # per-step timeout as Go duration (default "60s")
+```
+
+### Debugging
+
+Set `LOG_LEVEL=debug` to see pipeline decisions, planner LLM calls, step execution, and retry attempts — all prefixed with `[pipeline]`.
+
+### Current limitations (Phase 1)
+
+- **In-memory only** — pipeline state is not persisted; a process restart loses pending/running pipelines (persistence planned for Phase 4)
+- **No step output templating** — template references like `{{steps.1.output.id}}` are passed literally to plugins (planned for Phase 3)
+- **Sequential execution only** — steps with independent dependencies run one at a time (parallel execution planned for Phase 3)
+- **LLM quality dependent** — weaker models may return single-step plans for multi-step requests, causing fallback to the agent loop (expected safe degradation)
+- **No recovery advisor** — failed steps are retried as-is without LLM-assisted diagnosis (planned for Phase 2)
+
+> For the full roadmap (recovery advisor, replan, parallel execution, persistence), see [docs/design/pipeline.md](docs/design/pipeline.md).
 
 ## Build locally with plugins
 

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -10,10 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"time"
+
 	"github.com/opentalon/opentalon/internal/bundle"
 	"github.com/opentalon/opentalon/internal/channel"
 	"github.com/opentalon/opentalon/internal/config"
 	"github.com/opentalon/opentalon/internal/orchestrator"
+	"github.com/opentalon/opentalon/internal/pipeline"
 	"github.com/opentalon/opentalon/internal/plugin"
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/requestpkg"
@@ -221,6 +224,15 @@ func main() {
 	if permPluginName != "" {
 		permChecker = orchestrator.NewPermissionChecker(toolRegistry, orchestrator.NewGuard(), permPluginName)
 	}
+	pipelineCfg := pipeline.DefaultConfig()
+	if cfg.Orchestrator.Pipeline.MaxStepRetries > 0 {
+		pipelineCfg.MaxStepRetries = cfg.Orchestrator.Pipeline.MaxStepRetries
+	}
+	if cfg.Orchestrator.Pipeline.StepTimeout != "" {
+		if d, err := time.ParseDuration(cfg.Orchestrator.Pipeline.StepTimeout); err == nil {
+			pipelineCfg.StepTimeout = d
+		}
+	}
 	orch := orchestrator.NewWithRules(llm, orchestrator.DefaultParser, toolRegistry, memory, sessions, orchestrator.OrchestratorOpts{
 		CustomRules:             cfg.Orchestrator.Rules,
 		ContentPreparers:        contentPreparers,
@@ -231,6 +243,8 @@ func main() {
 		MaxMessagesAfterSummary: cfg.State.Session.MaxMessagesAfterSummary,
 		SummarizePrompt:         cfg.State.Session.SummarizePrompt,
 		SummarizeUpdatePrompt:   cfg.State.Session.SummarizeUpdatePrompt,
+		PipelineEnabled:         cfg.Orchestrator.Pipeline.Enabled,
+		PipelineConfig:          pipelineCfg,
 	})
 
 	ensureSession := func(sessionKey string) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -47,6 +47,13 @@ orchestrator:
     - plugin: hello-world
       action: prepare
       arg_key: text
+  # Pipeline execution: LLM-planned multi-step workflows with confirmation and retry.
+  # When enabled, the planner decomposes multi-step requests into a DAG of plugin actions,
+  # asks the user for confirmation, and executes with per-step retry and timeout.
+  # pipeline:
+  #   enabled: true
+  #   max_step_retries: 3    # retries per step before giving up (default 3)
+  #   step_timeout: "60s"    # per-step timeout as Go duration (default "60s")
 
 channels:
   console:

--- a/docs/design/pipeline.md
+++ b/docs/design/pipeline.md
@@ -1,0 +1,364 @@
+# Pipeline Execution Architecture
+
+## Problem
+
+Currently, OpenTalon's orchestrator handles multi-step tasks via an agentic loop — the LLM decides what to do at each step, calls tools, gets results, and repeats up to 20 iterations. The `invoke steps` feature provides a rigid sequential chain without LLM involvement.
+
+Neither approach is fault-tolerant. When a tool call fails, the agent loop dumps the error back to the LLM and hopes for the best. There's no structured retry, no error recovery, no progress tracking, and no way to resume a failed multi-step task.
+
+We need a middle ground: **structured pipeline execution with LLM-assisted error recovery**.
+
+## Motivating Example
+
+User prompt:
+> Check bug in appsignal, checkout source code, create jira bug ticket, create MR in gitlab with fix
+
+Expected behavior:
+
+1. Planner decomposes this into 4 steps
+2. **User reviews the plan** — confirms, edits, or rejects
+3. **Check bug in appsignal** -> success -> proceed
+4. **Checkout source code** -> success -> proceed
+5. **Create jira bug ticket** -> fails: `jira: command not found`
+   - Recovery advisor asks LLM: "why did this fail?"
+   - LLM responds: "jira CLI is not installed, install it with `brew install jira-cli`"
+   - System executes remediation -> retries step -> success -> proceed
+6. **Create MR in gitlab with fix** -> success
+7. Pipeline complete, return results to user
+
+If retries exceed the configured limit (e.g., 5), the pipeline aborts and reports what succeeded, what failed, and why.
+
+## Architecture Overview
+
+```
++---------------------------------------------------------+
+|                     User Prompt                         |
++----------------------------+----------------------------+
+                             |
+                             v
++---------------------------------------------------------+
+|                       PLANNER                           |
+|  LLM decomposes prompt into a Pipeline (DAG of Steps)  |
+|  Each step: command, plugin/action, success criteria,   |
+|  dependencies on prior steps                            |
++----------------------------+----------------------------+
+                             |  Proposed Pipeline
+                             v
++---------------------------------------------------------+
+|                  CONFIRMATION GATE                      |
+|  Present plan to user via channel                       |
+|  User can: approve / edit steps / reject                |
+|  Also triggered after every replan                      |
++----------------------------+----------------------------+
+                             |  Approved Pipeline
+                             v
++---------------------------------------------------------+
+|                 PIPELINE EXECUTOR                       |
+|  Walks DAG in topological order                         |
+|  Manages state transitions per step                     |
+|  Passes context (outputs) between steps                 |
+|  Enforces global + per-step retry limits                |
++------------+----------------------------+---------------+
+             | execute                    | on failure
+             v                            v
++----------------+            +------------------------+
+|  STEP RUNNER   |            |   RECOVERY ADVISOR     |
+|  Plugin call   |            |   Sends error + ctx    |
+|  Shell cmd     |            |   to LLM: "why did     |
+|  HTTP request  |            |   this fail? how to    |
+|  LLM query     |            |   fix it?"             |
++----------------+            +-----------+------------+
+                                          |
+                                          v
+                              +------------------------+
+                              |   REMEDIATOR           |
+                              |   Executes the fix     |
+                              |   suggested by LLM     |
+                              |   Then retries step    |
+                              +------------------------+
+```
+
+---
+
+## Implementation Status
+
+### Phase 1 — MVP: IMPLEMENTED
+
+Phase 1 is fully implemented and tested. Below is a component-by-component breakdown.
+
+#### Files Created
+
+| File | Status | Description |
+|------|--------|-------------|
+| `internal/pipeline/pipeline.go` | Done | Pipeline, PipelineState, PipelineConfig, FormatForConfirmation |
+| `internal/pipeline/step.go` | Done | Step, StepState, StepResult |
+| `internal/pipeline/command.go` | Done | PluginCommand (only command type for Phase 1) |
+| `internal/pipeline/context.go` | Done | PipelineContext with thread-safe Set/Get/Merge |
+| `internal/pipeline/confirmation.go` | Done | ParseConfirmation — binary approve/reject |
+| `internal/pipeline/planner.go` | Done | Planner with LLM decomposition, JSON parsing, markdown fence handling |
+| `internal/pipeline/executor.go` | Done | Executor with retry, backoff, FailFast, dependency skipping |
+| `internal/pipeline/context_test.go` | Done | 4 tests |
+| `internal/pipeline/confirmation_test.go` | Done | 2 tests |
+| `internal/pipeline/planner_test.go` | Done | 8 tests |
+| `internal/pipeline/executor_test.go` | Done | 7 tests |
+| `internal/pipeline/pipeline_test.go` | Done | 4 tests |
+
+#### Files Modified
+
+| File | Status | Description |
+|------|--------|-------------|
+| `internal/config/config.go` | Done | Added `PipelineOrchestratorConfig` to config struct |
+| `internal/orchestrator/orchestrator.go` | Done | Pipeline integration: planner, pending pipelines, confirmation, execution |
+| `cmd/opentalon/main.go` | Done | Wiring: config → PipelineConfig → OrchestratorOpts |
+| `internal/orchestrator/orchestrator_test.go` | Done | 6 pipeline integration tests |
+
+#### Component Details
+
+**1. Planner** — Done
+- Separate LLM call with system prompt listing available tools
+- Returns `{"type": "direct"}` or `{"type": "pipeline", "steps": [...]}`
+- Handles markdown code fences in LLM output (`extractJSON`)
+- Falls back to "direct" on parse failure (safe degradation)
+- Debug logging via `LOG_LEVEL=debug` env var
+
+**2. Confirmation Gate** — Done (simplified from design)
+- Uses **session-state pattern**: pipeline stored in `pendingPipelines[sessionID]`, next user message parses confirmation. This avoids blocking the channel dispatch goroutine.
+- Binary decision only: `y`/`yes` (case-insensitive) → approve; everything else → reject with message "Pipeline cancelled (expected y/yes to confirm)."
+- Unix-style prompt: `Proceed? (y)es / (n)o`
+
+**Deviation from design:** The original design had three-way confirmation (approve/edit/reject) and a dedicated `ConfirmationGate` struct with channel sender and timeout. The implementation uses a simpler session-state approach with no edit capability and no timeout. The `Unknown` state (treating non-y/n input as a new request) was removed during development — strict binary is better UX.
+
+**3. Pipeline & Step Types** — Done
+- 6 pipeline states: `planned`, `awaiting_confirmation`, `running`, `completed`, `failed`, `rejected`
+- 5 step states: `pending`, `running`, `succeeded`, `failed`, `skipped`
+- `PipelineConfig`: MaxStepRetries (default 3), StepTimeout (default 60s), FailFast (default true)
+- `FormatForConfirmation()` renders human-readable plan with step names, actions, args, dependencies
+
+**Deviation from design:** No `MaxRemediations`, `FailStrategy` enum, `RequireConfirm`, or `ConfirmOnReplan` config fields — these belong to Phase 2/3. Config uses a simple `FailFast bool` instead of `FailStrategy` enum.
+
+**4. Command Types** — Done (Phase 1 scope)
+- Only `PluginCommand` implemented (struct with Plugin, Action, Args fields)
+- No `Command` interface — unnecessary abstraction for Phase 1 with only one type
+
+**Deviation from design:** The design proposed a `Command` interface with `Execute()`, `Describe()`, `Type()` methods and four implementations (Plugin, Shell, LLM, HTTP). Phase 1 uses a plain struct. The interface can be introduced in Phase 3 when additional command types are needed.
+
+**5. Pipeline Context** — Done
+- Thread-safe `sync.RWMutex` protected `map[string]any`
+- Keys stored as `stepID+"."+key`
+- Methods: `NewContext()`, `Set()`, `Get()`, `Merge()`
+- Step outputs automatically merged into context on success
+
+**6. Executor** — Done
+- Sequential execution respecting `DependsOn` ordering
+- Per-step retry with exponential backoff (500ms × attempt)
+- Per-step timeout via `context.WithTimeout`
+- FailFast: abort pipeline on first unrecoverable failure
+- When FailFast=false: skip failed step's dependents, continue rest, report overall failure
+- `StepRunnerFunc` adapter pattern: bridges pipeline package to orchestrator's `executeCall()` without import cycle
+- Returns `ExecutionResult` with success flag, human-readable summary, and per-step records
+
+**7. Orchestrator Integration** — Done
+- **Block A** (top of `Run()`): checks `pendingPipelines[sessionID]` for pending confirmation
+- **Block B** (after content preparers): calls planner, creates pipeline if >1 steps, stores in pendingPipelines
+- `executePipeline()`: creates StepRunnerFunc adapter, runs executor, records all tool calls/results in session history
+- `plannerLLMAdapter`: converts orchestrator LLMClient ↔ pipeline LLMClient (avoids import cycle)
+- `capabilitiesToPlannerInfo()`: converts registry capabilities to planner-friendly format
+- Debug logging throughout with `[pipeline]` prefix
+
+**8. Config** — Done
+```yaml
+orchestrator:
+  pipeline:
+    enabled: true          # default false
+    max_step_retries: 2    # default 3
+    step_timeout: "30s"    # Go duration, default "60s"
+```
+
+#### Known Limitations (Phase 1)
+
+1. **Console multi-line input**: The console channel sends each line as a separate message. Multi-line requests split across messages cause the planner to receive partial input. This is a console-specific limitation; Slack/Discord send complete messages. No clean fix without breaking the simple line-by-line console UX.
+
+2. **Step output templating not resolved**: The planner sometimes puts template references in args (e.g., `{{steps.1.output.error_id}}`), but these are passed literally to plugins — no template engine resolves them. Planned for Phase 3.
+
+3. **Planner quality depends on LLM**: Weaker models (e.g., DeepSeek) sometimes return 1 step for multi-step requests, causing fallback to the normal agent loop. This is expected behavior (safe degradation) but reduces pipeline usefulness.
+
+4. **No parallel step execution**: Steps with independent dependencies run sequentially. Planned for Phase 3.
+
+5. **No pipeline persistence**: Pipelines exist only in memory. Process restart loses pending/running pipelines. Planned for Phase 4.
+
+---
+
+## Remaining Phases
+
+### Phase 2 — Smart Recovery (NOT STARTED)
+
+| Component | Description |
+|-----------|-------------|
+| Recovery Advisor | LLM-assisted error diagnosis: sends error + context to LLM asking "why did this fail? how to fix it?" |
+| Remediator | Executes the fix suggested by Recovery Advisor, then retries the step |
+| Circuit Breaker | Stops retrying when same error occurs 3x or LLM keeps suggesting same failing fix |
+| `RemediationRecord` | Tracks error, diagnosis, action, result, timestamp per recovery attempt |
+| `Step.Remediations` field | History of recovery attempts per step |
+| `PipelineConfig.MaxRemediations` | Max recovery advisor attempts per step |
+
+### Phase 3 — Adaptive Execution (NOT STARTED)
+
+| Component | Description |
+|-----------|-------------|
+| Replan strategy | `FailStrategy` enum: `fail_fast` / `continue_on_error` / `replan`. On failure, LLM replans remaining steps with user confirmation |
+| Plan editing | User can modify steps before approval (add, remove, reorder) |
+| Step output templating | Resolve `{{steps.X.output.Y}}` references in step args before execution |
+| Parallel step execution | Run independent steps concurrently (no mutual dependencies) |
+| `Command` interface | Abstract over PluginCommand, ShellCommand, LLMCommand, HTTPCommand |
+| `ConfirmOnReplan` config | Require user confirmation after replan |
+
+### Phase 4 — Production Hardening (NOT STARTED)
+
+| Component | Description |
+|-----------|-------------|
+| Plugin permissions | Per-plugin config: allowed actions, shell/network access, host restrictions, path restrictions |
+| Pipeline-level permission overrides | Per-channel/per-user scoping of what plugins are available |
+| Startup validation | Validate `required_env` and `required_cli` at plugin load time |
+| Pipeline persistence | Survive process restarts — store pipeline state in DB/file |
+| Pipeline history & audit log | Record all pipeline executions for review |
+| Cost tracking | LLM tokens spent per pipeline |
+| Rate limiting | Per-plugin invocation limits |
+| `require_approval` per plugin | Force user confirmation for specific plugin invocations |
+
+---
+
+## Core Components (Full Design Reference)
+
+### 1. Planner
+
+Takes a user prompt and asks the LLM to decompose it into a structured pipeline — a DAG (directed acyclic graph) of steps with dependencies. The output is a `Pipeline` struct.
+
+The plan is a "best guess." The system must be ready for it to be wrong (see Replan strategy in Phase 3).
+
+### 2. Confirmation Gate
+
+**Every plan must be confirmed by the user before execution begins.** This includes initial plans and replans (Phase 3).
+
+The Confirmation Gate sends the proposed plan back to the user via their channel (Slack, console, etc.) in a human-readable format and waits for a response.
+
+```
+I've created a plan with the following steps:
+
+1. **Check bug in AppSignal**
+   Action: `appsignal.get_error`
+   Args: error_id=4521
+2. **Checkout source code**
+   Action: `git.clone`
+   Depends on: 1
+3. **Create Jira bug ticket**
+   Action: `jira.create_issue`
+   Depends on: 1
+4. **Create MR with fix**
+   Action: `gitlab.create_mr`
+   Depends on: 2, 3
+
+Proceed? (y)es / (n)o
+```
+
+Phase 1: approve (y/yes) or reject (anything else).
+Phase 3: adds edit capability.
+
+### 3. Pipeline
+
+```go
+type Pipeline struct {
+    ID        string
+    Steps     []*Step
+    State     PipelineState
+    Config    PipelineConfig
+    Context   *PipelineContext
+    CreatedAt time.Time
+}
+
+type PipelineConfig struct {
+    MaxStepRetries    int            // default 3
+    StepTimeout       time.Duration  // default 60s
+    FailFast          bool           // Phase 1: only strategy implemented
+    // Phase 2+:
+    // MaxRemediations   int
+    // FailStrategy      FailStrategy  // fail_fast | continue_on_error | replan
+    // RequireConfirm    bool
+    // ConfirmOnReplan   bool
+}
+```
+
+### 4. Step
+
+```go
+type Step struct {
+    ID         string
+    Name       string
+    Command    *PluginCommand
+    DependsOn  []string
+    State      StepState
+    Attempts   int
+    MaxRetries int           // -1 = use pipeline default
+    Result     *StepResult
+    // Phase 2+:
+    // Remediations []RemediationRecord
+}
+```
+
+### 5. Command
+
+Phase 1: `PluginCommand` struct only.
+Phase 3: `Command` interface with PluginCommand, ShellCommand, LLMCommand, HTTPCommand implementations.
+
+### 6. Pipeline Context
+
+Shared state between steps. Each step's output is merged into the context, making it available to subsequent steps.
+
+Phase 3 adds template resolution for `{{steps.X.output.Y}}` references in step args.
+
+### 7. Recovery Advisor (Phase 2)
+
+When a step fails, sends error context to the LLM: "This step failed with this error. Given the pipeline context, why did it fail and what should be done to fix it?"
+
+### 8. Circuit Breaker (Phase 2)
+
+Prevents burning retries on the same broken thing. If the same error occurs 3 times in a row, or the LLM keeps suggesting the same failing remediation, the circuit breaker trips.
+
+---
+
+## Failure Strategies
+
+| Strategy | Status | Behavior | Use Case |
+|---|---|---|---|
+| **FailFast** | Phase 1 ✅ | Abort pipeline on first unrecoverable failure | Critical workflows where partial completion is dangerous |
+| **ContinueOnError** | Phase 1 ✅ (partial) | Skip failed step and its dependents, continue rest | Best-effort workflows where some steps are optional |
+| **Replan** | Phase 3 | Ask LLM to replan remaining steps, user confirms new plan | Most flexible — handles unexpected situations gracefully |
+
+Note: ContinueOnError works in the executor (FailFast=false) but is not exposed as a named strategy in config yet. Config only has `FailFast bool`.
+
+---
+
+## Integration with Existing OpenTalon
+
+- **Orchestrator** gets a new code path: if the Planner decomposes a prompt into multiple steps, hand off to the Pipeline Executor. Single-step requests still use the existing agent loop.
+- **Plugin system** stays unchanged — `PluginCommand` calls `plugin.Client.Execute()` via gRPC as it does today.
+- **Sessions** store pipeline state for inspection and resume (Phase 4: persistence).
+- **Recovery Advisor** wraps the existing LLM provider with a specific prompt template (Phase 2).
+- **Channels** don't need changes — confirmation works via session state, not channel protocol.
+
+---
+
+## Key Design Principles
+
+1. **Confirm before executing.** Every plan goes through user confirmation. The cost of one prompt is trivial compared to undoing a pipeline that created wrong Jira tickets and merged bad MRs.
+
+2. **Replan > Retry.** Blindly retrying the same command is usually useless. Diagnose first, remediate, then retry. If remediation fails too, replan the whole approach. (Phase 1 has retry only; Phase 2 adds diagnosis; Phase 3 adds replan.)
+
+3. **DAG, not a linked list.** Real-world tasks have branching and conditional dependencies. A flat command chain breaks down quickly.
+
+4. **Steps compose via context, not coupling.** Steps don't know about each other — they read from and write to a shared context. This makes them reorderable and replaceable.
+
+5. **Safe degradation.** If the planner fails to parse, returns "direct", or produces only 1 step — the system falls back to the normal agent loop. Pipeline is additive, never breaks existing functionality.
+
+6. **Fail loudly with history.** When a pipeline fails, the user sees: what succeeded, what failed, how many retries were attempted. No silent failures.
+
+7. **Don't over-plan.** The initial plan is a best guess. The system must handle the plan being wrong. Over-investing in perfect upfront planning is a trap — invest in good recovery instead.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,10 +174,10 @@ type ContentPreparerEntry struct {
 }
 
 type OrchestratorConfig struct {
-	Rules            []string                     `yaml:"rules"`
-	ContentPreparers []ContentPreparerEntry       `yaml:"content_preparers,omitempty"`
-	PermissionPlugin string                       `yaml:"permission_plugin,omitempty"` // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
-	Pipeline         PipelineOrchestratorConfig   `yaml:"pipeline,omitempty"`
+	Rules            []string                   `yaml:"rules"`
+	ContentPreparers []ContentPreparerEntry     `yaml:"content_preparers,omitempty"`
+	PermissionPlugin string                     `yaml:"permission_plugin,omitempty"` // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
+	Pipeline         PipelineOrchestratorConfig `yaml:"pipeline,omitempty"`
 }
 
 // PipelineOrchestratorConfig enables structured multi-step pipeline execution.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,9 +174,17 @@ type ContentPreparerEntry struct {
 }
 
 type OrchestratorConfig struct {
-	Rules            []string               `yaml:"rules"`
-	ContentPreparers []ContentPreparerEntry `yaml:"content_preparers,omitempty"`
-	PermissionPlugin string                 `yaml:"permission_plugin,omitempty"` // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
+	Rules            []string                     `yaml:"rules"`
+	ContentPreparers []ContentPreparerEntry       `yaml:"content_preparers,omitempty"`
+	PermissionPlugin string                       `yaml:"permission_plugin,omitempty"` // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
+	Pipeline         PipelineOrchestratorConfig   `yaml:"pipeline,omitempty"`
+}
+
+// PipelineOrchestratorConfig enables structured multi-step pipeline execution.
+type PipelineOrchestratorConfig struct {
+	Enabled        bool   `yaml:"enabled"`          // default false
+	MaxStepRetries int    `yaml:"max_step_retries"` // default 3
+	StepTimeout    string `yaml:"step_timeout"`     // Go duration, default "60s"
 }
 
 type StateConfig struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -91,14 +91,14 @@ type Orchestrator struct {
 	guard                   *Guard
 	rules                   *RulesConfig
 	preparers               []ContentPreparerEntry
-	luaScriptPaths          map[string]string // optional; plugin name -> path to .lua script (for "lua:name" preparers)
-	permissionChecker       PermissionChecker // optional; when set, executeCall checks permission before running
-	permissionPluginName    string            // name of the permission plugin (skip permission check when executing it)
-	summarizeAfterMessages  int               // 0 = off; after this many messages run summarization
-	maxMessagesAfterSummary int               // keep this many messages after summarization
-	summarizePrompt         string            // system prompt for initial summarization (config; empty = default English)
-	summarizeUpdatePrompt   string            // system prompt for updating summary (config; empty = default English)
-	planner                 *pipeline.Planner            // nil = pipeline disabled
+	luaScriptPaths          map[string]string             // optional; plugin name -> path to .lua script (for "lua:name" preparers)
+	permissionChecker       PermissionChecker             // optional; when set, executeCall checks permission before running
+	permissionPluginName    string                        // name of the permission plugin (skip permission check when executing it)
+	summarizeAfterMessages  int                           // 0 = off; after this many messages run summarization
+	maxMessagesAfterSummary int                           // keep this many messages after summarization
+	summarizePrompt         string                        // system prompt for initial summarization (config; empty = default English)
+	summarizeUpdatePrompt   string                        // system prompt for updating summary (config; empty = default English)
+	planner                 *pipeline.Planner             // nil = pipeline disabled
 	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline
 	pipelineConfig          pipeline.PipelineConfig
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opentalon/opentalon/internal/actor"
 	"github.com/opentalon/opentalon/internal/lua"
+	"github.com/opentalon/opentalon/internal/pipeline"
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/state"
 )
@@ -61,6 +62,8 @@ type OrchestratorOpts struct {
 	MaxMessagesAfterSummary int    // keep this many messages after summarization
 	SummarizePrompt         string // empty = default English
 	SummarizeUpdatePrompt   string // empty = default English
+	PipelineEnabled         bool   // when true, create Planner from llm
+	PipelineConfig          pipeline.PipelineConfig
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -95,6 +98,9 @@ type Orchestrator struct {
 	maxMessagesAfterSummary int               // keep this many messages after summarization
 	summarizePrompt         string            // system prompt for initial summarization (config; empty = default English)
 	summarizeUpdatePrompt   string            // system prompt for updating summary (config; empty = default English)
+	planner                 *pipeline.Planner            // nil = pipeline disabled
+	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline
+	pipelineConfig          pipeline.PipelineConfig
 }
 
 const (
@@ -126,6 +132,14 @@ func NewWithRules(
 	if opts.SummarizeUpdatePrompt == "" {
 		opts.SummarizeUpdatePrompt = defaultSummarizeUpdatePrompt
 	}
+	var planner *pipeline.Planner
+	if opts.PipelineEnabled {
+		planner = pipeline.NewPlanner(&plannerLLMAdapter{llm: llm})
+	}
+	pipelineCfg := opts.PipelineConfig
+	if pipelineCfg.MaxStepRetries == 0 && pipelineCfg.StepTimeout == 0 {
+		pipelineCfg = pipeline.DefaultConfig()
+	}
 	return &Orchestrator{
 		llm:                     llm,
 		parser:                  parser,
@@ -142,6 +156,9 @@ func NewWithRules(
 		maxMessagesAfterSummary: opts.MaxMessagesAfterSummary,
 		summarizePrompt:         opts.SummarizePrompt,
 		summarizeUpdatePrompt:   opts.SummarizeUpdatePrompt,
+		planner:                 planner,
+		pendingPipelines:        make(map[string]*pipeline.Pipeline),
+		pipelineConfig:          pipelineCfg,
 	}
 }
 
@@ -189,6 +206,28 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string) (
 
 	if _, err := o.sessions.Get(sessionID); err != nil {
 		return nil, fmt.Errorf("session lookup: %w", err)
+	}
+
+	// Block A: Check for pending pipeline confirmation.
+	if p := o.pendingPipelines[sessionID]; p != nil {
+		decision := pipeline.ParseConfirmation(userMessage)
+		if os.Getenv("LOG_LEVEL") == "debug" {
+			log.Printf("[pipeline] pending pipeline %s for session %s, user input: %q, decision: %d", p.ID, sessionID, userMessage, decision)
+		}
+		delete(o.pendingPipelines, sessionID)
+		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
+		if decision == pipeline.Approved {
+			if os.Getenv("LOG_LEVEL") == "debug" {
+				log.Printf("[pipeline] executing pipeline %s (%d steps)", p.ID, len(p.Steps))
+			}
+			return o.executePipeline(ctx, sessionID, p)
+		}
+		resp := "Pipeline cancelled (expected y/yes to confirm)."
+		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
+		if os.Getenv("LOG_LEVEL") == "debug" {
+			log.Printf("[pipeline] pipeline %s rejected: %q", p.ID, userMessage)
+		}
+		return &RunResult{Response: resp}, nil
 	}
 
 	content := userMessage
@@ -267,6 +306,33 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string) (
 		}
 	}
 
+	// Block B: Run planner to check if this requires a multi-step pipeline.
+	if o.planner != nil {
+		if os.Getenv("LOG_LEVEL") == "debug" {
+			log.Printf("[pipeline] running planner for session %s, message: %q", sessionID, content)
+		}
+		planResult, err := o.planner.Plan(ctx, content, capabilitiesToPlannerInfo(o.registry.ListCapabilities()))
+		if err != nil {
+			if os.Getenv("LOG_LEVEL") == "debug" {
+				log.Printf("[pipeline] planner error: %v — falling through to agent loop", err)
+			}
+		} else if os.Getenv("LOG_LEVEL") == "debug" {
+			log.Printf("[pipeline] planner result: type=%s, steps=%d", planResult.Type, len(planResult.Steps))
+		}
+		if err == nil && planResult.Type == "pipeline" && len(planResult.Steps) > 1 {
+			p := pipeline.NewPipeline(planResult.Steps, o.pipelineConfig)
+			o.pendingPipelines[sessionID] = p
+			planText := p.FormatForConfirmation()
+			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: content})
+			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
+			if os.Getenv("LOG_LEVEL") == "debug" {
+				log.Printf("[pipeline] stored pending pipeline %s for session %s (%d steps), awaiting confirmation", p.ID, sessionID, len(p.Steps))
+			}
+			return &RunResult{Response: planText}, nil
+		}
+		// If "direct" or error or single step, fall through to normal agent loop
+	}
+
 	if err := o.sessions.AddMessage(sessionID, provider.Message{
 		Role:    provider.RoleUser,
 		Content: content,
@@ -340,6 +406,67 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string) (
 	}
 
 	return nil, fmt.Errorf("agent loop exceeded %d iterations", maxAgentLoopIterations)
+}
+
+func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p *pipeline.Pipeline) (*RunResult, error) {
+	debug := os.Getenv("LOG_LEVEL") == "debug"
+	runner := func(ctx context.Context, pluginName, action string, args map[string]string) pipeline.StepRunResult {
+		if debug {
+			log.Printf("[pipeline] executing step: %s.%s args=%v", pluginName, action, args)
+		}
+		call := ToolCall{
+			ID:     fmt.Sprintf("pipeline-%s-%s", pluginName, action),
+			Plugin: pluginName,
+			Action: action,
+			Args:   args,
+		}
+		result := o.executeCall(ctx, call)
+		if debug {
+			if result.Error != "" {
+				log.Printf("[pipeline] step %s.%s failed: %s", pluginName, action, result.Error)
+			} else {
+				preview := result.Content
+				if len(preview) > 500 {
+					preview = preview[:500] + "... [truncated]"
+				}
+				log.Printf("[pipeline] step %s.%s succeeded: %s", pluginName, action, preview)
+			}
+		}
+		return pipeline.StepRunResult{Content: result.Content, Error: result.Error}
+	}
+	executor := pipeline.NewExecutor(runner, p.Config)
+	execResult, err := executor.Run(ctx, p)
+	if err != nil {
+		return nil, fmt.Errorf("pipeline execution: %w", err)
+	}
+
+	if debug {
+		log.Printf("[pipeline] execution done: success=%v, steps_executed=%d", execResult.Success, len(execResult.Steps))
+	}
+
+	// Record step results in session history
+	var toolCalls []ToolCall
+	var toolResults []ToolResult
+	for _, es := range execResult.Steps {
+		tc := ToolCall{
+			ID:     fmt.Sprintf("pipeline-%s-%s", es.Plugin, es.Action),
+			Plugin: es.Plugin,
+			Action: es.Action,
+			Args:   es.Args,
+		}
+		tr := ToolResult{CallID: tc.ID, Content: es.Content, Error: es.Error}
+		toolCalls = append(toolCalls, tc)
+		toolResults = append(toolResults, tr)
+		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: formatToolCallMessage(tc)})
+		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: o.guard.WrapContent(tr)})
+	}
+	_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: execResult.Summary})
+
+	return &RunResult{
+		Response:  execResult.Summary,
+		ToolCalls: toolCalls,
+		Results:   toolResults,
+	}, nil
 }
 
 func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, userMessage string) []provider.Message {
@@ -627,6 +754,40 @@ func formatToolResultMessage(result ToolResult) string {
 		return fmt.Sprintf("[tool_result] error: %s", result.Error)
 	}
 	return fmt.Sprintf("[tool_result] %s", result.Content)
+}
+
+// plannerLLMAdapter adapts orchestrator.LLMClient to pipeline.LLMClient.
+type plannerLLMAdapter struct {
+	llm LLMClient
+}
+
+func (a *plannerLLMAdapter) Complete(ctx context.Context, req *pipeline.CompletionRequest) (*pipeline.CompletionResponse, error) {
+	msgs := make([]provider.Message, len(req.Messages))
+	for i, m := range req.Messages {
+		msgs[i] = provider.Message{Role: provider.Role(m.Role), Content: m.Content}
+	}
+	resp, err := a.llm.Complete(ctx, &provider.CompletionRequest{Messages: msgs})
+	if err != nil {
+		return nil, err
+	}
+	return &pipeline.CompletionResponse{Content: resp.Content}, nil
+}
+
+// capabilitiesToPlannerInfo converts orchestrator PluginCapability to pipeline CapabilityInfo.
+func capabilitiesToPlannerInfo(caps []PluginCapability) []pipeline.CapabilityInfo {
+	result := make([]pipeline.CapabilityInfo, len(caps))
+	for i, cap := range caps {
+		actions := make([]pipeline.ActionInfo, len(cap.Actions))
+		for j, a := range cap.Actions {
+			params := make([]pipeline.ParamInfo, len(a.Parameters))
+			for k, p := range a.Parameters {
+				params[k] = pipeline.ParamInfo{Name: p.Name, Description: p.Description, Required: p.Required}
+			}
+			actions[j] = pipeline.ActionInfo{Name: a.Name, Description: a.Description, Parameters: params}
+		}
+		result[i] = pipeline.CapabilityInfo{Name: cap.Name, Description: cap.Description, Actions: actions}
+	}
+	return result
 }
 
 // permissionCheckerImpl invokes the permission plugin with action "check" and args actor, plugin.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -691,7 +691,7 @@ func TestPipelineDisabledNormalFlow(t *testing.T) {
 func TestPlannerReturnsDirect_FallsThrough(t *testing.T) {
 	// Planner returns "direct" → falls through to normal agent loop
 	llm := &fakeLLM{responses: []string{
-		`{"type": "direct"}`,           // planner response
+		`{"type": "direct"}`,       // planner response
 		"I'll help you with that!", // agent response
 	}}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -637,6 +637,176 @@ func TestInvokeStepsUnmarshalSingleAndArray(t *testing.T) {
 	}
 }
 
+// --- Pipeline integration tests ---
+
+func setupPipelineOrchestrator(plannerLLM *fakeLLM, agentLLM *fakeLLM) (*Orchestrator, string) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:        "appsignal",
+		Description: "AppSignal integration",
+		Actions:     []Action{{Name: "get_error", Description: "Get error details"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "jira",
+		Description: "Jira integration",
+		Actions:     []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("test-session")
+
+	// The planner LLM is used for planning; the agent LLM is used for the normal agent loop.
+	// We use the planner LLM since it's the same LLM interface for both.
+	orch := NewWithRules(plannerLLM, &fakeParser{parseFn: func(response string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		PipelineEnabled: true,
+	})
+
+	return orch, "test-session"
+}
+
+func TestPipelineDisabledNormalFlow(t *testing.T) {
+	// Pipeline disabled → normal agent loop, no planner call
+	llm := &fakeLLM{responses: []string{"Hello!"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		PipelineEnabled: false,
+	})
+
+	result, err := orch.Run(context.Background(), "s1", "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response != "Hello!" {
+		t.Errorf("Response = %q, want Hello!", result.Response)
+	}
+}
+
+func TestPlannerReturnsDirect_FallsThrough(t *testing.T) {
+	// Planner returns "direct" → falls through to normal agent loop
+	llm := &fakeLLM{responses: []string{
+		`{"type": "direct"}`,           // planner response
+		"I'll help you with that!", // agent response
+	}}
+
+	orch, sessID := setupPipelineOrchestrator(llm, llm)
+	result, err := orch.Run(context.Background(), sessID, "simple question")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response != "I'll help you with that!" {
+		t.Errorf("Response = %q", result.Response)
+	}
+}
+
+func TestPlannerReturnsPipeline_StoresPending(t *testing.T) {
+	planJSON := `{"type": "pipeline", "steps": [
+		{"id": "1", "name": "Get error", "plugin": "appsignal", "action": "get_error", "args": {"error_id": "123"}},
+		{"id": "2", "name": "Create issue", "plugin": "jira", "action": "create_issue", "args": {"title": "Fix it"}, "depends_on": ["1"]}
+	]}`
+	llm := &fakeLLM{responses: []string{planJSON}}
+
+	orch, sessID := setupPipelineOrchestrator(llm, llm)
+	result, err := orch.Run(context.Background(), sessID, "investigate error 123 and create a ticket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should return confirmation text
+	if !strings.Contains(result.Response, "Get error") {
+		t.Errorf("Response should contain step names: %q", result.Response)
+	}
+	if !strings.Contains(result.Response, "(y)es") {
+		t.Errorf("Response should ask for confirmation: %q", result.Response)
+	}
+	// Should have pending pipeline
+	if orch.pendingPipelines[sessID] == nil {
+		t.Error("expected pending pipeline to be stored")
+	}
+}
+
+func TestPipelineConfirmation_Yes(t *testing.T) {
+	planJSON := `{"type": "pipeline", "steps": [
+		{"id": "1", "name": "Get error", "plugin": "appsignal", "action": "get_error"},
+		{"id": "2", "name": "Create issue", "plugin": "jira", "action": "create_issue", "depends_on": ["1"]}
+	]}`
+	llm := &fakeLLM{responses: []string{planJSON}}
+
+	orch, sessID := setupPipelineOrchestrator(llm, llm)
+	// First call: planner returns pipeline, stores pending
+	_, err := orch.Run(context.Background(), sessID, "do stuff")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call: user confirms
+	result, err := orch.Run(context.Background(), sessID, "yes")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Response, "successfully") {
+		t.Errorf("expected success summary, got: %q", result.Response)
+	}
+	if len(result.ToolCalls) != 2 {
+		t.Errorf("expected 2 tool calls, got %d", len(result.ToolCalls))
+	}
+	// Pending pipeline should be cleared
+	if orch.pendingPipelines[sessID] != nil {
+		t.Error("expected pending pipeline to be cleared after execution")
+	}
+}
+
+func TestPipelineConfirmation_No(t *testing.T) {
+	planJSON := `{"type": "pipeline", "steps": [
+		{"id": "1", "name": "Get error", "plugin": "appsignal", "action": "get_error"},
+		{"id": "2", "name": "Create issue", "plugin": "jira", "action": "create_issue"}
+	]}`
+	llm := &fakeLLM{responses: []string{planJSON, "ok, cancelled."}}
+
+	orch, sessID := setupPipelineOrchestrator(llm, llm)
+	_, _ = orch.Run(context.Background(), sessID, "do stuff")
+
+	result, err := orch.Run(context.Background(), sessID, "no")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Response, "cancelled") {
+		t.Errorf("Response = %q, want cancellation message", result.Response)
+	}
+	if orch.pendingPipelines[sessID] != nil {
+		t.Error("expected pending pipeline to be cleared after rejection")
+	}
+}
+
+func TestPipelineConfirmation_Unrelated(t *testing.T) {
+	// Anything other than y/yes defaults to rejection
+	planJSON := `{"type": "pipeline", "steps": [
+		{"id": "1", "name": "Get error", "plugin": "appsignal", "action": "get_error"},
+		{"id": "2", "name": "Create issue", "plugin": "jira", "action": "create_issue"}
+	]}`
+	llm := &fakeLLM{responses: []string{planJSON}}
+
+	orch, sessID := setupPipelineOrchestrator(llm, llm)
+	_, _ = orch.Run(context.Background(), sessID, "do stuff")
+
+	// Unrelated message → defaults to rejection (not y/yes)
+	result, err := orch.Run(context.Background(), sessID, "what is the weather today")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Response, "cancelled") {
+		t.Errorf("Response = %q, want cancellation message", result.Response)
+	}
+	if orch.pendingPipelines[sessID] != nil {
+		t.Error("expected pending pipeline to be cleared")
+	}
+}
+
 func TestInsecurePreparerCannotInvoke(t *testing.T) {
 	// Insecure preparer returns send_to_llm: false + invoke; we must not run invoke, request continues to LLM.
 	invokeJSON := `{"send_to_llm": false, "invoke": {"plugin": "gitlab", "action": "analyze_code"}}`

--- a/internal/pipeline/command.go
+++ b/internal/pipeline/command.go
@@ -1,0 +1,8 @@
+package pipeline
+
+// PluginCommand is the only command type for Phase 1.
+type PluginCommand struct {
+	Plugin string
+	Action string
+	Args   map[string]string
+}

--- a/internal/pipeline/confirmation.go
+++ b/internal/pipeline/confirmation.go
@@ -1,0 +1,25 @@
+package pipeline
+
+import "strings"
+
+// ConfirmationDecision represents the user's response to a pipeline plan.
+type ConfirmationDecision int
+
+const (
+	Approved ConfirmationDecision = iota
+	Rejected
+)
+
+var approvedWords = map[string]bool{
+	"yes": true, "y": true,
+}
+
+// ParseConfirmation determines whether user input is an explicit approval.
+// Anything other than y/yes (case-insensitive) is treated as rejection.
+func ParseConfirmation(input string) ConfirmationDecision {
+	normalized := strings.TrimSpace(strings.ToLower(input))
+	if approvedWords[normalized] {
+		return Approved
+	}
+	return Rejected
+}

--- a/internal/pipeline/confirmation_test.go
+++ b/internal/pipeline/confirmation_test.go
@@ -1,0 +1,27 @@
+package pipeline
+
+import "testing"
+
+func TestParseConfirmationApproved(t *testing.T) {
+	approved := []string{"yes", "y", "Yes", "YES", "Y", " yes ", " Y "}
+	for _, input := range approved {
+		if got := ParseConfirmation(input); got != Approved {
+			t.Errorf("ParseConfirmation(%q) = %d, want Approved", input, got)
+		}
+	}
+}
+
+func TestParseConfirmationRejected(t *testing.T) {
+	// Anything that's not y/yes is rejected
+	rejected := []string{
+		"no", "n", "cancel", "stop",
+		"what is the weather",
+		"actually can you also check logs",
+		"maybe", "", "yess", "ye", "nope",
+	}
+	for _, input := range rejected {
+		if got := ParseConfirmation(input); got != Rejected {
+			t.Errorf("ParseConfirmation(%q) = %d, want Rejected", input, got)
+		}
+	}
+}

--- a/internal/pipeline/context.go
+++ b/internal/pipeline/context.go
@@ -1,0 +1,38 @@
+package pipeline
+
+import "sync"
+
+// PipelineContext holds shared state across pipeline steps.
+type PipelineContext struct {
+	mu     sync.RWMutex
+	values map[string]any
+}
+
+// NewContext creates an empty pipeline context.
+func NewContext() *PipelineContext {
+	return &PipelineContext{values: make(map[string]any)}
+}
+
+// Set stores a value scoped to a step ID and key.
+func (c *PipelineContext) Set(stepID, key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.values[stepID+"."+key] = value
+}
+
+// Get retrieves a value by step ID and key.
+func (c *PipelineContext) Get(stepID, key string) (any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	v, ok := c.values[stepID+"."+key]
+	return v, ok
+}
+
+// Merge stores all entries from data scoped to the given step ID.
+func (c *PipelineContext) Merge(stepID string, data map[string]any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for k, v := range data {
+		c.values[stepID+"."+k] = v
+	}
+}

--- a/internal/pipeline/context_test.go
+++ b/internal/pipeline/context_test.go
@@ -1,0 +1,52 @@
+package pipeline
+
+import "testing"
+
+func TestContextSetGet(t *testing.T) {
+	ctx := NewContext()
+	ctx.Set("step1", "output", "hello")
+
+	val, ok := ctx.Get("step1", "output")
+	if !ok {
+		t.Fatal("expected value to exist")
+	}
+	if val != "hello" {
+		t.Errorf("Get = %v, want hello", val)
+	}
+}
+
+func TestContextGetMissing(t *testing.T) {
+	ctx := NewContext()
+	_, ok := ctx.Get("nonexistent", "key")
+	if ok {
+		t.Error("expected ok=false for missing key")
+	}
+}
+
+func TestContextMerge(t *testing.T) {
+	ctx := NewContext()
+	ctx.Merge("step1", map[string]any{
+		"output": "data1",
+		"status": "ok",
+	})
+
+	val, ok := ctx.Get("step1", "output")
+	if !ok || val != "data1" {
+		t.Errorf("Get output = %v, %v", val, ok)
+	}
+	val, ok = ctx.Get("step1", "status")
+	if !ok || val != "ok" {
+		t.Errorf("Get status = %v, %v", val, ok)
+	}
+}
+
+func TestContextOverwrite(t *testing.T) {
+	ctx := NewContext()
+	ctx.Set("s1", "k", "v1")
+	ctx.Set("s1", "k", "v2")
+
+	val, _ := ctx.Get("s1", "k")
+	if val != "v2" {
+		t.Errorf("expected overwritten value v2, got %v", val)
+	}
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -1,0 +1,192 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// StepRunnerFunc executes a single plugin command. The orchestrator provides an adapter
+// that bridges its own ToolCall/ToolResult types to these pipeline-local types.
+type StepRunnerFunc func(ctx context.Context, plugin, action string, args map[string]string) StepRunResult
+
+// StepRunResult is the pipeline-local result of running a step.
+type StepRunResult struct {
+	Content string
+	Error   string
+}
+
+// Executor runs a pipeline's steps sequentially with retry logic.
+type Executor struct {
+	runner StepRunnerFunc
+	config PipelineConfig
+}
+
+// ExecutionResult holds the outcome of a full pipeline execution.
+type ExecutionResult struct {
+	Success   bool
+	Summary   string
+	Steps     []*ExecutedStep
+}
+
+// ExecutedStep records each attempt made during pipeline execution.
+type ExecutedStep struct {
+	Plugin  string
+	Action  string
+	Args    map[string]string
+	Content string
+	Error   string
+}
+
+// NewExecutor creates an executor with the given step runner and config.
+func NewExecutor(runner StepRunnerFunc, config PipelineConfig) *Executor {
+	return &Executor{runner: runner, config: config}
+}
+
+// Run executes all steps in the pipeline sequentially, respecting DependsOn ordering.
+func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, error) {
+	p.State = StateRunning
+	result := &ExecutionResult{}
+
+	completed := make(map[string]bool)
+	anyFailed := false
+
+	for _, step := range p.Steps {
+		// Check dependencies
+		depsMet := true
+		for _, dep := range step.DependsOn {
+			if !completed[dep] {
+				depsMet = false
+				break
+			}
+		}
+		if !depsMet {
+			step.State = StepSkipped
+			step.Result = &StepResult{
+				Success: false,
+				Output:  fmt.Sprintf("skipped: dependency not completed"),
+			}
+			if e.config.FailFast {
+				p.State = StateFailed
+				result.Success = false
+				result.Summary = buildSummary(p, false)
+				return result, nil
+			}
+			continue
+		}
+
+		maxRetries := step.MaxRetries
+		if maxRetries < 0 {
+			maxRetries = e.config.MaxStepRetries
+		}
+
+		success := false
+		step.State = StepRunning
+
+		for attempt := 0; attempt <= maxRetries; attempt++ {
+			step.Attempts = attempt + 1
+
+			var stepCtx context.Context
+			var cancel context.CancelFunc
+			if e.config.StepTimeout > 0 {
+				stepCtx, cancel = context.WithTimeout(ctx, e.config.StepTimeout)
+			} else {
+				stepCtx, cancel = context.WithCancel(ctx)
+			}
+
+			runResult := e.runner(stepCtx, step.Command.Plugin, step.Command.Action, step.Command.Args)
+			cancel()
+
+			result.Steps = append(result.Steps, &ExecutedStep{
+				Plugin:  step.Command.Plugin,
+				Action:  step.Command.Action,
+				Args:    step.Command.Args,
+				Content: runResult.Content,
+				Error:   runResult.Error,
+			})
+
+			if runResult.Error == "" {
+				step.State = StepSucceeded
+				step.Result = &StepResult{
+					Success: true,
+					Output:  runResult.Content,
+					Data:    map[string]any{"output": runResult.Content},
+				}
+				p.Context.Merge(step.ID, step.Result.Data)
+				completed[step.ID] = true
+				success = true
+				break
+			}
+
+			// Last attempt failed
+			if attempt == maxRetries {
+				step.State = StepFailed
+				step.Result = &StepResult{
+					Success: false,
+					Output:  runResult.Error,
+				}
+			}
+
+			// Brief backoff before retry
+			if attempt < maxRetries {
+				select {
+				case <-ctx.Done():
+					step.State = StepFailed
+					step.Result = &StepResult{
+						Success: false,
+						Output:  "context cancelled during retry backoff",
+					}
+					p.State = StateFailed
+					result.Success = false
+					result.Summary = buildSummary(p, false)
+					return result, nil
+				case <-time.After(time.Duration(attempt+1) * 500 * time.Millisecond):
+				}
+			}
+		}
+
+		if !success {
+			anyFailed = true
+			if e.config.FailFast {
+				p.State = StateFailed
+				result.Success = false
+				result.Summary = buildSummary(p, false)
+				return result, nil
+			}
+		}
+	}
+
+	if anyFailed {
+		p.State = StateFailed
+		result.Success = false
+		result.Summary = buildSummary(p, false)
+	} else {
+		p.State = StateCompleted
+		result.Success = true
+		result.Summary = buildSummary(p, true)
+	}
+	return result, nil
+}
+
+func buildSummary(p *Pipeline, success bool) string {
+	var sb strings.Builder
+	if success {
+		sb.WriteString("Pipeline completed successfully.\n\n")
+	} else {
+		sb.WriteString("Pipeline failed.\n\n")
+	}
+	for i, step := range p.Steps {
+		status := string(step.State)
+		sb.WriteString(fmt.Sprintf("%d. %s — %s", i+1, step.Name, status))
+		if step.Result != nil && step.Result.Output != "" {
+			output := step.Result.Output
+			if len(output) > 200 {
+				output = output[:200] + "..."
+			}
+			sb.WriteString(fmt.Sprintf(": %s", output))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -25,9 +25,9 @@ type Executor struct {
 
 // ExecutionResult holds the outcome of a full pipeline execution.
 type ExecutionResult struct {
-	Success   bool
-	Summary   string
-	Steps     []*ExecutedStep
+	Success bool
+	Summary string
+	Steps   []*ExecutedStep
 }
 
 // ExecutedStep records each attempt made during pipeline execution.
@@ -65,7 +65,7 @@ func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, erro
 			step.State = StepSkipped
 			step.Result = &StepResult{
 				Success: false,
-				Output:  fmt.Sprintf("skipped: dependency not completed"),
+				Output:  "skipped: dependency not completed",
 			}
 			if e.config.FailFast {
 				p.State = StateFailed

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -1,0 +1,210 @@
+package pipeline
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func successRunner(_ context.Context, plugin, action string, _ map[string]string) StepRunResult {
+	return StepRunResult{Content: "executed " + plugin + "." + action}
+}
+
+func failRunner(_ context.Context, _, _ string, _ map[string]string) StepRunResult {
+	return StepRunResult{Error: "step failed"}
+}
+
+func makeCountingRunner() (StepRunnerFunc, *int) {
+	count := 0
+	return func(_ context.Context, _, _ string, _ map[string]string) StepRunResult {
+		count++
+		if count <= 2 {
+			return StepRunResult{Error: "transient error"}
+		}
+		return StepRunResult{Content: "success on attempt " + string(rune('0'+count))}
+	}, &count
+}
+
+func makeSteps(names ...string) []*Step {
+	steps := make([]*Step, len(names))
+	for i, name := range names {
+		steps[i] = &Step{
+			ID:   name,
+			Name: "Step " + name,
+			Command: &PluginCommand{
+				Plugin: "test",
+				Action: name,
+				Args:   map[string]string{},
+			},
+			State:      StepPending,
+			MaxRetries: -1,
+		}
+	}
+	return steps
+}
+
+func TestExecutorAllStepsSucceed(t *testing.T) {
+	steps := makeSteps("a", "b", "c")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(successRunner, p.Config)
+	result, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Success {
+		t.Error("expected success")
+	}
+	if p.State != StateCompleted {
+		t.Errorf("pipeline state = %q, want completed", p.State)
+	}
+	if len(result.Steps) != 3 {
+		t.Errorf("expected 3 executed steps, got %d", len(result.Steps))
+	}
+	for _, step := range p.Steps {
+		if step.State != StepSucceeded {
+			t.Errorf("step %s state = %q, want succeeded", step.ID, step.State)
+		}
+	}
+}
+
+func TestExecutorFailFast(t *testing.T) {
+	steps := makeSteps("a", "b")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(failRunner, p.Config)
+	result, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Success {
+		t.Error("expected failure")
+	}
+	if p.State != StateFailed {
+		t.Errorf("pipeline state = %q, want failed", p.State)
+	}
+	// Only first step should have been attempted
+	if len(result.Steps) != 1 {
+		t.Errorf("expected 1 executed step (fail-fast), got %d", len(result.Steps))
+	}
+	if p.Steps[0].State != StepFailed {
+		t.Errorf("step a state = %q, want failed", p.Steps[0].State)
+	}
+	// Step b should still be pending (never reached)
+	if p.Steps[1].State != StepPending {
+		t.Errorf("step b state = %q, want pending", p.Steps[1].State)
+	}
+}
+
+func TestExecutorRetryThenSucceed(t *testing.T) {
+	runner, count := makeCountingRunner()
+	steps := makeSteps("a")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 3, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(runner, p.Config)
+	result, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Success {
+		t.Error("expected success after retries")
+	}
+	if *count != 3 {
+		t.Errorf("expected 3 attempts, got %d", *count)
+	}
+	if p.Steps[0].Attempts != 3 {
+		t.Errorf("step attempts = %d, want 3", p.Steps[0].Attempts)
+	}
+	// Should have 3 executed steps (2 failures + 1 success)
+	if len(result.Steps) != 3 {
+		t.Errorf("expected 3 executed steps, got %d", len(result.Steps))
+	}
+}
+
+func TestExecutorRetryExhausted(t *testing.T) {
+	steps := makeSteps("a")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 1, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(failRunner, p.Config)
+	result, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Success {
+		t.Error("expected failure after retries exhausted")
+	}
+	if p.Steps[0].State != StepFailed {
+		t.Errorf("step state = %q, want failed", p.Steps[0].State)
+	}
+	// 1 initial + 1 retry = 2 attempts
+	if p.Steps[0].Attempts != 2 {
+		t.Errorf("step attempts = %d, want 2", p.Steps[0].Attempts)
+	}
+}
+
+func TestExecutorDependencySkipped(t *testing.T) {
+	steps := makeSteps("a", "b")
+	steps[1].DependsOn = []string{"a"}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: false})
+
+	executor := NewExecutor(failRunner, p.Config)
+	result, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Success {
+		t.Error("expected failure")
+	}
+	// Step a fails, step b should be skipped because dep not met
+	if p.Steps[1].State != StepSkipped {
+		t.Errorf("step b state = %q, want skipped", p.Steps[1].State)
+	}
+}
+
+func TestExecutorContextMerge(t *testing.T) {
+	steps := makeSteps("a", "b")
+	steps[1].DependsOn = []string{"a"}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(successRunner, p.Config)
+	_, err := executor.Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	val, ok := p.Context.Get("a", "output")
+	if !ok {
+		t.Fatal("expected step a output in context")
+	}
+	if !strings.Contains(val.(string), "executed") {
+		t.Errorf("context value = %v", val)
+	}
+}
+
+func TestExecutorSummaryContent(t *testing.T) {
+	steps := makeSteps("a")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(successRunner, p.Config)
+	result, _ := executor.Run(context.Background(), p)
+
+	if !strings.Contains(result.Summary, "successfully") {
+		t.Errorf("summary should mention success: %q", result.Summary)
+	}
+	if !strings.Contains(result.Summary, "Step a") {
+		t.Errorf("summary should list step name: %q", result.Summary)
+	}
+}
+
+func TestExecutorFailedSummary(t *testing.T) {
+	steps := makeSteps("a")
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	executor := NewExecutor(failRunner, p.Config)
+	result, _ := executor.Run(context.Background(), p)
+
+	if !strings.Contains(result.Summary, "failed") {
+		t.Errorf("summary should mention failure: %q", result.Summary)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -1,0 +1,83 @@
+package pipeline
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// PipelineState represents the lifecycle state of a pipeline.
+type PipelineState string
+
+const (
+	StatePlanned              PipelineState = "planned"
+	StateAwaitingConfirmation PipelineState = "awaiting_confirmation"
+	StateRunning              PipelineState = "running"
+	StateCompleted            PipelineState = "completed"
+	StateFailed               PipelineState = "failed"
+	StateRejected             PipelineState = "rejected"
+)
+
+// PipelineConfig holds execution settings for a pipeline.
+type PipelineConfig struct {
+	MaxStepRetries int
+	StepTimeout    time.Duration
+	FailFast       bool
+}
+
+// DefaultConfig returns sensible defaults for pipeline execution.
+func DefaultConfig() PipelineConfig {
+	return PipelineConfig{
+		MaxStepRetries: 3,
+		StepTimeout:    60 * time.Second,
+		FailFast:       true,
+	}
+}
+
+// Pipeline is a planned sequence of steps to execute.
+type Pipeline struct {
+	ID        string
+	Steps     []*Step
+	State     PipelineState
+	Config    PipelineConfig
+	Context   *PipelineContext
+	CreatedAt time.Time
+}
+
+// NewPipeline creates a pipeline from planner-produced steps with the given config.
+func NewPipeline(steps []*Step, cfg PipelineConfig) *Pipeline {
+	return &Pipeline{
+		ID:        fmt.Sprintf("pipeline-%d", time.Now().UnixNano()),
+		Steps:     steps,
+		State:     StateAwaitingConfirmation,
+		Config:    cfg,
+		Context:   NewContext(),
+		CreatedAt: time.Now(),
+	}
+}
+
+// FormatForConfirmation renders a human-readable plan for user approval.
+func (p *Pipeline) FormatForConfirmation() string {
+	var sb strings.Builder
+	sb.WriteString("I've created a plan with the following steps:\n\n")
+	for i, step := range p.Steps {
+		sb.WriteString(fmt.Sprintf("%d. **%s**\n", i+1, step.Name))
+		if step.Command != nil {
+			sb.WriteString(fmt.Sprintf("   Action: `%s.%s`\n", step.Command.Plugin, step.Command.Action))
+			if len(step.Command.Args) > 0 {
+				sb.WriteString("   Args: ")
+				parts := make([]string, 0, len(step.Command.Args))
+				for k, v := range step.Command.Args {
+					parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+				}
+				sb.WriteString(strings.Join(parts, ", "))
+				sb.WriteString("\n")
+			}
+		}
+		if len(step.DependsOn) > 0 {
+			sb.WriteString(fmt.Sprintf("   Depends on: %s\n", strings.Join(step.DependsOn, ", ")))
+		}
+	}
+	sb.WriteString("\nProceed? (y)es / (n)o")
+	return sb.String()
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1,0 +1,104 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewPipeline(t *testing.T) {
+	steps := []*Step{
+		{ID: "1", Name: "Step 1", Command: &PluginCommand{Plugin: "p", Action: "a"}, State: StepPending},
+	}
+	p := NewPipeline(steps, DefaultConfig())
+
+	if p.State != StateAwaitingConfirmation {
+		t.Errorf("State = %q, want awaiting_confirmation", p.State)
+	}
+	if p.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if len(p.Steps) != 1 {
+		t.Errorf("expected 1 step, got %d", len(p.Steps))
+	}
+	if p.Context == nil {
+		t.Error("expected non-nil context")
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.MaxStepRetries != 3 {
+		t.Errorf("MaxStepRetries = %d, want 3", cfg.MaxStepRetries)
+	}
+	if cfg.StepTimeout != 60*time.Second {
+		t.Errorf("StepTimeout = %v, want 60s", cfg.StepTimeout)
+	}
+	if !cfg.FailFast {
+		t.Error("FailFast should be true by default")
+	}
+}
+
+func TestFormatForConfirmation(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:   "1",
+			Name: "Get error details",
+			Command: &PluginCommand{
+				Plugin: "appsignal",
+				Action: "get_error",
+				Args:   map[string]string{"error_id": "123"},
+			},
+		},
+		{
+			ID:   "2",
+			Name: "Create Jira issue",
+			Command: &PluginCommand{
+				Plugin: "jira",
+				Action: "create_issue",
+				Args:   map[string]string{"title": "Fix error"},
+			},
+			DependsOn: []string{"1"},
+		},
+	}
+	p := NewPipeline(steps, DefaultConfig())
+	text := p.FormatForConfirmation()
+
+	if !strings.Contains(text, "Get error details") {
+		t.Error("should contain step 1 name")
+	}
+	if !strings.Contains(text, "Create Jira issue") {
+		t.Error("should contain step 2 name")
+	}
+	if !strings.Contains(text, "appsignal.get_error") {
+		t.Error("should contain step 1 action")
+	}
+	if !strings.Contains(text, "jira.create_issue") {
+		t.Error("should contain step 2 action")
+	}
+	if !strings.Contains(text, "(y)es") {
+		t.Error("should mention (y)es to confirm")
+	}
+	if !strings.Contains(text, "(n)o") {
+		t.Error("should mention (n)o to cancel")
+	}
+	if !strings.Contains(text, "1.") && !strings.Contains(text, "2.") {
+		t.Error("should number the steps")
+	}
+}
+
+func TestFormatForConfirmationNoDependsOn(t *testing.T) {
+	steps := []*Step{
+		{
+			ID:      "1",
+			Name:    "Simple step",
+			Command: &PluginCommand{Plugin: "p", Action: "a"},
+		},
+	}
+	p := NewPipeline(steps, DefaultConfig())
+	text := p.FormatForConfirmation()
+
+	if strings.Contains(text, "Depends on") {
+		t.Error("should not show depends_on for steps without dependencies")
+	}
+}

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -1,0 +1,199 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+)
+
+// LLMClient is the interface the planner uses for LLM calls, matching orchestrator.LLMClient.
+type LLMClient interface {
+	Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error)
+}
+
+// CompletionRequest mirrors provider.CompletionRequest for planner use.
+type CompletionRequest struct {
+	Messages []Message
+}
+
+// CompletionResponse mirrors provider.CompletionResponse.
+type CompletionResponse struct {
+	Content string
+}
+
+// Message mirrors provider.Message.
+type Message struct {
+	Role    string
+	Content string
+}
+
+// CapabilityInfo describes a plugin's capabilities for the planner prompt.
+type CapabilityInfo struct {
+	Name        string
+	Description string
+	Actions     []ActionInfo
+}
+
+// ActionInfo describes a single action.
+type ActionInfo struct {
+	Name        string
+	Description string
+	Parameters  []ParamInfo
+}
+
+// ParamInfo describes a parameter.
+type ParamInfo struct {
+	Name        string
+	Description string
+	Required    bool
+}
+
+// Planner uses an LLM to decompose user requests into pipeline steps.
+type Planner struct {
+	llm LLMClient
+}
+
+// PlanResult holds the planner's decision: either "direct" (single action, use normal agent loop)
+// or "pipeline" with multiple steps.
+type PlanResult struct {
+	Type  string  // "direct" | "pipeline"
+	Steps []*Step // only when Type == "pipeline"
+}
+
+// NewPlanner creates a planner backed by the given LLM client.
+func NewPlanner(llm LLMClient) *Planner {
+	return &Planner{llm: llm}
+}
+
+// planResponse is the JSON shape we expect from the LLM.
+type planResponse struct {
+	Type  string         `json:"type"`
+	Steps []planStepJSON `json:"steps"`
+}
+
+type planStepJSON struct {
+	ID        string            `json:"id"`
+	Name      string            `json:"name"`
+	Plugin    string            `json:"plugin"`
+	Action    string            `json:"action"`
+	Args      map[string]string `json:"args"`
+	DependsOn []string          `json:"depends_on"`
+}
+
+// Plan asks the LLM whether the user's message requires a multi-step pipeline or a direct action.
+func (p *Planner) Plan(ctx context.Context, message string, capabilities []CapabilityInfo) (*PlanResult, error) {
+	systemPrompt := buildPlannerPrompt(capabilities)
+	debug := os.Getenv("LOG_LEVEL") == "debug"
+
+	if debug {
+		log.Printf("[pipeline:planner] system prompt:\n%s", systemPrompt)
+		log.Printf("[pipeline:planner] user message: %q", message)
+	}
+
+	resp, err := p.llm.Complete(ctx, &CompletionRequest{
+		Messages: []Message{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: message},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("planner LLM call: %w", err)
+	}
+
+	if debug {
+		log.Printf("[pipeline:planner] LLM response: %s", resp.Content)
+	}
+
+	return parsePlanResponse(resp.Content)
+}
+
+func buildPlannerPrompt(capabilities []CapabilityInfo) string {
+	var sb strings.Builder
+	sb.WriteString(`You are a task planner. Given the user's request and available tools, decide:
+1. If this is a simple single-action request, return: {"type": "direct"}
+2. If this requires multiple steps, return: {"type": "pipeline", "steps": [...]}
+
+Each step must have: {"id": "<unique>", "name": "<human description>", "plugin": "<plugin>", "action": "<action>", "args": {}, "depends_on": []}
+
+Available tools:
+`)
+	for _, cap := range capabilities {
+		for _, action := range cap.Actions {
+			sb.WriteString(fmt.Sprintf("- %s.%s: %s\n", cap.Name, action.Name, action.Description))
+			for _, param := range action.Parameters {
+				req := ""
+				if param.Required {
+					req = " (required)"
+				}
+				sb.WriteString(fmt.Sprintf("  - %s: %s%s\n", param.Name, param.Description, req))
+			}
+		}
+	}
+	sb.WriteString("\nRespond ONLY with valid JSON, no other text.")
+	return sb.String()
+}
+
+func parsePlanResponse(content string) (*PlanResult, error) {
+	// Try to extract JSON from the response (LLMs sometimes wrap in markdown code blocks)
+	jsonStr := extractJSON(content)
+
+	var resp planResponse
+	if err := json.Unmarshal([]byte(jsonStr), &resp); err != nil {
+		// Parse failure → fallback to direct
+		return &PlanResult{Type: "direct"}, nil
+	}
+
+	if resp.Type != "pipeline" || len(resp.Steps) == 0 {
+		return &PlanResult{Type: "direct"}, nil
+	}
+
+	steps := make([]*Step, len(resp.Steps))
+	for i, s := range resp.Steps {
+		id := s.ID
+		if id == "" {
+			id = fmt.Sprintf("%d", i+1)
+		}
+		args := s.Args
+		if args == nil {
+			args = make(map[string]string)
+		}
+		steps[i] = &Step{
+			ID:   id,
+			Name: s.Name,
+			Command: &PluginCommand{
+				Plugin: s.Plugin,
+				Action: s.Action,
+				Args:   args,
+			},
+			DependsOn:  s.DependsOn,
+			State:      StepPending,
+			MaxRetries: -1, // use pipeline default
+		}
+	}
+
+	return &PlanResult{Type: "pipeline", Steps: steps}, nil
+}
+
+// extractJSON tries to pull JSON from a response that may be wrapped in markdown code fences.
+func extractJSON(s string) string {
+	s = strings.TrimSpace(s)
+
+	// Try to find ```json ... ``` blocks
+	if idx := strings.Index(s, "```json"); idx >= 0 {
+		s = s[idx+7:]
+		if end := strings.Index(s, "```"); end >= 0 {
+			return strings.TrimSpace(s[:end])
+		}
+	}
+	if idx := strings.Index(s, "```"); idx >= 0 {
+		s = s[idx+3:]
+		if end := strings.Index(s, "```"); end >= 0 {
+			return strings.TrimSpace(s[:end])
+		}
+	}
+
+	return s
+}

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -1,0 +1,180 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+)
+
+type fakePlannerLLM struct {
+	response string
+}
+
+func (f *fakePlannerLLM) Complete(_ context.Context, _ *CompletionRequest) (*CompletionResponse, error) {
+	return &CompletionResponse{Content: f.response}, nil
+}
+
+func TestPlannerReturnsDirect(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{"type": "direct"}`}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "hello", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Type != "direct" {
+		t.Errorf("Type = %q, want direct", result.Type)
+	}
+	if len(result.Steps) != 0 {
+		t.Errorf("expected no steps for direct, got %d", len(result.Steps))
+	}
+}
+
+func TestPlannerReturnsPipeline(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{
+		"type": "pipeline",
+		"steps": [
+			{"id": "1", "name": "Get error details", "plugin": "appsignal", "action": "get_error", "args": {"error_id": "123"}, "depends_on": []},
+			{"id": "2", "name": "Create Jira issue", "plugin": "jira", "action": "create_issue", "args": {"title": "Fix error"}, "depends_on": ["1"]}
+		]
+	}`}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "investigate error 123 and create a ticket", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Type != "pipeline" {
+		t.Errorf("Type = %q, want pipeline", result.Type)
+	}
+	if len(result.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(result.Steps))
+	}
+	if result.Steps[0].Command.Plugin != "appsignal" {
+		t.Errorf("step 0 plugin = %q", result.Steps[0].Command.Plugin)
+	}
+	if result.Steps[1].Command.Plugin != "jira" {
+		t.Errorf("step 1 plugin = %q", result.Steps[1].Command.Plugin)
+	}
+	if len(result.Steps[1].DependsOn) != 1 || result.Steps[1].DependsOn[0] != "1" {
+		t.Errorf("step 1 depends_on = %v", result.Steps[1].DependsOn)
+	}
+	if result.Steps[0].State != StepPending {
+		t.Errorf("step state = %q, want pending", result.Steps[0].State)
+	}
+	if result.Steps[0].MaxRetries != -1 {
+		t.Errorf("step max_retries = %d, want -1", result.Steps[0].MaxRetries)
+	}
+}
+
+func TestPlannerHandlesMarkdownCodeFence(t *testing.T) {
+	llm := &fakePlannerLLM{response: "```json\n{\"type\": \"pipeline\", \"steps\": [{\"id\": \"1\", \"name\": \"Step one\", \"plugin\": \"p\", \"action\": \"a\"}]}\n```"}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "do things", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Type != "pipeline" {
+		t.Errorf("Type = %q, want pipeline", result.Type)
+	}
+	if len(result.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(result.Steps))
+	}
+}
+
+func TestPlannerFallsBackOnInvalidJSON(t *testing.T) {
+	llm := &fakePlannerLLM{response: "I'm not sure what you mean, here's some text"}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "something", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Type != "direct" {
+		t.Errorf("Type = %q, want direct (fallback)", result.Type)
+	}
+}
+
+func TestPlannerFallsBackOnEmptySteps(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{"type": "pipeline", "steps": []}`}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "something", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Type != "direct" {
+		t.Errorf("Type = %q, want direct (empty steps fallback)", result.Type)
+	}
+}
+
+func TestPlannerAssignsDefaultIDs(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{"type": "pipeline", "steps": [{"name": "Step A", "plugin": "p", "action": "a"}, {"name": "Step B", "plugin": "p", "action": "b"}]}`}
+	planner := NewPlanner(llm)
+
+	result, err := planner.Plan(context.Background(), "do things", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Steps[0].ID != "1" {
+		t.Errorf("step 0 ID = %q, want 1", result.Steps[0].ID)
+	}
+	if result.Steps[1].ID != "2" {
+		t.Errorf("step 1 ID = %q, want 2", result.Steps[1].ID)
+	}
+}
+
+func TestExtractJSON(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`{"type": "direct"}`, `{"type": "direct"}`},
+		{"```json\n{\"type\": \"direct\"}\n```", `{"type": "direct"}`},
+		{"```\n{\"type\": \"direct\"}\n```", `{"type": "direct"}`},
+		{"  {\"type\": \"direct\"}  ", `{"type": "direct"}`},
+	}
+	for _, tt := range tests {
+		got := extractJSON(tt.input)
+		if got != tt.want {
+			t.Errorf("extractJSON(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBuildPlannerPrompt(t *testing.T) {
+	caps := []CapabilityInfo{
+		{
+			Name:        "jira",
+			Description: "Jira integration",
+			Actions: []ActionInfo{
+				{Name: "create_issue", Description: "Create a Jira issue", Parameters: []ParamInfo{
+					{Name: "title", Description: "Issue title", Required: true},
+				}},
+			},
+		},
+	}
+	prompt := buildPlannerPrompt(caps)
+	if prompt == "" {
+		t.Error("expected non-empty prompt")
+	}
+	if !containsStr(prompt, "jira.create_issue") {
+		t.Error("prompt should list jira.create_issue")
+	}
+	if !containsStr(prompt, "(required)") {
+		t.Error("prompt should mark required params")
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pipeline/step.go
+++ b/internal/pipeline/step.go
@@ -1,0 +1,31 @@
+package pipeline
+
+// StepState represents the execution state of a step.
+type StepState string
+
+const (
+	StepPending   StepState = "pending"
+	StepRunning   StepState = "running"
+	StepSucceeded StepState = "succeeded"
+	StepFailed    StepState = "failed"
+	StepSkipped   StepState = "skipped"
+)
+
+// Step is a single unit of work in a pipeline.
+type Step struct {
+	ID         string
+	Name       string
+	Command    *PluginCommand
+	DependsOn  []string
+	State      StepState
+	Attempts   int
+	MaxRetries int // -1 = use pipeline default
+	Result     *StepResult
+}
+
+// StepResult holds the outcome of executing a step.
+type StepResult struct {
+	Success bool
+	Output  string
+	Data    map[string]any
+}


### PR DESCRIPTION
## Summary

Adds structured pipeline execution for multi-step user requests. When a user asks something that requires multiple tool calls (e.g. "check the bug in AppSignal, create a Jira ticket, and open a GitLab MR"), the system now:

1. **Plans** — A separate LLM call decomposes the request into a DAG of steps with dependencies
2. **Confirms** — Presents the plan to the user for approval before executing anything
3. **Executes** — Runs steps sequentially with per-step retry and timeout
4. **Reports** — Returns a structured summary of what succeeded and what failed

Single-step requests are unaffected — they fall through to the existing agent loop.

## What's new

### `internal/pipeline/` package (7 files + 5 test files)

- **`pipeline.go`** — `Pipeline`, `PipelineState`, `PipelineConfig`, `FormatForConfirmation()`. Six lifecycle states: planned → awaiting_confirmation → running → completed/failed/rejected.
- **`step.go`** — `Step`, `StepState`, `StepResult`. Five states: pending → running → succeeded/failed/skipped.
- **`command.go`** — `PluginCommand` struct (plugin, action, args). Only command type for Phase 1.
- **`context.go`** — `PipelineContext`: thread-safe shared state (`sync.RWMutex`) across steps. Step outputs merge into context automatically.
- **`planner.go`** — `Planner` sends a system prompt with available tools to the LLM, expects JSON response (`{"type": "direct"}` or `{"type": "pipeline", "steps": [...]}`). Handles markdown code fences. Falls back to "direct" on parse failure.
- **`executor.go`** — `Executor` runs steps sequentially respecting `DependsOn`. Retry with backoff (500ms × attempt). FailFast aborts on first failure; when disabled, skips dependents and continues.
- **`confirmation.go`** — `ParseConfirmation()`: only `y`/`yes` (case-insensitive) approves, everything else rejects. Unix-style prompt: `(y)es / (n)o`.

### Orchestrator integration

- **Block A** (top of `Run()`): checks for pending pipeline awaiting user confirmation
- **Block B** (after content preparers): runs planner on every message when pipeline is enabled
- **`executePipeline()`**: bridges pipeline executor to orchestrator's `executeCall()` via adapter function
- **Import cycle avoided**: pipeline package defines its own `LLMClient`, `Message`, `CapabilityInfo` types; orchestrator provides adapter implementations

### Config

```yaml
orchestrator:
  pipeline:
    enabled: true          # default: false
    max_step_retries: 2    # default: 3
    step_timeout: "30s"    # default: "60s"
```

### Debug logging

All pipeline code paths log with `[pipeline]` / `[pipeline:planner]` prefix when `LOG_LEVEL=debug`.

## How confirmation works

The channel dispatch loop calls `orchestrator.Run()` synchronously — blocking for user input would deadlock. So confirmation uses **session state**:

1. `Run()` → planner decomposes → stores pipeline in `pendingPipelines[sessionID]` → returns plan text to user
2. Next user message → `Run()` finds pending pipeline → `ParseConfirmation()` → executes or cancels
3. No changes to channel or proto code required

## What's NOT included (future phases)

- **Phase 2**: Recovery Advisor (LLM-assisted error diagnosis), Remediator, Circuit Breaker
- **Phase 3**: Replan strategy, plan editing, step output templating (`{{steps.X.output.Y}}`), parallel execution, Command interface
- **Phase 4**: Plugin permissions, pipeline persistence, audit log, cost tracking

See `docs/design/pipeline.md` for the full design document with implementation status.

## Test plan

- [x] `internal/pipeline/` — 25 unit tests covering context, confirmation, planner, executor, pipeline formatting
- [x] `internal/orchestrator/` — 6 integration tests: disabled flow, direct fallthrough, pipeline storage, yes/no/unrelated confirmation
- [x] All existing tests pass (`go test ./...`)
- [x] Manual test: run locally with `LOG_LEVEL=debug`, send multi-step request, confirm with `y`, verify execution
- [x] Manual test: send multi-step request, reject with anything other than y/yes, verify cancellation