### PR TITLE
fix: send valid JSON to plugins with empty config

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -98,6 +98,19 @@ plugins:
     # ref: "master"
     config: {}
 
+  # MCP bridge: connects to MCP-compatible tool servers.
+  # Config block is passed to the plugin via the Init RPC.
+  # mcp:
+  #   enabled: true
+  #   github: "opentalon/mcp-plugin"
+  #   ref: "master"
+  #   config:
+  #     servers:
+  #       - name: my-mcp-server
+  #         url: "https://mcp.example.com/sse"
+  #         headers:
+  #           Authorization: "Bearer {{env.MCP_TOKEN}}"
+
 # Request packages: skill-style API calls (no compiled plugin). Core runs HTTP requests from templates.
 # Use {{env.VAR}} and {{args.param}} in url/body/headers. Guardrails: required_env validated before request.
 # To reuse OpenClaw/ClawHub skills you can:

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -166,16 +166,16 @@ func (m *Manager) connectRemote(entry PluginEntry) (*Client, error) {
 	return client, nil
 }
 
-// configJSON serializes the plugin's Config map to JSON, returning empty string
+// configJSON serializes the plugin's Config map to JSON, returning "{}"
 // when there is no config or serialization fails.
 func configJSON(entry PluginEntry) string {
 	if len(entry.Config) == 0 {
-		return ""
+		return "{}"
 	}
 	b, err := json.Marshal(entry.Config)
 	if err != nil {
 		slog.Warn("failed to marshal config", "component", "plugin-manager", "plugin", entry.Name, "error", err)
-		return ""
+		return "{}"
 	}
 	return string(b)
 }

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -1,0 +1,45 @@
+package plugin
+
+import "testing"
+
+func TestConfigJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry PluginEntry
+		want  string
+	}{
+		{
+			name:  "nil config returns empty JSON object",
+			entry: PluginEntry{Name: "test"},
+			want:  "{}",
+		},
+		{
+			name:  "empty config map returns empty JSON object",
+			entry: PluginEntry{Name: "test", Config: map[string]interface{}{}},
+			want:  "{}",
+		},
+		{
+			name: "config with values returns JSON",
+			entry: PluginEntry{
+				Name: "mcp",
+				Config: map[string]interface{}{
+					"servers": []interface{}{
+						map[string]interface{}{
+							"name": "myserver",
+							"url":  "https://example.com/mcp",
+						},
+					},
+				},
+			},
+			want: `{"servers":[{"name":"myserver","url":"https://example.com/mcp"}]}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := configJSON(tt.entry)
+			if got != tt.want {
+				t.Errorf("configJSON() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `configJSON()` returned `""` for plugins with no/empty `config:` block, causing plugins implementing `Configurable` (via Init RPC) to fail with `unexpected end of JSON input`
- Now returns `"{}"` (valid empty JSON object) so plugin `Configure` receives parseable input
- Adds `TestConfigJSON` covering nil config, empty map, and populated config
- Adds commented MCP plugin example to `config.example.yaml` showing `config.servers` structure

## Context
Discovered while deploying mcp-plugin with `config: {}` — the plugin's `Configure` tried to `json.Unmarshal("")` and failed. Related to #50 (Init RPC support).

## Test plan
- [x] `TestConfigJSON` — nil, empty, and populated config cases
- [x] All existing tests pass
- [x] Lint + build pass