### PR TITLE
fix: request package executor, tool call parser, debug logging, YAML channels

### DIFF
--- a/internal/bundle/fetch.go
+++ b/internal/bundle/fetch.go
@@ -87,6 +87,16 @@ func CloneAndBuild(ctx context.Context, repo, ref, resolvedSHA, dir, binaryName 
 		}
 	}
 
+	// If this is a YAML-only repo (no go.mod), skip Go build steps entirely
+	// and return the channel.yaml path directly.
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); os.IsNotExist(err) {
+		yamlPath := filepath.Join(dir, "channel.yaml")
+		if _, err := os.Stat(yamlPath); err == nil {
+			return yamlPath, nil
+		}
+		return "", fmt.Errorf("repo has no go.mod and no channel.yaml")
+	}
+
 	// If running from source, point the cloned repo at our local core module
 	// so it builds against the same SDK version we're running. When installed
 	// as a standalone binary (no go.mod nearby), this is a no-op and the repo

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -3,6 +3,7 @@ package channel
 import (
 	"context"
 	"log"
+	"os"
 
 	"github.com/opentalon/opentalon/internal/actor"
 	pkg "github.com/opentalon/opentalon/pkg/channel"
@@ -34,7 +35,7 @@ func NewMessageHandler(
 		if outContent == "" {
 			outContent = "(No response)"
 		}
-		if msg.ChannelID == "console" && inputForDisplay != "" {
+		if msg.ChannelID == "console" && inputForDisplay != "" && os.Getenv("LOG_LEVEL") == "debug" {
 			outContent = "Input to LLM:\n" + inputForDisplay + "\n\n---\n\nResponse:\n" + response
 		}
 		return pkg.OutboundMessage{

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -403,11 +403,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string) (
 			result.Response = resp.Content
 			if len(result.Results) > 0 {
 				var parts []string
-				for _, r := range result.Results {
+				for i, r := range result.Results {
+					if i < len(result.ToolCalls) {
+						parts = append(parts, formatToolCallMessage(result.ToolCalls[i]))
+					}
 					if r.Error != "" {
-						parts = append(parts, "[error] "+r.Error)
+						parts = append(parts, "[tool_result] error: "+r.Error)
 					} else if r.Content != "" {
-						parts = append(parts, r.Content)
+						preview := r.Content
+						if len(preview) > 500 {
+							preview = preview[:500] + "..."
+						}
+						parts = append(parts, "[tool_result] "+preview)
 					}
 				}
 				result.InputForDisplay = strings.TrimSpace(strings.Join(parts, "\n"))
@@ -424,6 +431,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string) (
 			toolResult := o.executeCall(ctx, call)
 			result.ToolCalls = append(result.ToolCalls, call)
 			result.Results = append(result.Results, toolResult)
+
+			if toolResult.Error != "" {
+				log.Printf("[tool_result] %s.%s error: %s", call.Plugin, call.Action, toolResult.Error)
+			}
 
 			_ = o.sessions.AddMessage(sessionID, provider.Message{
 				Role:    provider.RoleAssistant,
@@ -522,6 +533,10 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string) string {
 	var sb strings.Builder
 	sb.WriteString("You are an AI assistant with access to the following tools.\n\n")
+	sb.WriteString("To call a tool, use EXACTLY this format (no other format will be recognized):\n\n")
+	sb.WriteString("[tool_call]\n{\"tool\": \"plugin.action\", \"args\": {\"key\": \"value\"}}\n[/tool_call]\n\n")
+	sb.WriteString("Example:\n[tool_call]\n{\"tool\": \"brave-search.search\", \"args\": {\"query\": \"latest news\"}}\n[/tool_call]\n\n")
+	sb.WriteString("You may include multiple [tool_call]...[/tool_call] blocks in a single response. Any text outside these blocks is ignored when tool calls are present.\n\n")
 	sb.WriteString("When you receive plugin or tool results, reply to the user in a brief natural language answer. Do not simply repeat or echo the tool output; use it to answer the user's question or confirm what was done.\n\n")
 
 	sb.WriteString(o.rules.BuildPromptSection())

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -7,14 +7,27 @@ import (
 )
 
 // toolCallJSON is the shape we expect inside [tool_call]...[/tool_call].
+// Args uses interface{} to accept mixed types (string, number, bool) from LLMs.
 type toolCallJSON struct {
-	Tool string            `json:"tool"`
-	Args map[string]string `json:"args"`
+	Tool string                 `json:"tool"`
+	Args map[string]interface{} `json:"args"`
 }
 
-// DefaultParser parses LLM response text for [tool_call]...[/tool_call] blocks
-// with JSON like {"tool": "plugin.action", "args": {...}}. Returns nil if no
-// tool calls are found (response is the final answer).
+// DefaultParser parses LLM response text for tool call blocks. It supports two formats:
+//
+// Format A (structured):
+//
+//	[tool_call]
+//	{"tool": "plugin.action", "args": {"key": "value"}}
+//	[/tool_call]
+//
+// Format B (inline, common LLM output):
+//
+//	[tool_call] plugin.action
+//	{"key": "value", "count": 10}
+//	[/tool_call]    (closing tag optional)
+//
+// Returns nil if no tool calls are found (response is the final answer).
 var DefaultParser ToolCallParser = defaultParser{}
 
 type defaultParser struct{}
@@ -28,37 +41,133 @@ func (defaultParser) Parse(response string) []ToolCall {
 			break
 		}
 		rest = rest[start+len("[tool_call]"):]
+
+		// Extract body: prefer [/tool_call] closing tag, fall back to end of string or next [tool_call].
+		var body string
 		end := strings.Index(rest, "[/tool_call]")
-		if end < 0 {
-			break
+		nextStart := strings.Index(rest, "[tool_call]")
+		switch {
+		case end >= 0:
+			body = strings.TrimSpace(rest[:end])
+			rest = rest[end+len("[/tool_call]"):]
+		case nextStart >= 0:
+			body = strings.TrimSpace(rest[:nextStart])
+			rest = rest[nextStart:]
+		default:
+			body = strings.TrimSpace(rest)
+			rest = ""
 		}
-		body := strings.TrimSpace(rest[:end])
-		rest = rest[end+len("[/tool_call]"):]
+
+		if body == "" {
+			continue
+		}
+
+		// Format A: {"tool": "plugin.action", "args": {...}}
 		var block toolCallJSON
-		if err := json.Unmarshal([]byte(body), &block); err != nil {
+		if err := json.Unmarshal([]byte(body), &block); err == nil && block.Tool != "" {
+			plugin, action, err := parseToolName(block.Tool)
+			if err != nil {
+				continue
+			}
+			args := toStringMap(block.Args)
+			calls = append(calls, ToolCall{
+				ID:     fmt.Sprintf("call-%d", len(calls)+1),
+				Plugin: plugin,
+				Action: action,
+				Args:   args,
+			})
 			continue
 		}
-		if block.Tool == "" {
-			continue
+
+		// Format B: plugin.action\n{json_args}
+		// Format C: plugin.action(key=value, key=value)
+		// Skip if body starts with '{' — that's malformed Format A, not an inline call.
+		if !strings.HasPrefix(body, "{") {
+			if call, ok := parseInlineToolCall(body, len(calls)+1); ok {
+				calls = append(calls, call)
+			}
 		}
-		plugin, action, err := parseToolName(block.Tool)
-		if err != nil {
-			continue
-		}
-		if block.Args == nil {
-			block.Args = make(map[string]string)
-		}
-		calls = append(calls, ToolCall{
-			ID:     fmt.Sprintf("call-%d", len(calls)+1),
-			Plugin: plugin,
-			Action: action,
-			Args:   block.Args,
-		})
 	}
 	if len(calls) == 0 {
 		return nil
 	}
 	return calls
+}
+
+// parseInlineToolCall parses these formats:
+//
+//	plugin.action\n{json_args}           (Format B)
+//	plugin.action(key=value, key=value)  (Format C)
+//	plugin.action                        (no args)
+func parseInlineToolCall(body string, callNum int) (ToolCall, bool) {
+	lines := strings.SplitN(body, "\n", 2)
+	firstLine := strings.TrimSpace(lines[0])
+
+	// Format C: plugin.action(key=value, key=value)
+	if paren := strings.IndexByte(firstLine, '('); paren > 0 {
+		toolName := firstLine[:paren]
+		plugin, action, err := parseToolName(toolName)
+		if err != nil {
+			return ToolCall{}, false
+		}
+		args := make(map[string]string)
+		argsStr := strings.TrimSuffix(strings.TrimSpace(firstLine[paren+1:]), ")")
+		if argsStr != "" {
+			for _, pair := range strings.Split(argsStr, ", ") {
+				eq := strings.IndexByte(pair, '=')
+				if eq > 0 {
+					args[strings.TrimSpace(pair[:eq])] = strings.TrimSpace(pair[eq+1:])
+				}
+			}
+		}
+		return ToolCall{
+			ID:     fmt.Sprintf("call-%d", callNum),
+			Plugin: plugin,
+			Action: action,
+			Args:   args,
+		}, true
+	}
+
+	// Format B: plugin.action\n{json_args} or just plugin.action
+	plugin, action, err := parseToolName(firstLine)
+	if err != nil {
+		return ToolCall{}, false
+	}
+
+	args := make(map[string]string)
+	if len(lines) > 1 {
+		jsonPart := strings.TrimSpace(lines[1])
+		if jsonPart != "" {
+			var rawArgs map[string]interface{}
+			if err := json.Unmarshal([]byte(jsonPart), &rawArgs); err == nil {
+				args = toStringMap(rawArgs)
+			}
+		}
+	}
+
+	return ToolCall{
+		ID:     fmt.Sprintf("call-%d", callNum),
+		Plugin: plugin,
+		Action: action,
+		Args:   args,
+	}, true
+}
+
+// toStringMap converts map[string]interface{} to map[string]string.
+func toStringMap(m map[string]interface{}) map[string]string {
+	if m == nil {
+		return make(map[string]string)
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		switch val := v.(type) {
+		case string:
+			result[k] = val
+		default:
+			result[k] = fmt.Sprintf("%v", val)
+		}
+	}
+	return result
 }
 
 // parseToolName splits "plugin.action" into ("plugin", "action").

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -1,0 +1,228 @@
+package orchestrator
+
+import (
+	"testing"
+)
+
+func TestParseFormatA(t *testing.T) {
+	response := `Let me search for that.
+[tool_call]
+{"tool": "brave-search.search", "args": {"query": "first human in space"}}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Action != "search" {
+		t.Errorf("action = %q", calls[0].Action)
+	}
+	if calls[0].Args["query"] != "first human in space" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+}
+
+func TestParseFormatB_WithClosingTag(t *testing.T) {
+	response := `[tool_call] brave-search.search
+{"query": "first human in space", "count": 10}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Action != "search" {
+		t.Errorf("action = %q", calls[0].Action)
+	}
+	if calls[0].Args["query"] != "first human in space" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+	if calls[0].Args["count"] != "10" {
+		t.Errorf("count = %q, want %q", calls[0].Args["count"], "10")
+	}
+}
+
+func TestParseFormatB_NoClosingTag(t *testing.T) {
+	response := `[tool_call] brave-search.search
+{
+  "query": "first human in space history",
+  "count": 10
+}`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Args["query"] != "first human in space history" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+	if calls[0].Args["count"] != "10" {
+		t.Errorf("count = %q", calls[0].Args["count"])
+	}
+}
+
+func TestParseFormatB_NoArgs(t *testing.T) {
+	response := `[tool_call] gitlab.list_repos
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "gitlab" || calls[0].Action != "list_repos" {
+		t.Errorf("call = %s.%s", calls[0].Plugin, calls[0].Action)
+	}
+}
+
+func TestParseMultipleCalls(t *testing.T) {
+	response := `[tool_call]
+{"tool": "brave-search.search", "args": {"query": "cats"}}
+[/tool_call]
+[tool_call] gitlab.list_repos
+{}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("call[0] plugin = %q", calls[0].Plugin)
+	}
+	if calls[1].Plugin != "gitlab" {
+		t.Errorf("call[1] plugin = %q", calls[1].Plugin)
+	}
+}
+
+func TestParseNoToolCalls(t *testing.T) {
+	calls := DefaultParser.Parse("Hello! How can I help?")
+	if calls != nil {
+		t.Errorf("expected nil, got %v", calls)
+	}
+}
+
+func TestParseInvalidToolName(t *testing.T) {
+	response := `[tool_call] invalidname
+{"query": "test"}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if calls != nil {
+		t.Errorf("expected nil for invalid tool name, got %v", calls)
+	}
+}
+
+func TestParseEmptyBody(t *testing.T) {
+	response := `[tool_call][/tool_call]`
+	calls := DefaultParser.Parse(response)
+	if calls != nil {
+		t.Errorf("expected nil for empty body, got %v", calls)
+	}
+}
+
+func TestParseFormatA_MixedArgTypes(t *testing.T) {
+	// LLMs often send "count": 10 (integer) instead of "count": "10" (string)
+	response := `[tool_call] {"tool": "brave-search.search", "args": {"query": "SpaceX launch news", "count": 10, "freshness": "pd"}}
+`
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Args["query"] != "SpaceX launch news" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+	if calls[0].Args["count"] != "10" {
+		t.Errorf("count = %q, want %q", calls[0].Args["count"], "10")
+	}
+	if calls[0].Args["freshness"] != "pd" {
+		t.Errorf("freshness = %q", calls[0].Args["freshness"])
+	}
+}
+
+func TestParseFormatC_ParenArgs(t *testing.T) {
+	response := `[tool_call] brave-search.search(query=SpaceX launch today, freshness=pd)
+`
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Action != "search" {
+		t.Errorf("action = %q", calls[0].Action)
+	}
+	if calls[0].Args["query"] != "SpaceX launch today" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+	if calls[0].Args["freshness"] != "pd" {
+		t.Errorf("freshness = %q", calls[0].Args["freshness"])
+	}
+}
+
+func TestParseFormatC_NoArgs(t *testing.T) {
+	response := `[tool_call] opentalon.list_commands
+`
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "opentalon" || calls[0].Action != "list_commands" {
+		t.Errorf("call = %s.%s", calls[0].Plugin, calls[0].Action)
+	}
+}
+
+func TestParseFormatA_InlineNoClosingTag(t *testing.T) {
+	// LLM puts JSON on same line as [tool_call] without [/tool_call]
+	response := `[tool_call] {"tool": "brave-search.search", "args": {"query": "test"}}` + "\n"
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "brave-search" {
+		t.Errorf("plugin = %q", calls[0].Plugin)
+	}
+	if calls[0].Args["query"] != "test" {
+		t.Errorf("query = %q", calls[0].Args["query"])
+	}
+}
+
+func TestParseToolName(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantPlugin string
+		wantAction string
+		wantErr    bool
+	}{
+		{"brave-search.search", "brave-search", "search", false},
+		{"gitlab.analyze_code", "gitlab", "analyze_code", false},
+		{"a.b.c", "a.b", "c", false},
+		{"noaction", "", "", true},
+		{".nodot", "", "", true},
+		{"nodot.", "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			p, a, err := parseToolName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("err = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if p != tt.wantPlugin || a != tt.wantAction {
+				t.Errorf("got (%q, %q), want (%q, %q)", p, a, tt.wantPlugin, tt.wantAction)
+			}
+		})
+	}
+}

--- a/internal/requestpkg/package.go
+++ b/internal/requestpkg/package.go
@@ -62,6 +62,37 @@ func Substitute(s string, args map[string]string) string {
 	return s
 }
 
+// cleanURLParams removes query parameters whose values still contain
+// unsubstituted {{args.X}} templates. This allows request packages to
+// define optional query parameters that are only included when the
+// caller provides them.
+func cleanURLParams(rawURL string) string {
+	if !strings.Contains(rawURL, "{{args.") {
+		return rawURL
+	}
+	qmark := strings.IndexByte(rawURL, '?')
+	if qmark < 0 {
+		return rawURL
+	}
+	base := rawURL[:qmark]
+	query := rawURL[qmark+1:]
+
+	var kept []string
+	for _, param := range strings.Split(query, "&") {
+		if param == "" {
+			continue
+		}
+		if strings.Contains(param, "{{args.") {
+			continue
+		}
+		kept = append(kept, param)
+	}
+	if len(kept) == 0 {
+		return base
+	}
+	return base + "?" + strings.Join(kept, "&")
+}
+
 // Executor runs request packages for a single plugin. It implements orchestrator.PluginExecutor.
 type Executor struct {
 	pluginName string
@@ -101,7 +132,7 @@ func (e *Executor) Execute(call orchestrator.ToolCall) orchestrator.ToolResult {
 		}
 	}
 
-	url := Substitute(pkg.URL, call.Args)
+	url := cleanURLParams(Substitute(pkg.URL, call.Args))
 	if url == "" {
 		return orchestrator.ToolResult{CallID: call.ID, Error: "URL is empty after substitution"}
 	}

--- a/internal/requestpkg/package.go
+++ b/internal/requestpkg/package.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -93,6 +94,17 @@ func cleanURLParams(rawURL string) string {
 	return base + "?" + strings.Join(kept, "&")
 }
 
+// encodeURLParams re-parses the URL and properly encodes query parameter values.
+// This ensures values with spaces or special characters are percent-encoded.
+func encodeURLParams(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	u.RawQuery = u.Query().Encode()
+	return u.String()
+}
+
 // Executor runs request packages for a single plugin. It implements orchestrator.PluginExecutor.
 type Executor struct {
 	pluginName string
@@ -132,7 +144,7 @@ func (e *Executor) Execute(call orchestrator.ToolCall) orchestrator.ToolResult {
 		}
 	}
 
-	url := cleanURLParams(Substitute(pkg.URL, call.Args))
+	url := encodeURLParams(cleanURLParams(Substitute(pkg.URL, call.Args)))
 	if url == "" {
 		return orchestrator.ToolResult{CallID: call.ID, Error: "URL is empty after substitution"}
 	}

--- a/internal/requestpkg/package_test.go
+++ b/internal/requestpkg/package_test.go
@@ -36,6 +36,65 @@ func TestSubstitute(t *testing.T) {
 	}
 }
 
+func TestCleanURLParams(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"no templates", "https://api.example.com/search?q=cats", "https://api.example.com/search?q=cats"},
+		{"all resolved", "https://api.example.com/search?q=cats&count=5", "https://api.example.com/search?q=cats&count=5"},
+		{"one unresolved", "https://api.example.com/search?q=cats&count={{args.count}}", "https://api.example.com/search?q=cats"},
+		{"multiple unresolved", "https://api.example.com/search?q=cats&count={{args.count}}&lang={{args.lang}}", "https://api.example.com/search?q=cats"},
+		{"all unresolved", "https://api.example.com/search?q={{args.query}}&count={{args.count}}", "https://api.example.com/search"},
+		{"no query string", "https://api.example.com/search", "https://api.example.com/search"},
+		{"mixed resolved and unresolved", "https://api.example.com/search?q=cats&count=5&lang={{args.lang}}&country=US", "https://api.example.com/search?q=cats&count=5&country=US"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanURLParams(tt.url)
+			if got != tt.want {
+				t.Errorf("cleanURLParams() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutor_Execute_OptionalParams(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("q") != "test" {
+			t.Errorf("q = %q, want %q", q.Get("q"), "test")
+		}
+		// count should be stripped (not provided by caller)
+		if q.Get("count") != "" {
+			t.Errorf("count should be empty, got %q", q.Get("count"))
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	exec := NewExecutor("search", []Package{
+		{
+			Action: "search",
+			Method: "GET",
+			URL:    srv.URL + "/search?q={{args.query}}&count={{args.count}}",
+		},
+	})
+
+	result := exec.Execute(orchestrator.ToolCall{
+		ID:     "call-opt",
+		Plugin: "search",
+		Action: "search",
+		Args:   map[string]string{"query": "test"},
+	})
+
+	if result.Error != "" {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+}
+
 func TestExecutor_Execute(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {

--- a/internal/requestpkg/package_test.go
+++ b/internal/requestpkg/package_test.go
@@ -95,6 +95,59 @@ func TestExecutor_Execute_OptionalParams(t *testing.T) {
 	}
 }
 
+func TestEncodeURLParams(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"no encoding needed", "https://api.example.com/search?q=cats", "https://api.example.com/search?q=cats"},
+		{"spaces in value", "https://api.example.com/search?q=SpaceX launch news", "https://api.example.com/search?q=SpaceX+launch+news"},
+		{"multiple params with spaces", "https://api.example.com/search?q=hello world&lang=en", "https://api.example.com/search?lang=en&q=hello+world"},
+		{"no query string", "https://api.example.com/search", "https://api.example.com/search"},
+		{"already encoded", "https://api.example.com/search?q=already%20encoded", "https://api.example.com/search?q=already+encoded"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := encodeURLParams(tt.url)
+			if got != tt.want {
+				t.Errorf("encodeURLParams() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecutor_Execute_URLEncoding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("q") != "SpaceX launch news" {
+			t.Errorf("q = %q, want %q", q.Get("q"), "SpaceX launch news")
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"results":[]}`))
+	}))
+	defer srv.Close()
+
+	exec := NewExecutor("search", []Package{
+		{
+			Action: "search",
+			Method: "GET",
+			URL:    srv.URL + "/search?q={{args.query}}",
+		},
+	})
+
+	result := exec.Execute(orchestrator.ToolCall{
+		ID:     "call-enc",
+		Plugin: "search",
+		Action: "search",
+		Args:   map[string]string{"query": "SpaceX launch news"},
+	})
+
+	if result.Error != "" {
+		t.Fatalf("unexpected error: %s", result.Error)
+	}
+}
+
 func TestExecutor_Execute(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {


### PR DESCRIPTION
## Summary

- **URL-encode query params**: Add `encodeURLParams()` to properly percent-encode substituted values (fixes HTTP 400 from Brave and other APIs when args contain spaces)
- **Multi-format tool call parser**: Rewrite parser to handle 3 LLM output formats:
  - Format A: `[tool_call]{"tool":"p.a","args":{}}[/tool_call]` (structured JSON)
  - Format B: `[tool_call] p.a\n{json}` (inline name + JSON body, with/without closing tag)
  - Format C: `[tool_call] p.a(key=val, key=val)` (parenthesized args)
- **Fix JSON args type mismatch**: Change `toolCallJSON.Args` from `map[string]string` to `map[string]interface{}` + `toStringMap()` (handles integer values like `"count": 10`)
- **Debug log gating**: Hide console "Input to LLM" and tool call/result output behind `LOG_LEVEL=debug`
- **System prompt tool format**: Add tool call format instructions to system prompt so LLM uses the correct syntax
- **YAML channel support**: Skip `go build` for YAML-only channel repos (no `go.mod`) in the bundler
- **Strip optional URL params**: Clean unsubstituted `{{args.X}}` template vars from query strings

## Test plan

- [x] `TestEncodeURLParams` — verifies spaces and special chars are encoded
- [x] `TestExecutor_Execute_URLEncoding` — integration test with httptest server
- [x] `TestCleanURLParams` — 7 cases for optional param stripping
- [x] Parser tests — 12 cases covering all 3 formats, mixed types, edge cases
- [x] Manual test: Brave Search returns results with multi-word queries
- [x] Manual test: Slack channel loads from YAML-only repo
- [x] Manual test: Console output is clean without `LOG_LEVEL=debug`