### PR TITLE
fix: Slack message delivery and error handling

### DIFF
--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/opentalon/opentalon/internal/actor"
 	pkg "github.com/opentalon/opentalon/pkg/channel"
@@ -29,7 +30,12 @@ func NewMessageHandler(
 		response, inputForDisplay, err := runner.Run(ctx, sessionKey, content)
 		if err != nil {
 			log.Printf("handler: run: %v", err)
-			return pkg.OutboundMessage{Content: "Error: " + err.Error()}, nil
+			return pkg.OutboundMessage{
+				ConversationID: msg.ConversationID,
+				ThreadID:       msg.ThreadID,
+				Content:        friendlyError(err),
+				Metadata:       msg.Metadata,
+			}, nil
 		}
 		outContent := response
 		if outContent == "" {
@@ -44,5 +50,20 @@ func NewMessageHandler(
 			Content:        outContent,
 			Metadata:       msg.Metadata,
 		}, nil
+	}
+}
+
+// friendlyError returns a user-facing message for known error conditions.
+func friendlyError(err error) string {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "maximum context length") || strings.Contains(msg, "context_length_exceeded"):
+		return "Sorry, this conversation has grown too long for the model to process. Please start a new conversation or clear the session."
+	case strings.Contains(msg, "rate_limit") || strings.Contains(msg, "429"):
+		return "I'm being rate-limited right now. Please try again in a moment."
+	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
+		return "The request timed out. Please try again."
+	default:
+		return "Something went wrong processing your message. Please try again or start a new conversation."
 	}
 }

--- a/internal/channel/yaml_template.go
+++ b/internal/channel/yaml_template.go
@@ -48,3 +48,23 @@ func jsonEscapeString(s string) string {
 	// json.Marshal wraps in quotes: "value" → strip them
 	return string(b[1 : len(b)-1])
 }
+
+// stripEmptyJSONValues removes top-level keys whose values are empty strings
+// from a JSON object body. This prevents sending invalid parameters to APIs
+// (e.g. Slack rejects "thread_ts":"" as invalid_thread_ts).
+func stripEmptyJSONValues(s string) string {
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		return s // not valid JSON, return as-is
+	}
+	for k, v := range obj {
+		if str, ok := v.(string); ok && str == "" {
+			delete(obj, k)
+		}
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return s
+	}
+	return string(out)
+}

--- a/internal/channel/yaml_template_test.go
+++ b/internal/channel/yaml_template_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -101,6 +102,62 @@ func TestSubstituteTemplateJSON(t *testing.T) {
 	want := `{"text":"He said \"hello\" and it's fine\nnew line","channel":"C123"}`
 	if got != want {
 		t.Errorf("substituteTemplateJSON:\ngot  %s\nwant %s", got, want)
+	}
+}
+
+func TestStripEmptyJSONValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "removes empty thread_ts",
+			input: `{"channel":"C123","text":"hello","thread_ts":""}`,
+			want:  `{"channel":"C123","text":"hello"}`,
+		},
+		{
+			name:  "keeps non-empty values",
+			input: `{"channel":"C123","text":"hello","thread_ts":"123.456"}`,
+			want:  `{"channel":"C123","text":"hello","thread_ts":"123.456"}`,
+		},
+		{
+			name:  "not valid JSON returns as-is",
+			input: `not json`,
+			want:  `not json`,
+		},
+		{
+			name:  "keeps non-string values",
+			input: `{"count":0,"name":""}`,
+			want:  `{"count":0}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripEmptyJSONValues(tt.input)
+			// Compare as parsed JSON to ignore key ordering
+			if got != tt.want {
+				// Parse both and compare
+				var gotMap, wantMap map[string]interface{}
+				if err1 := json.Unmarshal([]byte(got), &gotMap); err1 == nil {
+					if err2 := json.Unmarshal([]byte(tt.want), &wantMap); err2 == nil {
+						if len(gotMap) == len(wantMap) {
+							match := true
+							for k, v := range wantMap {
+								if gotMap[k] != v {
+									match = false
+									break
+								}
+							}
+							if match {
+								return
+							}
+						}
+					}
+				}
+				t.Errorf("stripEmptyJSONValues(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/channel/yaml_ws.go
+++ b/internal/channel/yaml_ws.go
@@ -415,6 +415,7 @@ func (ch *YAMLChannel) doHTTPCall(ctx context.Context, call HTTPCallSpec, contex
 		var resolved string
 		if isJSON {
 			resolved = substituteTemplateJSON(call.Body, contexts)
+			resolved = stripEmptyJSONValues(resolved)
 		} else {
 			resolved = substituteTemplate(call.Body, contexts)
 		}

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -116,7 +116,9 @@ func parseInlineToolCall(body string, callNum int) (ToolCall, bool) {
 			for _, pair := range strings.Split(argsStr, ", ") {
 				eq := strings.IndexByte(pair, '=')
 				if eq > 0 {
-					args[strings.TrimSpace(pair[:eq])] = strings.TrimSpace(pair[eq+1:])
+					val := strings.TrimSpace(pair[eq+1:])
+					val = stripSurroundingQuotes(val)
+					args[strings.TrimSpace(pair[:eq])] = val
 				}
 			}
 		}
@@ -154,6 +156,8 @@ func parseInlineToolCall(body string, callNum int) (ToolCall, bool) {
 }
 
 // toStringMap converts map[string]interface{} to map[string]string.
+// Zero-value non-string types (0, false, nil) are skipped because LLMs
+// often emit them as placeholders for omitted optional parameters.
 func toStringMap(m map[string]interface{}) map[string]string {
 	if m == nil {
 		return make(map[string]string)
@@ -163,11 +167,34 @@ func toStringMap(m map[string]interface{}) map[string]string {
 		switch val := v.(type) {
 		case string:
 			result[k] = val
+		case nil:
+			// skip
+		case float64:
+			if val == 0 {
+				continue
+			}
+			result[k] = fmt.Sprintf("%v", val)
+		case bool:
+			if !val {
+				continue
+			}
+			result[k] = "true"
 		default:
 			result[k] = fmt.Sprintf("%v", val)
 		}
 	}
 	return result
+}
+
+// stripSurroundingQuotes removes matching outer quotes (single or double)
+// that LLMs sometimes wrap around argument values.
+func stripSurroundingQuotes(s string) string {
+	if len(s) >= 2 {
+		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }
 
 // parseToolName splits "plugin.action" into ("plugin", "action").

--- a/internal/requestpkg/package.go
+++ b/internal/requestpkg/package.go
@@ -55,14 +55,31 @@ var (
 
 // Substitute replaces {{env.X}} and {{args.Y}} in s. Missing env vars are empty; missing args are left as literal.
 func Substitute(s string, args map[string]string) string {
+	return substitute(s, args, false)
+}
+
+// SubstituteJSON is like Substitute but JSON-escapes all substituted values
+// for safe embedding inside JSON string literals.
+func SubstituteJSON(s string, args map[string]string) string {
+	return substitute(s, args, true)
+}
+
+func substitute(s string, args map[string]string, jsonEscape bool) string {
+	escape := func(v string) string {
+		if jsonEscape {
+			b, _ := json.Marshal(v)
+			return string(b[1 : len(b)-1]) // strip surrounding quotes from json.Marshal
+		}
+		return v
+	}
 	s = envRe.ReplaceAllStringFunc(s, func(match string) string {
 		name := envRe.FindStringSubmatch(match)[1]
-		return os.Getenv(name)
+		return escape(os.Getenv(name))
 	})
 	s = argsRe.ReplaceAllStringFunc(s, func(match string) string {
 		name := argsRe.FindStringSubmatch(match)[1]
 		if v, ok := args[name]; ok {
-			return v
+			return escape(v)
 		}
 		return match
 	})
@@ -109,6 +126,27 @@ func encodeURLParams(rawURL string) string {
 	}
 	u.RawQuery = u.Query().Encode()
 	return u.String()
+}
+
+// cleanJSONBody removes top-level keys whose values are empty strings or
+// contain unresolved {{args.X}} templates from a JSON object body. This
+// prevents sending invalid optional parameters to APIs (e.g. Slack rejects
+// "thread_ts":"" as invalid_thread_ts).
+func cleanJSONBody(s string) string {
+	var obj map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		return s
+	}
+	for k, v := range obj {
+		if str, ok := v.(string); ok && (str == "" || strings.Contains(str, "{{args.")) {
+			delete(obj, k)
+		}
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return s
+	}
+	return string(out)
 }
 
 // Executor runs request packages for a single plugin. It implements orchestrator.PluginExecutor.
@@ -165,7 +203,16 @@ func (e *Executor) Execute(call orchestrator.ToolCall) orchestrator.ToolResult {
 	}
 
 	if pkg.Body != "" {
-		body := Substitute(pkg.Body, call.Args)
+		// Use JSON-escaping for JSON bodies to handle quotes/newlines in values.
+		ct := req.Header.Get("Content-Type")
+		isJSON := strings.EqualFold(ct, "application/json") || strings.Contains(ct, "json")
+		var body string
+		if isJSON {
+			body = SubstituteJSON(pkg.Body, call.Args)
+			body = cleanJSONBody(body)
+		} else {
+			body = Substitute(pkg.Body, call.Args)
+		}
 		req.Body = io.NopCloser(strings.NewReader(body))
 		req.ContentLength = int64(len(body))
 		if req.Header.Get("Content-Type") == "" {


### PR DESCRIPTION
## Summary

- **Strip empty/invalid JSON values from outbound HTTP bodies** — prevents Slack `invalid_thread_ts` errors when `thread_ts` is absent or zero (channel outbound + request package executor)
- **JSON-escape substituted values in request package bodies** — prevents Slack `invalid_json` errors when LLM-generated text contains quotes, newlines, or special characters (added `SubstituteJSON`)
- **Fix Format C tool call parser** — strip surrounding quotes from arg values so `text="hello"` is parsed as `hello`, not `"hello"` which broke JSON bodies
- **Skip zero-value non-string types in `toStringMap`** — LLMs emit `0`/`false`/`null` as placeholders for omitted optional params; these are now excluded from the args map
- **Return friendly error messages to users** — context length exceeded, rate limits, and timeouts now show human-readable messages in the channel instead of raw API error dumps. Error responses also include correct routing info (`conversation_id`, `thread_id`) so they actually reach the user

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lint passes
- [x] New test: `TestStripEmptyJSONValues` covers empty strings, non-empty values, invalid JSON, and non-string values
- [x] Manual: send a Slack DM via `post_message` tool without `thread_ts` — should succeed without `invalid_thread_ts`
- [x] Manual: send a message with quotes/newlines in text — should not return `invalid_json`
- [x] Manual: trigger context length error — user should see friendly message, not raw API error