### PR TITLE
feat: add `make clean-cache` to clear cached bundles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test lint deps setup plugin channel run clean proto
+.PHONY: all build test lint deps setup plugin channel run clean clean-cache clean-plugins clean-channels clean-skills clean-lua-plugins proto
 
 BINARY      := opentalon
 CMD_PKG     := ./cmd/opentalon
@@ -70,3 +70,20 @@ clean:
 	rm -f $(BINARY)
 	rm -f $(HELLO_WORLD_BIN)
 	rm -f $(CONSOLE_BIN)
+
+# ── Clean cache: clear cached plugins/channels/skills ──────────────────────
+
+clean-cache: build
+	@./$(BINARY) -clean all
+
+clean-plugins: build
+	@./$(BINARY) -clean plugins
+
+clean-channels: build
+	@./$(BINARY) -clean channels
+
+clean-skills: build
+	@./$(BINARY) -clean skills
+
+clean-lua-plugins: build
+	@./$(BINARY) -clean lua_plugins

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -30,11 +30,17 @@ func main() {
 	fmt.Fprintln(os.Stderr, "OpenTalon starting...")
 	configPath := flag.String("config", "", "path to config file")
 	showVersion := flag.Bool("version", false, "print version and exit")
+	cleanFlag := flag.String("clean", "", "clear cached bundles and exit (all, plugins, channels, skills, lua_plugins)")
 	flag.Parse()
 
 	if *showVersion {
 		fmt.Println(version.Get())
 		os.Exit(0)
+	}
+
+	if *cleanFlag != "" {
+		runClean(*configPath, *cleanFlag)
+		return
 	}
 
 	if *configPath == "" {
@@ -418,6 +424,50 @@ func buildLuaScriptPaths(ctx context.Context, dataDir string, cfg *config.Config
 		}
 	}
 	return paths
+}
+
+// runClean clears cached bundles under the state data dir and exits.
+func runClean(configPath, category string) {
+	var dataDir string
+	if configPath != "" {
+		cfg, err := config.Load(configPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+			os.Exit(1)
+		}
+		dataDir = cfg.State.DataDir
+	}
+	if dataDir == "" {
+		home, _ := os.UserHomeDir()
+		dataDir = filepath.Join(home, ".opentalon")
+	}
+
+	var err error
+	switch category {
+	case "all":
+		fmt.Fprintf(os.Stderr, "Cleaning all cached bundles in %s...\n", dataDir)
+		err = bundle.CleanAll(dataDir)
+	case "plugins":
+		fmt.Fprintf(os.Stderr, "Cleaning cached plugins in %s...\n", dataDir)
+		err = bundle.CleanPlugins(dataDir)
+	case "channels":
+		fmt.Fprintf(os.Stderr, "Cleaning cached channels in %s...\n", dataDir)
+		err = bundle.CleanChannels(dataDir)
+	case "skills":
+		fmt.Fprintf(os.Stderr, "Cleaning cached skills in %s...\n", dataDir)
+		err = bundle.CleanSkills(dataDir)
+	case "lua_plugins":
+		fmt.Fprintf(os.Stderr, "Cleaning cached Lua plugins in %s...\n", dataDir)
+		err = bundle.CleanLuaPlugins(dataDir)
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown clean category %q. Use: all, plugins, channels, skills, lua_plugins\n", category)
+		os.Exit(1)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Clean failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stderr, "Done. Next run will re-download from configured refs.")
 }
 
 // buildProvider returns a provider and the default model ID from config.

--- a/internal/bundle/prune.go
+++ b/internal/bundle/prune.go
@@ -1,0 +1,52 @@
+package bundle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CleanPlugins removes cached plugins and their lock file.
+func CleanPlugins(stateDir string) error {
+	return cleanCategory(stateDir, "plugins", pluginsLockPath(stateDir))
+}
+
+// CleanChannels removes cached channels and their lock file.
+func CleanChannels(stateDir string) error {
+	return cleanCategory(stateDir, "channels", channelsLockPath(stateDir))
+}
+
+// CleanSkills removes cached skills and their lock file.
+func CleanSkills(stateDir string) error {
+	return cleanCategory(stateDir, "skills", skillsLockPath(stateDir))
+}
+
+// CleanLuaPlugins removes cached Lua plugins and their lock file.
+func CleanLuaPlugins(stateDir string) error {
+	return cleanCategory(stateDir, "lua_plugins", luaPluginsLockPath(stateDir))
+}
+
+// CleanAll removes all cached plugins, channels, skills, Lua plugins, and their lock files.
+func CleanAll(stateDir string) error {
+	var errs []error
+	for _, fn := range []func(string) error{CleanPlugins, CleanChannels, CleanSkills, CleanLuaPlugins} {
+		if err := fn(stateDir); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("clean errors: %v", errs)
+	}
+	return nil
+}
+
+func cleanCategory(stateDir, subdir, lockPath string) error {
+	dir := filepath.Join(stateDir, subdir)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("remove %s: %w", dir, err)
+	}
+	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s: %w", lockPath, err)
+	}
+	return nil
+}

--- a/internal/bundle/prune_test.go
+++ b/internal/bundle/prune_test.go
@@ -1,0 +1,92 @@
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanAll(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create cached dirs and lock files
+	for _, sub := range []string{"plugins/foo", "channels/bar", "skills/baz", "lua_plugins/qux"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := SavePluginsLock(dir, &PluginsLock{Plugins: map[string]LockEntry{"foo": {GitHub: "a/b"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveChannelsLock(dir, &ChannelsLock{Channels: map[string]LockEntry{"bar": {GitHub: "a/c"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveSkillsLock(dir, &SkillsLock{Skills: map[string]LockEntry{"baz": {GitHub: "a/d"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveLuaPluginsLock(dir, &LuaPluginsLock{Plugins: map[string]LockEntry{"qux": {GitHub: "a/e"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanAll(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify dirs are gone
+	for _, sub := range []string{"plugins", "channels", "skills", "lua_plugins"} {
+		if _, err := os.Stat(filepath.Join(dir, sub)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", sub)
+		}
+	}
+	// Verify lock files are gone
+	for _, lock := range []string{"plugins.lock", "channels.lock", "skills.lock", "lua_plugins.lock"} {
+		if _, err := os.Stat(filepath.Join(dir, lock)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", lock)
+		}
+	}
+}
+
+func TestCleanPluginsOnly(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(dir, "plugins/foo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "channels/bar"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := SavePluginsLock(dir, &PluginsLock{Plugins: map[string]LockEntry{"foo": {}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveChannelsLock(dir, &ChannelsLock{Channels: map[string]LockEntry{"bar": {}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CleanPlugins(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	// plugins gone
+	if _, err := os.Stat(filepath.Join(dir, "plugins")); !os.IsNotExist(err) {
+		t.Error("expected plugins dir to be removed")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "plugins.lock")); !os.IsNotExist(err) {
+		t.Error("expected plugins.lock to be removed")
+	}
+
+	// channels untouched
+	if _, err := os.Stat(filepath.Join(dir, "channels")); os.IsNotExist(err) {
+		t.Error("expected channels dir to still exist")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "channels.lock")); os.IsNotExist(err) {
+		t.Error("expected channels.lock to still exist")
+	}
+}
+
+func TestCleanNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	// Should not error when there's nothing to clean
+	if err := CleanAll(dir); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `-clean` CLI flag to remove cached plugins, channels, skills, and Lua plugins under `state.data_dir`
- Adds `make clean-cache`, `make clean-plugins`, `make clean-channels`, `make clean-skills`, `make clean-lua-plugins` targets
- Next run re-downloads everything from configured refs

Closes #26