### PR TITLE
fix: clear error when plugin lacks Init RPC

### DIFF
--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -44,8 +44,15 @@ The gRPC service defined in `proto/plugin.proto`:
 
 ```protobuf
 service PluginService {
+    // Init delivers host configuration to the plugin before any other calls.
+    // Required — plugins that do not implement Init will fail to load.
+    rpc Init(PluginInitRequest) returns (google.protobuf.Empty);
     rpc Execute(ToolCallRequest) returns (ToolResultResponse);
     rpc Capabilities(google.protobuf.Empty) returns (PluginCapabilities);
+}
+
+message PluginInitRequest {
+    string config_json = 1; // JSON-encoded config block from the host's config.yaml
 }
 
 message ToolCallRequest {
@@ -71,6 +78,7 @@ message Action {
     string name = 1;
     string description = 2;
     repeated Parameter parameters = 3;
+    bool user_only = 4;
 }
 
 message Parameter {
@@ -82,6 +90,18 @@ message Parameter {
 ```
 
 There is no method to list other plugins, query the registry, access peer state, or call the orchestrator. The surface is deliberately minimal.
+
+### Init and the Configurable interface
+
+The `Init` RPC is called once before `Capabilities` and passes the plugin's config block as JSON. On the Go SDK side, plugins receive this automatically — implement the `Configurable` interface on your `Handler` to process the config:
+
+```go
+type Configurable interface {
+    Configure(configJSON string) error
+}
+```
+
+If your handler implements `Configurable`, the SDK calls `Configure` during `Init`. If not, `Init` succeeds as a no-op. All plugins must be built against a SDK version that includes `Init` — the core will reject plugins that do not implement it.
 
 ### Plugin capabilities
 
@@ -463,13 +483,12 @@ The `PluginStateStore` enforces isolation at the API level:
 
 #### 5. Strict gRPC contract
 
-The plugin gRPC interface exposes exactly one method: `Execute`. There is no method to:
+The plugin gRPC interface exposes three methods: `Init`, `Execute`, and `Capabilities`. There is no method to:
 
 - List other plugins
 - Query the registry
 - Access peer state
 - Call the orchestrator
-- Discover capabilities
 
 ### Guard flow
 

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -9,7 +9,9 @@ import (
 	pkg "github.com/opentalon/opentalon/pkg/plugin"
 	"github.com/opentalon/opentalon/proto/pluginpb"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -63,6 +65,9 @@ func DialFromHandshake(hs pkg.Handshake, timeout time.Duration, configJSON strin
 
 func (c *Client) fetchCapabilities(ctx context.Context, configJSON string) error {
 	if _, err := c.client.Init(ctx, &pluginpb.PluginInitRequest{ConfigJson: configJSON}); err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return fmt.Errorf("init plugin: plugin does not implement Init — update the plugin to the latest SDK (go get github.com/opentalon/opentalon@latest)")
+		}
 		return fmt.Errorf("init plugin: %w", err)
 	}
 	resp, err := c.client.Capabilities(ctx, &emptypb.Empty{})

--- a/internal/plugin/client_test.go
+++ b/internal/plugin/client_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -163,6 +164,57 @@ func TestClientMultipleCalls(t *testing.T) {
 		if result.Content != "echo: ping" {
 			t.Fatalf("call %d: content = %q", i, result.Content)
 		}
+	}
+}
+
+// legacyPluginService does NOT implement Init — simulates plugins built
+// against an older SDK (before Init was added).
+type legacyPluginService struct {
+	pluginpb.UnimplementedPluginServiceServer
+}
+
+func (s *legacyPluginService) Capabilities(_ context.Context, _ *emptypb.Empty) (*pluginpb.PluginCapabilities, error) {
+	return &pluginpb.PluginCapabilities{
+		Name:        "legacy",
+		Description: "Plugin without Init",
+		Actions: []*pluginpb.Action{
+			{Name: "ping", Description: "Ping"},
+		},
+	}, nil
+}
+
+func (s *legacyPluginService) Execute(_ context.Context, req *pluginpb.ToolCallRequest) (*pluginpb.ToolResultResponse, error) {
+	return &pluginpb.ToolResultResponse{CallId: req.Id, Content: "pong"}, nil
+}
+
+func TestClientRejectsPluginWithoutInit(t *testing.T) {
+	lis := bufconn.Listen(bufSize)
+	srv := grpc.NewServer()
+	pluginpb.RegisterPluginServiceServer(srv, &legacyPluginService{})
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(func() { srv.Stop() })
+
+	cc, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(_ context.Context, _ string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cc.Close() })
+
+	c := &Client{conn: cc, client: pluginpb.NewPluginServiceClient(cc)}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = c.fetchCapabilities(ctx, "")
+	if err == nil {
+		t.Fatal("expected error for plugin without Init")
+	}
+	if got := err.Error(); !strings.Contains(got, "does not implement Init") {
+		t.Errorf("error = %q, want message about missing Init", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a clear error message when a plugin doesn't implement the `Init` RPC (introduced in #41), telling the developer to update to the latest SDK
- Updates `docs/design/plugins.md` with the `Init` contract, `PluginInitRequest`, `Configurable` interface, `user_only` action field, and corrected gRPC method list

## Test plan
- [x] `TestClientRejectsPluginWithoutInit` — verifies that a plugin without `Init` is rejected with a message containing "does not implement Init"
- [x] All existing plugin tests pass
- [x] Lint + build pass