### PR TITLE
feat: add MCP bridge support for HTTP+SSE MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,33 @@ All three categories share the same set of extension points:
 - [Pipeline execution](#pipeline-execution) (multi-step orchestration)
 - Custom API endpoints (inbound via [channels](#channel-plugins-grpc--http--ws--any-language), outbound via [tool plugins](#tool-plugins-grpc--any-language))
 
+### MCP (Model Context Protocol) Support
+
+OpenTalon supports the **Model Context Protocol (MCP)**, allowing it to connect to any MCP-compatible tool server alongside its native gRPC plugins.
+
+The **[opentalon/mcp-plugin](https://github.com/opentalon/mcp-plugin)** acts as an MCP bridge: it runs as a standard OpenTalon gRPC tool plugin and transparently proxies tool calls to one or more MCP servers over HTTP+SSE. From the core's perspective it is just another plugin; from the MCP server's perspective it is a standard MCP client.
+
+```
+OpenTalon Core  ──gRPC──▶  mcp-plugin  ──HTTP+SSE──▶  MCP Server A
+                                        ──HTTP+SSE──▶  MCP Server B
+```
+
+Configure it like any other plugin:
+
+```yaml
+plugins:
+  mcp:
+    enabled: true
+    github: "opentalon/mcp-plugin"
+    ref: "master"
+    config:
+      servers:
+        - name: my-mcp-server
+          url: "http://localhost:8080/sse"
+```
+
+Each tool exposed by the MCP servers is automatically registered in OpenTalon's tool registry and becomes callable by the LLM. All security guards (response sanitization, size limits, timeouts, namespace isolation) apply to MCP tool results exactly as they do to native gRPC plugins.
+
 ### Developer Experience
 
 - **Example: [Hello World plugin](https://github.com/opentalon/hellow-world-plugin)** — build your first tool plugin (hello→world + optional prompt fragment), then run OpenTalon with DeepSeek or any provider.

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -232,15 +232,7 @@ func main() {
 				if e.Name != "mcp" {
 					continue
 				}
-				env := os.Environ()
-				filtered := make([]string, 0, len(env)+1)
-				for _, v := range env {
-					if !strings.HasPrefix(v, "OPENTALON_MCP_SERVERS=") {
-						filtered = append(filtered, v)
-					}
-				}
-				filtered = append(filtered, "OPENTALON_MCP_SERVERS="+string(mcpJSON))
-				pluginEntries[i].Env = filtered
+				pluginEntries[i].WithEnvOverride("OPENTALON_MCP_SERVERS", string(mcpJSON))
 				injected = true
 				break
 			}

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -229,18 +229,20 @@ func main() {
 		} else {
 			injected := false
 			for i, e := range pluginEntries {
-				if e.Name == "mcp" {
-					env := os.Environ()
+				if e.Name != "mcp" {
+					continue
+				}
+				env := os.Environ()
 				filtered := make([]string, 0, len(env)+1)
-				for _, e := range env {
-					if !strings.HasPrefix(e, "OPENTALON_MCP_SERVERS=") {
-						filtered = append(filtered, e)
+				for _, v := range env {
+					if !strings.HasPrefix(v, "OPENTALON_MCP_SERVERS=") {
+						filtered = append(filtered, v)
 					}
 				}
-				pluginEntries[i].Env = append(filtered, "OPENTALON_MCP_SERVERS="+string(mcpJSON))
-					injected = true
-					break
-				}
+				filtered = append(filtered, "OPENTALON_MCP_SERVERS="+string(mcpJSON))
+				pluginEntries[i].Env = filtered
+				injected = true
+				break
 			}
 			if !injected {
 				log.Printf("Warning: MCP skill configs found but no 'mcp' plugin entry in config")

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -126,19 +127,8 @@ func main() {
 			Name: name, Plugin: path, Enabled: p.Enabled, Config: p.Config,
 		})
 	}
-	for _, e := range pluginEntries {
-		if e.Enabled && dataDir != "" {
-			if err := store.RunPluginMigrations(dataDir, e.Name, e.Plugin); err != nil {
-				log.Printf("Warning: plugin %s migrations: %v", e.Name, err)
-			}
-		}
-	}
-	pluginManager := plugin.NewManager(toolRegistry)
-	if err := pluginManager.LoadAll(ctx, pluginEntries); err != nil {
-		log.Printf("Warning: some plugins failed to load: %v", err)
-	}
-
-	// Request packages (skill-style): no compiled plugin, core runs HTTP requests from config/dir
+	// Request packages (skill-style): loaded before plugins so MCP server configs
+	// can be injected into the MCP plugin binary's environment at launch.
 	var requestSets []requestpkg.Set
 	if cfg.RequestPackages.Path != "" {
 		dirSets, err := requestpkg.LoadDir(cfg.RequestPackages.Path)
@@ -229,6 +219,40 @@ func main() {
 		}
 		requestSets = append(requestSets, set)
 	}
+
+	// Collect MCP server configs and inject into the "mcp" plugin entry's environment
+	// before the plugin is launched so the binary knows which servers to connect to.
+	if mcpServers := requestpkg.CollectMCPServers(requestSets); len(mcpServers) > 0 {
+		mcpJSON, err := json.Marshal(mcpServers)
+		if err != nil {
+			log.Printf("Warning: marshal MCP servers: %v", err)
+		} else {
+			injected := false
+			for i, e := range pluginEntries {
+				if e.Name == "mcp" {
+					pluginEntries[i].Env = append(os.Environ(), "OPENTALON_MCP_SERVERS="+string(mcpJSON))
+					injected = true
+					break
+				}
+			}
+			if !injected {
+				log.Printf("Warning: MCP skill configs found but no 'mcp' plugin entry in config")
+			}
+		}
+	}
+
+	for _, e := range pluginEntries {
+		if e.Enabled && dataDir != "" {
+			if err := store.RunPluginMigrations(dataDir, e.Name, e.Plugin); err != nil {
+				log.Printf("Warning: plugin %s migrations: %v", e.Name, err)
+			}
+		}
+	}
+	pluginManager := plugin.NewManager(toolRegistry)
+	if err := pluginManager.LoadAll(ctx, pluginEntries); err != nil {
+		log.Printf("Warning: some plugins failed to load: %v", err)
+	}
+
 	if err := requestpkg.Register(toolRegistry, requestSets); err != nil {
 		log.Printf("Warning: request_packages: %v", err)
 	}

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -230,7 +230,14 @@ func main() {
 			injected := false
 			for i, e := range pluginEntries {
 				if e.Name == "mcp" {
-					pluginEntries[i].Env = append(os.Environ(), "OPENTALON_MCP_SERVERS="+string(mcpJSON))
+					env := os.Environ()
+				filtered := make([]string, 0, len(env)+1)
+				for _, e := range env {
+					if !strings.HasPrefix(e, "OPENTALON_MCP_SERVERS=") {
+						filtered = append(filtered, e)
+					}
+				}
+				pluginEntries[i].Env = append(filtered, "OPENTALON_MCP_SERVERS="+string(mcpJSON))
 					injected = true
 					break
 				}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -23,7 +24,26 @@ type PluginEntry struct {
 	Plugin  string // path to binary or grpc://...
 	Enabled bool
 	Config  map[string]interface{}
-	Env     []string // optional: if set, passed as subprocess env (replaces inherited env)
+	Env     []string // if non-nil, used as the subprocess env verbatim; use WithEnvOverride to build it
+}
+
+// WithEnvOverride starts from the current process environment (or the entry's
+// existing Env slice) and overrides key to value, replacing any prior value
+// for that key. Safe to call multiple times to layer additional overrides.
+func (e *PluginEntry) WithEnvOverride(key, value string) {
+	base := e.Env
+	if base == nil {
+		base = os.Environ()
+	}
+	prefix := key + "="
+	result := make([]string, 0, len(base)+1)
+	for _, v := range base {
+		if !strings.HasPrefix(v, prefix) {
+			result = append(result, v)
+		}
+	}
+	result = append(result, key+"="+value)
+	e.Env = result
 }
 
 type managed struct {

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -23,6 +23,7 @@ type PluginEntry struct {
 	Plugin  string // path to binary or grpc://...
 	Enabled bool
 	Config  map[string]interface{}
+	Env     []string // optional: if set, passed as subprocess env (replaces inherited env)
 }
 
 type managed struct {
@@ -118,6 +119,9 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 
 func (m *Manager) launchBinary(ctx context.Context, entry PluginEntry) (*Process, *Client, error) {
 	proc := NewProcess(entry.Plugin)
+	if len(entry.Env) > 0 {
+		proc.SetEnv(entry.Env)
+	}
 	hs, err := proc.Start(ctx, defaultHandshakeTimeout)
 	if err != nil {
 		return nil, nil, fmt.Errorf("start %s: %w", entry.Name, err)

--- a/internal/plugin/process.go
+++ b/internal/plugin/process.go
@@ -20,6 +20,7 @@ type Process struct {
 	mu     sync.Mutex
 	path   string
 	args   []string
+	env    []string // if non-nil, used as cmd.Env (replaces inherited env)
 	cmd    *exec.Cmd
 	hs     pkg.Handshake
 	exited chan struct{}
@@ -33,6 +34,14 @@ func NewProcess(binaryPath string, args ...string) *Process {
 	}
 }
 
+// SetEnv sets the environment for the subprocess. If called before Start,
+// cmd.Env is set to env instead of inheriting the parent process environment.
+func (p *Process) SetEnv(env []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.env = env
+}
+
 // Start launches the plugin binary and reads its handshake line from
 // stdout. The plugin must print "version|network|address\n" within
 // the given timeout.
@@ -42,6 +51,9 @@ func (p *Process) Start(ctx context.Context, timeout time.Duration) (pkg.Handsha
 
 	cmd := exec.CommandContext(ctx, p.path, p.args...)
 	cmd.Stderr = os.Stderr
+	if len(p.env) > 0 {
+		cmd.Env = p.env
+	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/requestpkg/loader.go
+++ b/internal/requestpkg/loader.go
@@ -41,8 +41,13 @@ func LoadDir(dir string) ([]Set, error) {
 }
 
 // Register registers each set with the tool registry (capability + executor).
+// Sets with a non-nil MCP field are skipped — their capabilities come from the
+// opentalon-mcp plugin binary, not the built-in HTTP executor.
 func Register(registry *orchestrator.ToolRegistry, sets []Set) error {
 	for _, set := range sets {
+		if set.MCP != nil {
+			continue
+		}
 		cap := ToCapability(set)
 		exec := NewExecutor(set.PluginName, set.Packages)
 		if err := registry.Register(cap, exec); err != nil {
@@ -50,4 +55,17 @@ func Register(registry *orchestrator.ToolRegistry, sets []Set) error {
 		}
 	}
 	return nil
+}
+
+// CollectMCPServers returns the MCPServerConfig from every set that has one.
+// These are serialized as OPENTALON_MCP_SERVERS and injected into the MCP
+// plugin binary's environment before it is launched.
+func CollectMCPServers(sets []Set) []MCPServerConfig {
+	var configs []MCPServerConfig
+	for _, set := range sets {
+		if set.MCP != nil {
+			configs = append(configs, *set.MCP)
+		}
+	}
+	return configs
 }

--- a/internal/requestpkg/loader.go
+++ b/internal/requestpkg/loader.go
@@ -35,6 +35,9 @@ func LoadDir(dir string) ([]Set, error) {
 		if s.PluginName == "" {
 			return nil, fmt.Errorf("%s: missing plugin name", path)
 		}
+		if s.MCP != nil && s.MCP.URL == "" {
+			return nil, fmt.Errorf("%s: mcp section requires a non-empty url", path)
+		}
 		sets = append(sets, s)
 	}
 	return sets, nil

--- a/internal/requestpkg/loader_test.go
+++ b/internal/requestpkg/loader_test.go
@@ -1,0 +1,73 @@
+package requestpkg
+
+import (
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/orchestrator"
+)
+
+func TestCollectMCPServers(t *testing.T) {
+	sets := []Set{
+		{PluginName: "jira", Packages: []Package{{Action: "a"}}},
+		{PluginName: "mcp1", MCP: &MCPServerConfig{Server: "srv1", URL: "http://s1"}},
+		{PluginName: "mcp2", MCP: &MCPServerConfig{Server: "srv2", URL: "http://s2"}},
+	}
+	got := CollectMCPServers(sets)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Server != "srv1" || got[1].Server != "srv2" {
+		t.Errorf("unexpected servers: %+v", got)
+	}
+}
+
+func TestCollectMCPServers_NonePresent(t *testing.T) {
+	got := CollectMCPServers([]Set{
+		{PluginName: "jira", Packages: []Package{{Action: "a"}}},
+	})
+	if len(got) != 0 {
+		t.Fatalf("len = %d, want 0", len(got))
+	}
+}
+
+func TestCollectMCPServers_AllNil(t *testing.T) {
+	if got := CollectMCPServers(nil); len(got) != 0 {
+		t.Fatalf("len = %d, want 0", len(got))
+	}
+}
+
+func TestRegister_SkipsMCPSets(t *testing.T) {
+	reg := orchestrator.NewToolRegistry()
+	sets := []Set{
+		{
+			PluginName: "jira",
+			Packages:   []Package{{Action: "create_issue", Description: "d", Method: "GET", URL: "http://x"}},
+		},
+		{
+			PluginName: "mcp",
+			MCP:        &MCPServerConfig{Server: "mysrv", URL: "http://mcp.example.com/sse"},
+		},
+	}
+	if err := Register(reg, sets); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, ok := reg.GetCapability("jira"); !ok {
+		t.Error("jira should be registered")
+	}
+	if _, ok := reg.GetCapability("mcp"); ok {
+		t.Error("mcp set should be skipped (not registered via HTTP executor)")
+	}
+}
+
+func TestRegister_OnlyMCPSets(t *testing.T) {
+	reg := orchestrator.NewToolRegistry()
+	sets := []Set{
+		{PluginName: "mcp", MCP: &MCPServerConfig{Server: "s", URL: "http://u"}},
+	}
+	if err := Register(reg, sets); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if caps := reg.ListCapabilities(); len(caps) != 0 {
+		t.Errorf("expected no registrations, got %d", len(caps))
+	}
+}

--- a/internal/requestpkg/package.go
+++ b/internal/requestpkg/package.go
@@ -16,8 +16,6 @@ import (
 	pkgrpkg "github.com/opentalon/opentalon/pkg/requestpkg"
 )
 
-// MCPServerConfig is an alias for the public MCPServerConfig type so callers
-// of internal/requestpkg don't need to import pkg/requestpkg separately.
 type MCPServerConfig = pkgrpkg.MCPServerConfig
 
 // Package defines a single request package (skill-style): an HTTP request

--- a/internal/requestpkg/package.go
+++ b/internal/requestpkg/package.go
@@ -13,7 +13,12 @@ import (
 	"time"
 
 	"github.com/opentalon/opentalon/internal/orchestrator"
+	pkgrpkg "github.com/opentalon/opentalon/pkg/requestpkg"
 )
+
+// MCPServerConfig is an alias for the public MCPServerConfig type so callers
+// of internal/requestpkg don't need to import pkg/requestpkg separately.
+type MCPServerConfig = pkgrpkg.MCPServerConfig
 
 // Package defines a single request package (skill-style): an HTTP request
 // with URL/body/headers templated with {{env.X}} and {{args.Y}}.
@@ -36,10 +41,13 @@ type ParamDefinition struct {
 }
 
 // Set groups request packages by plugin name. Each plugin has a list of actions (packages).
+// If MCP is non-nil, this set is handled by the opentalon-mcp plugin binary instead of
+// the built-in HTTP executor; Packages is ignored in that case.
 type Set struct {
-	PluginName  string    `yaml:"plugin"` // e.g. jira
-	Description string    `yaml:"description"`
-	Packages    []Package `yaml:"packages"`
+	PluginName  string           `yaml:"plugin"` // e.g. jira, or "mcp"
+	Description string           `yaml:"description"`
+	Packages    []Package        `yaml:"packages"`
+	MCP         *MCPServerConfig `yaml:"mcp,omitempty"`
 }
 
 var (

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -20,6 +20,15 @@ type Handler interface {
 	Execute(req Request) Response
 }
 
+// ServeListener starts a gRPC server on an existing listener. The caller is
+// responsible for printing the handshake line to stdout before calling this.
+// Useful for TCP mode (MCP_GRPC_PORT).
+func ServeListener(ln net.Listener, handler Handler) error {
+	srv := grpc.NewServer()
+	pluginpb.RegisterPluginServiceServer(srv, &grpcServer{handler: handler})
+	return srv.Serve(ln)
+}
+
 // Serve starts a gRPC server on a Unix socket and serves requests from the
 // host using the given handler. It prints the handshake line to stdout so the
 // host can discover the socket. This function blocks until the server is stopped.

--- a/pkg/plugin/server.go
+++ b/pkg/plugin/server.go
@@ -21,7 +21,8 @@ type Handler interface {
 }
 
 // ServeListener starts a gRPC server on an existing listener. The caller is
-// responsible for printing the handshake line to stdout before calling this.
+// responsible for printing the handshake line to stdout before calling this,
+// and for closing the listener after ServeListener returns.
 // Useful for TCP mode (MCP_GRPC_PORT).
 func ServeListener(ln net.Listener, handler Handler) error {
 	srv := grpc.NewServer()

--- a/pkg/requestpkg/types.go
+++ b/pkg/requestpkg/types.go
@@ -1,0 +1,9 @@
+package requestpkg
+
+// MCPServerConfig holds the configuration for one MCP server, as specified
+// in the mcp: section of a skill YAML file.
+type MCPServerConfig struct {
+	Server  string            `json:"server" yaml:"server"`
+	URL     string            `json:"url" yaml:"url"`
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+}


### PR DESCRIPTION
- Add MCPServerConfig to pkg/requestpkg/types.go (public, importable by the external opentalon-mcp plugin binary)
- Add MCP *MCPServerConfig field to requestpkg.Set; skill YAMLs with an mcp: section are skipped by the HTTP executor (tools come from the plugin binary)
- Add CollectMCPServers() to requestpkg loader to gather MCP server configs from all loaded skill sets
- Add SetEnv() to plugin.Process and Env []string to plugin.PluginEntry so the MCP plugin binary receives OPENTALON_MCP_SERVERS at launch
- Add ServeListener() to pkg/plugin/server.go for TCP (remote gRPC) mode
- Wire it all together in main.go: request sets are loaded before plugins so MCP configs can be injected into the mcp plugin entry's environment