### PR TITLE
feat: support MCP server config in inline request packages

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -207,6 +207,13 @@ func main() {
 	}
 	for _, inl := range cfg.RequestPackages.Inline {
 		set := requestpkg.Set{PluginName: inl.Plugin, Description: inl.Description}
+		if inl.MCP != nil {
+			set.MCP = &requestpkg.MCPServerConfig{
+				Server:  inl.MCP.Server,
+				URL:     inl.MCP.URL,
+				Headers: inl.MCP.Headers,
+			}
+		}
 		for _, p := range inl.Packages {
 			params := make([]requestpkg.ParamDefinition, len(p.Parameters))
 			for i, q := range p.Parameters {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,11 +103,20 @@ func (s *SkillEntry) UnmarshalYAML(n *yaml.Node) error {
 	return nil
 }
 
+// MCPServerConfigInl is the inline config shape for one MCP server.
+type MCPServerConfigInl struct {
+	Server  string            `yaml:"server"`
+	URL     string            `yaml:"url"`
+	Headers map[string]string `yaml:"headers,omitempty"`
+}
+
 // RequestSetInl is an inline request package set (plugin name + packages).
+// If MCP is set, Packages is ignored — the tools come from the MCP plugin binary.
 type RequestSetInl struct {
 	Plugin      string              `yaml:"plugin"`
 	Description string              `yaml:"description"`
 	Packages    []RequestPackageInl `yaml:"packages"`
+	MCP         *MCPServerConfigInl `yaml:"mcp,omitempty"`
 }
 
 // RequestPackageInl is the config shape for one request package.


### PR DESCRIPTION
Add MCP field to RequestSetInl so MCP servers can be configured directly in config.yaml under request_packages.inline instead of requiring a separate skill YAML file.