### PR TITLE
Overhaul logging: structured slog, trace_id, level filtering

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -250,7 +250,7 @@ func main() {
 				break
 			}
 			if !injected {
-				slog.Warn("MCP skill configs found but no 'mcp' plugin entry in config")
+				slog.Warn("MCP skill configs found but no 'mcp' plugin entry in config", "component", "mcp")
 			}
 		}
 	}

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -2,7 +2,7 @@ package channel
 
 import (
 	"context"
-	"os"
+	"log/slog"
 	"strings"
 
 	"github.com/opentalon/opentalon/internal/actor"
@@ -41,7 +41,7 @@ func NewMessageHandler(
 		if outContent == "" {
 			outContent = "(No response)"
 		}
-		if msg.ChannelID == "console" && inputForDisplay != "" && os.Getenv("LOG_LEVEL") == "debug" {
+		if msg.ChannelID == "console" && inputForDisplay != "" && slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 			outContent = "Input to LLM:\n" + inputForDisplay + "\n\n---\n\nResponse:\n" + response
 		}
 		return pkg.OutboundMessage{

--- a/internal/channel/yaml_webhook.go
+++ b/internal/channel/yaml_webhook.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"os"
 )
 
 // startWebhookInbound registers the HTTP webhook handler and starts the
@@ -58,9 +57,7 @@ func (ch *YAMLChannel) buildWebhookHandler(wh *WebhookInboundSpec) http.HandlerF
 			return
 		}
 
-		if os.Getenv("LOG_LEVEL") == "debug" {
-			slog.Debug("yaml-channel webhook received", "channel", ch.spec.ID, "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr, "body", string(body))
-		}
+		slog.Debug("yaml-channel webhook received", "channel", ch.spec.ID, "method", r.Method, "path", r.URL.Path, "remote", r.RemoteAddr, "body", string(body))
 
 		// Respond immediately (Teams requires fast ack)
 		w.WriteHeader(responseCode)

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -75,7 +75,7 @@ func (m *Manager) LoadAll(ctx context.Context, entries []PluginEntry) error {
 	var errs []string
 	for _, e := range entries {
 		if !e.Enabled {
-			slog.Info("plugin-manager: plugin disabled, skipping", "plugin", e.Name)
+			slog.Info("plugin disabled, skipping", "component", "plugin-manager", "plugin", e.Name)
 			continue
 		}
 		if err := m.Load(ctx, e); err != nil {
@@ -134,7 +134,7 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 		client:  client,
 	}
 
-	slog.Info("plugin-manager: loaded plugin", "plugin", entry.Name, "mode", mode, "actions", len(cap.Actions))
+	slog.Info("loaded plugin", "component", "plugin-manager", "plugin", entry.Name, "mode", mode, "actions", len(cap.Actions))
 	return nil
 }
 
@@ -174,7 +174,7 @@ func configJSON(entry PluginEntry) string {
 	}
 	b, err := json.Marshal(entry.Config)
 	if err != nil {
-		slog.Warn("plugin-manager: failed to marshal config", "plugin", entry.Name, "error", err)
+		slog.Warn("failed to marshal config", "component", "plugin-manager", "plugin", entry.Name, "error", err)
 		return ""
 	}
 	return string(b)
@@ -193,7 +193,7 @@ func (m *Manager) Reload(ctx context.Context, name string) error {
 	m.mu.Unlock()
 
 	if err := m.Unload(name); err != nil {
-		slog.Warn("plugin-manager: reload unload failed", "plugin", name, "error", err)
+		slog.Warn("reload unload failed", "component", "plugin-manager", "plugin", name, "error", err)
 	}
 	return m.Load(ctx, entry)
 }
@@ -231,7 +231,7 @@ func (m *Manager) StopAll() {
 
 	for _, name := range names {
 		if err := m.Unload(name); err != nil {
-			slog.Warn("plugin-manager: unload failed", "plugin", name, "error", err)
+			slog.Warn("unload failed", "component", "plugin-manager", "plugin", name, "error", err)
 		}
 	}
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -120,18 +120,18 @@ func (s *Scheduler) Start(staticJobs []Job) error {
 	for i := range staticJobs {
 		staticJobs[i].Source = "config"
 		if err := s.addJobLocked(staticJobs[i]); err != nil {
-			slog.Warn("scheduler: skipping static job", "job", staticJobs[i].Name, "error", err)
+			slog.Warn("skipping static job", "component", "scheduler", "job", staticJobs[i].Name, "error", err)
 		}
 	}
 
 	dynamicJobs, err := s.loadDynamic()
 	if err != nil {
-		slog.Error("scheduler: loading dynamic jobs", "error", err)
+		slog.Warn("loading dynamic jobs failed", "component", "scheduler", "error", err)
 	}
 	for _, j := range dynamicJobs {
 		j.Source = "dynamic"
 		if err := s.addJobLocked(j); err != nil {
-			slog.Warn("scheduler: skipping dynamic job", "job", j.Name, "error", err)
+			slog.Warn("skipping dynamic job", "component", "scheduler", "job", j.Name, "error", err)
 		}
 	}
 
@@ -337,7 +337,7 @@ func (s *Scheduler) runJob(ctx context.Context, rj *runningJob) {
 	job := s.snapshotJob(rj)
 	dur, err := job.parseDuration()
 	if err != nil {
-		slog.Error("scheduler: job invalid interval", "job", job.Name, "error", err)
+		slog.Warn("job invalid interval", "component", "scheduler", "job", job.Name, "error", err)
 		return
 	}
 
@@ -359,20 +359,20 @@ func (s *Scheduler) executeJob(rj *runningJob) {
 
 	plugin, action, err := job.parseAction()
 	if err != nil {
-		slog.Error("scheduler: job bad action", "job", job.Name, "error", err)
+		slog.Warn("job bad action", "component", "scheduler", "job", job.Name, "error", err)
 		return
 	}
 
 	result, err := s.runner.RunAction(s.ctx, plugin, action, job.Args)
 	if err != nil {
-		slog.Error("scheduler: job execution error", "job", job.Name, "error", err)
+		slog.Warn("job execution failed", "component", "scheduler", "job", job.Name, "error", err)
 		return
 	}
 
 	if job.NotifyChannel != "" && s.notifier != nil {
 		msg := fmt.Sprintf("[scheduled: %s] %s", job.Name, result)
 		if err := s.notifier.Notify(s.ctx, job.NotifyChannel, msg); err != nil {
-			slog.Error("scheduler: job notify error", "job", job.Name, "error", err)
+			slog.Warn("job notify failed", "component", "scheduler", "job", job.Name, "error", err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Replace file-based session logging** (`internal/sessionlog/`) with structured `log/slog` logger (`internal/logger/`) — all output to stderr with key-value pairs, deterministic `trace_id` per session, and configurable `LOG_LEVEL`
- **Clean up logging hygiene**: remove redundant `os.Getenv("LOG_LEVEL")` guards that bypass slog level filtering, downgrade scheduler operational errors from `Error` to `Warn`, add structured attributes to bare log calls, and replace message prefixes with `component` key-value pairs
- **Net deletion: ~200 lines** — removes file management, cleanup goroutines, and filename sanitization that don't belong in a containerized deployment

## Changes

- Add `internal/logger/` package with `Setup()`, `WithTraceID`/`FromContext` context propagation, and `slogWriter` bridge for legacy `log.Printf`
- Delete `internal/sessionlog/` (logger + tests)
- Update all call sites across orchestrator, channels, plugins, scheduler, and pipeline to use `slog` with structured fields
- Simplify `LogConfig` — remove `log.file`/`log.dir`, add `log.level`

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New logger tests cover trace ID handling, context propagation, level filtering, and slogWriter output (112 lines)
- [x] `go build ./...` clean
- [x] Lint passes