### PR TITLE
Trim conversation messages to fit model context window

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -81,6 +81,15 @@ func main() {
 	// LLM client that sets default model when orchestrator doesn't
 	llm := &defaultModelClient{provider: prov, model: defaultModel}
 
+	// Look up context window for the default model.
+	var contextWindow int
+	for _, m := range prov.Models() {
+		if m.ID == defaultModel {
+			contextWindow = m.ContextWindow
+			break
+		}
+	}
+
 	dataDir := cfg.State.DataDir
 	var memory orchestrator.MemoryStoreInterface
 	var sessions orchestrator.SessionStoreInterface
@@ -328,6 +337,7 @@ func main() {
 		SummarizeUpdatePrompt:   cfg.State.Session.SummarizeUpdatePrompt,
 		PipelineEnabled:         cfg.Orchestrator.Pipeline.Enabled,
 		PipelineConfig:          pipelineCfg,
+		ContextWindow:           contextWindow,
 	})
 
 	ensureSession := func(sessionKey string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -73,6 +73,7 @@ type OrchestratorOpts struct {
 	SummarizeUpdatePrompt   string                        // empty = default English
 	PipelineEnabled         bool                          // when true, create Planner from llm
 	PipelineConfig          pipeline.PipelineConfig
+	ContextWindow           int // model context window in tokens; 0 = no trimming
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -114,6 +115,7 @@ type Orchestrator struct {
 	planner                 *pipeline.Planner             // nil = pipeline disabled
 	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline
 	pipelineConfig          pipeline.PipelineConfig
+	contextWindow           int // model context window in tokens; 0 = no trimming
 }
 
 const (
@@ -202,6 +204,7 @@ func NewWithRules(
 		planner:                 planner,
 		pendingPipelines:        make(map[string]*pipeline.Pipeline),
 		pipelineConfig:          pipelineCfg,
+		contextWindow:           opts.ContextWindow,
 	}
 }
 
@@ -617,7 +620,64 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	}
 	messages = append(messages, sess.Messages...)
 
+	if o.contextWindow > 0 {
+		messages = trimToContextWindow(messages, o.contextWindow)
+	}
+
 	return messages
+}
+
+// estimateTokens returns a rough token count for a string.
+// Uses ~4 characters per token which is a reasonable average for most LLMs.
+func estimateTokens(s string) int {
+	return len(s) / 4
+}
+
+// trimToContextWindow drops the oldest conversation messages (preserving
+// system messages at the front) until the estimated token count fits within
+// the model's context window. Reserves 10% of the window for the response.
+func trimToContextWindow(messages []provider.Message, contextWindow int) []provider.Message {
+	maxInputTokens := contextWindow * 9 / 10 // reserve 10% for output
+
+	total := 0
+	for _, m := range messages {
+		total += estimateTokens(m.Content)
+	}
+	if total <= maxInputTokens {
+		return messages
+	}
+
+	// Find where conversation messages start (skip leading system messages).
+	convStart := 0
+	for convStart < len(messages) && messages[convStart].Role == provider.RoleSystem {
+		convStart++
+	}
+
+	// Drop oldest conversation messages (pairs of assistant+user typically)
+	// until we fit. Always keep at least the last conversation message.
+	for total > maxInputTokens && convStart < len(messages)-1 {
+		total -= estimateTokens(messages[convStart].Content)
+		convStart++
+	}
+
+	trimmed := make([]provider.Message, 0, len(messages)-convStart+convStart)
+	// Keep system messages.
+	for i := 0; i < len(messages); i++ {
+		if messages[i].Role == provider.RoleSystem {
+			trimmed = append(trimmed, messages[i])
+		} else {
+			break
+		}
+	}
+	// Append remaining conversation messages.
+	trimmed = append(trimmed, messages[convStart:]...)
+
+	if len(trimmed) < len(messages) {
+		log.Printf("context trimming: dropped %d old messages to fit context window (%d tokens, limit %d)",
+			len(messages)-len(trimmed), total, maxInputTokens)
+	}
+
+	return trimmed
 }
 
 func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string) string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1185,3 +1185,99 @@ func TestPreparerErrorFailOpenContinues(t *testing.T) {
 		t.Errorf("expected LLM called once when preparer errors and fail_open=true, got %d", llm.callCount)
 	}
 }
+
+// --- Context window trimming tests ---
+
+func TestEstimateTokens(t *testing.T) {
+	// 4 chars per token
+	if got := estimateTokens("abcd"); got != 1 {
+		t.Errorf("estimateTokens(4 chars) = %d, want 1", got)
+	}
+	if got := estimateTokens(strings.Repeat("x", 400)); got != 100 {
+		t.Errorf("estimateTokens(400 chars) = %d, want 100", got)
+	}
+	if got := estimateTokens(""); got != 0 {
+		t.Errorf("estimateTokens(empty) = %d, want 0", got)
+	}
+}
+
+func TestTrimToContextWindow_NoTrimNeeded(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleUser, Content: "hello"},
+		{Role: provider.RoleAssistant, Content: "hi there"},
+	}
+	// All messages are tiny, context window is huge — no trimming.
+	result := trimToContextWindow(msgs, 100000)
+	if len(result) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result))
+	}
+}
+
+func TestTrimToContextWindow_DropsOldConversation(t *testing.T) {
+	// System prompt: 40 chars = ~10 tokens
+	// Each conversation message: 400 chars = ~100 tokens
+	// Total with 5 conv messages: 10 + 500 = 510 tokens
+	// Context window: 400 tokens → max input = 360 (90%)
+	// Need to drop oldest conv messages until it fits.
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: strings.Repeat("s", 40)},
+		{Role: provider.RoleUser, Content: strings.Repeat("a", 400)},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("b", 400)},
+		{Role: provider.RoleUser, Content: strings.Repeat("c", 400)},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("d", 400)},
+		{Role: provider.RoleUser, Content: strings.Repeat("e", 400)},
+	}
+
+	result := trimToContextWindow(msgs, 400)
+
+	// System message must be preserved.
+	if result[0].Role != provider.RoleSystem {
+		t.Errorf("first message should be system, got %s", result[0].Role)
+	}
+	// Some conversation messages should have been dropped.
+	if len(result) >= len(msgs) {
+		t.Fatalf("expected fewer messages after trim, got %d (was %d)", len(result), len(msgs))
+	}
+	// Last message should be the most recent user message.
+	if result[len(result)-1].Content != strings.Repeat("e", 400) {
+		t.Error("last message should be the most recent conversation message")
+	}
+}
+
+func TestTrimToContextWindow_PreservesSystemMessages(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: strings.Repeat("s", 40)},
+		{Role: provider.RoleSystem, Content: "Previous conversation summary: stuff"},
+		{Role: provider.RoleUser, Content: strings.Repeat("a", 4000)},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("b", 4000)},
+		{Role: provider.RoleUser, Content: strings.Repeat("c", 400)},
+	}
+
+	result := trimToContextWindow(msgs, 2000)
+
+	// Both system messages should be preserved.
+	systemCount := 0
+	for _, m := range result {
+		if m.Role == provider.RoleSystem {
+			systemCount++
+		}
+	}
+	if systemCount != 2 {
+		t.Errorf("expected 2 system messages preserved, got %d", systemCount)
+	}
+}
+
+func TestTrimToContextWindow_ZeroWindow(t *testing.T) {
+	// contextWindow=0 means no trimming; but trimToContextWindow is only called
+	// when contextWindow > 0. Test that it returns messages unchanged for a
+	// very large window.
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "hi"},
+	}
+	result := trimToContextWindow(msgs, 999999)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(result))
+	}
+}


### PR DESCRIPTION
Messages were being sent to the LLM without checking the model's context_window limit, causing 400 errors when conversations grew large. Now buildMessages() estimates token count and drops oldest conversation messages (preserving system prompt and summary) to stay within 90% of the configured context window.