### PR TITLE
feat: YAML-driven inbound media handling for non-text messages

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -69,15 +69,43 @@ channels:
     # ref: "master"
     config: {}
 
-  # YAML-driven channel (no compiled binary — runs in-process from channel.yaml spec)
+  # YAML-driven channels (no compiled binary — run in-process from channel.yaml spec)
   # slack:
   #   enabled: true
-  #   plugin: "./channels/slack/channel.yaml"   # .yaml → YAML runtime (in-process)
-  #   github: "opentalon/slack-channel"          # auto-fetches channel.yaml + tools.yaml
-  #   ref: "master"
+  #   plugin: "./channels/slack-channel/channel.yaml"
   #   config:
   #     ack_reaction: eyes
   #     done_reaction: white_check_mark
+
+  # telegram:
+  #   enabled: true
+  #   plugin: "./channels/telegram-channel/channel.yaml"
+  #   config: {}
+
+  # --- Inbound media handling ---
+  #
+  # YAML channels support non-text messages (photos, voice, stickers, documents, etc.)
+  # via an `inbound.media` section in the channel's channel.yaml file.
+  #
+  # Each rule has three fields:
+  #   when:        event field whose presence triggers this rule (e.g. "photo", "voice")
+  #   description: text injected as message content — LLM sees this and responds naturally
+  #   resolve:     (optional) HTTP steps to download binary for LLM-supported types (images, PDFs)
+  #
+  # For LLM-supported types (images, PDFs): resolve downloads binary, attaches it as a file,
+  # and the LLM processes it natively via vision/document understanding.
+  # For unsupported types (voice, video, stickers): no resolve — the description tells the LLM
+  # what was sent, and it responds naturally. No hardcoded error messages.
+  #
+  # resolve steps run sequentially:
+  #   - Intermediate steps (with `store:`) parse JSON response and store fields
+  #   - The final step (without `store:`) captures raw binary
+  #   - Templates: {{event.*}}, {{env.*}}, {{resolve.*}}, {{self.*}}
+  #
+  # Content mapping supports fallback: `content: { field: "text", fallback: "caption" }`
+  #
+  # Working examples: channels/telegram-channel/channel.yaml, channels/slack-channel/channel.yaml
+  # NOTE: Outbound media (sending images/documents back) is planned for the next release.
 
 plugins:
   # Slash commands: /install skill, /show config, /commands, /set prompt, /clear

--- a/internal/channel/yaml_media_test.go
+++ b/internal/channel/yaml_media_test.go
@@ -1,0 +1,458 @@
+package channel
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pkg "github.com/opentalon/opentalon/pkg/channel"
+)
+
+// --- getStringField array indexing ---
+
+func TestGetStringField_ArrayFirstElement(t *testing.T) {
+	m := map[string]interface{}{
+		"items": []interface{}{
+			map[string]interface{}{"id": "first"},
+			map[string]interface{}{"id": "second"},
+		},
+	}
+	if got := getStringField(m, "items.0.id"); got != "first" {
+		t.Errorf("got %q, want %q", got, "first")
+	}
+}
+
+func TestGetStringField_ArrayLastElement(t *testing.T) {
+	m := map[string]interface{}{
+		"photo": []interface{}{
+			map[string]interface{}{"file_id": "small", "width": float64(90)},
+			map[string]interface{}{"file_id": "medium", "width": float64(320)},
+			map[string]interface{}{"file_id": "large", "width": float64(800)},
+		},
+	}
+	if got := getStringField(m, "photo.-1.file_id"); got != "large" {
+		t.Errorf("got %q, want %q", got, "large")
+	}
+}
+
+func TestGetStringField_ArrayNegativeIndex(t *testing.T) {
+	m := map[string]interface{}{
+		"arr": []interface{}{
+			map[string]interface{}{"v": "a"},
+			map[string]interface{}{"v": "b"},
+			map[string]interface{}{"v": "c"},
+		},
+	}
+	if got := getStringField(m, "arr.-2.v"); got != "b" {
+		t.Errorf("got %q, want %q", got, "b")
+	}
+}
+
+func TestGetStringField_ArrayOutOfBounds(t *testing.T) {
+	m := map[string]interface{}{
+		"arr": []interface{}{"a", "b"},
+	}
+	if got := getStringField(m, "arr.5"); got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestGetStringField_ArrayScalarElement(t *testing.T) {
+	m := map[string]interface{}{
+		"tags": []interface{}{"go", "yaml", "test"},
+	}
+	if got := getStringField(m, "tags.1"); got != "yaml" {
+		t.Errorf("got %q, want %q", got, "yaml")
+	}
+}
+
+func TestGetStringField_NestedArrayPath(t *testing.T) {
+	// Simulates Telegram photo message: message.photo.-1.file_id
+	m := map[string]interface{}{
+		"message": map[string]interface{}{
+			"photo": []interface{}{
+				map[string]interface{}{"file_id": "ABC123", "width": float64(90)},
+				map[string]interface{}{"file_id": "DEF456", "width": float64(800)},
+			},
+		},
+	}
+	if got := getStringField(m, "message.photo.-1.file_id"); got != "DEF456" {
+		t.Errorf("got %q, want %q", got, "DEF456")
+	}
+}
+
+// --- navigateToValue ---
+
+func TestNavigateToValue_TopLevelField(t *testing.T) {
+	m := map[string]interface{}{"text": "hello"}
+	if _, ok := navigateToValue(m, "text"); !ok {
+		t.Error("expected text to exist")
+	}
+}
+
+func TestNavigateToValue_MissingField(t *testing.T) {
+	m := map[string]interface{}{"text": "hello"}
+	if _, ok := navigateToValue(m, "photo"); ok {
+		t.Error("expected photo to not exist")
+	}
+}
+
+func TestNavigateToValue_Array(t *testing.T) {
+	m := map[string]interface{}{
+		"photo": []interface{}{
+			map[string]interface{}{"file_id": "abc"},
+		},
+	}
+	val, ok := navigateToValue(m, "photo")
+	if !ok {
+		t.Fatal("expected photo to exist")
+	}
+	if _, isArr := val.([]interface{}); !isArr {
+		t.Error("expected photo to be an array")
+	}
+}
+
+func TestNavigateToValue_NestedObject(t *testing.T) {
+	m := map[string]interface{}{
+		"sticker": map[string]interface{}{
+			"emoji": "😂",
+		},
+	}
+	if _, ok := navigateToValue(m, "sticker"); !ok {
+		t.Error("expected sticker to exist")
+	}
+}
+
+func TestNavigateToValue_NilValue(t *testing.T) {
+	m := map[string]interface{}{"key": nil}
+	if _, ok := navigateToValue(m, "key"); ok {
+		t.Error("expected nil value to return false")
+	}
+}
+
+// --- enrichEventCtx ---
+
+func TestEnrichEventCtx_ResolvesNestedPaths(t *testing.T) {
+	event := map[string]interface{}{
+		"photo": []interface{}{
+			map[string]interface{}{"file_id": "small123"},
+			map[string]interface{}{"file_id": "large456"},
+		},
+		"voice": map[string]interface{}{
+			"duration":  float64(5),
+			"mime_type": "audio/ogg",
+		},
+	}
+	eventCtx := flattenToStringMap(event)
+
+	rule := MediaRule{
+		Description: "[Photo: {{event.photo.-1.file_id}}, voice: {{event.voice.duration}}s]",
+	}
+
+	enrichEventCtx(event, eventCtx, rule)
+
+	if got := eventCtx["photo.-1.file_id"]; got != "large456" {
+		t.Errorf("photo.-1.file_id = %q, want %q", got, "large456")
+	}
+	if got := eventCtx["voice.duration"]; got != "5" {
+		t.Errorf("voice.duration = %q, want %q", got, "5")
+	}
+}
+
+func TestEnrichEventCtx_ResolvesFromResolveSteps(t *testing.T) {
+	event := map[string]interface{}{
+		"document": map[string]interface{}{
+			"file_id":   "doc123",
+			"file_name": "report.pdf",
+			"mime_type": "application/pdf",
+		},
+	}
+	eventCtx := flattenToStringMap(event)
+
+	rule := MediaRule{
+		Description: "[Document: {{event.document.file_name}}]",
+		Resolve: &MediaResolveSpec{
+			MimeType: "{{event.document.mime_type}}",
+			Name:     "{{event.document.file_name}}",
+			Steps: []MediaResolveStep{
+				{
+					URL: "https://example.com/getFile?file_id={{event.document.file_id}}",
+				},
+			},
+		},
+	}
+
+	enrichEventCtx(event, eventCtx, rule)
+
+	if got := eventCtx["document.file_id"]; got != "doc123" {
+		t.Errorf("document.file_id = %q, want %q", got, "doc123")
+	}
+	if got := eventCtx["document.file_name"]; got != "report.pdf" {
+		t.Errorf("document.file_name = %q, want %q", got, "report.pdf")
+	}
+	if got := eventCtx["document.mime_type"]; got != "application/pdf" {
+		t.Errorf("document.mime_type = %q, want %q", got, "application/pdf")
+	}
+}
+
+// --- resolveMedia ---
+
+func TestResolveMedia_DescriptionOnlyRule(t *testing.T) {
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{
+						When:        "voice",
+						Description: "[Voice message, {{event.voice.duration}}s. Type your message instead.]",
+					},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+	}
+
+	event := map[string]interface{}{
+		"voice": map[string]interface{}{
+			"duration":  float64(5),
+			"mime_type": "audio/ogg",
+		},
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: ""}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if msg.Content != "[Voice message, 5s. Type your message instead.]" {
+		t.Errorf("content = %q", msg.Content)
+	}
+	if len(msg.Files) != 0 {
+		t.Errorf("expected no files, got %d", len(msg.Files))
+	}
+}
+
+func TestResolveMedia_DoesNotOverrideExistingContent(t *testing.T) {
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{
+						When:        "photo",
+						Description: "[Photo]",
+					},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+	}
+
+	event := map[string]interface{}{
+		"photo": []interface{}{map[string]interface{}{"file_id": "abc"}},
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: "look at this!"}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if msg.Content != "look at this!" {
+		t.Errorf("content should not be overridden, got %q", msg.Content)
+	}
+}
+
+func TestResolveMedia_NoMatchingRule(t *testing.T) {
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{When: "photo", Description: "[Photo]"},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+	}
+
+	event := map[string]interface{}{
+		"text": "hello",
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: "hello"}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if msg.Content != "hello" {
+		t.Errorf("content should not change, got %q", msg.Content)
+	}
+}
+
+func TestResolveMedia_FirstMatchWins(t *testing.T) {
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{When: "sticker", Description: "[Sticker]"},
+					{When: "photo", Description: "[Photo]"},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+	}
+
+	// Event has both sticker and photo (unlikely but tests ordering)
+	event := map[string]interface{}{
+		"sticker": map[string]interface{}{"emoji": "😂"},
+		"photo":   []interface{}{map[string]interface{}{"file_id": "abc"}},
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: ""}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if msg.Content != "[Sticker]" {
+		t.Errorf("first rule should win, got %q", msg.Content)
+	}
+}
+
+func TestResolveMedia_WithResolveSteps(t *testing.T) {
+	// Mock Telegram API: getFile returns file_path, then serve binary
+	fileData := []byte{0x89, 0x50, 0x4E, 0x47} // fake PNG header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/botTOKEN/getFile":
+			resp := map[string]interface{}{
+				"ok": true,
+				"result": map[string]interface{}{
+					"file_path": "photos/test.jpg",
+				},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		case "/file/botTOKEN/photos/test.jpg":
+			_, _ = w.Write(fileData)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{
+						When:        "photo",
+						Description: "[Photo]",
+						Resolve: &MediaResolveSpec{
+							MimeType: "image/jpeg",
+							Name:     "photo.jpg",
+							Steps: []MediaResolveStep{
+								{
+									Method: "GET",
+									URL:    server.URL + "/botTOKEN/getFile?file_id={{event.photo.-1.file_id}}",
+									Store:  map[string]string{"file_path": "result.file_path"},
+								},
+								{
+									Method: "GET",
+									URL:    server.URL + "/file/botTOKEN/{{resolve.file_path}}",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+		client:   &http.Client{},
+		ctx:      ctx,
+	}
+
+	event := map[string]interface{}{
+		"photo": []interface{}{
+			map[string]interface{}{"file_id": "small123", "width": float64(90)},
+			map[string]interface{}{"file_id": "large456", "width": float64(800)},
+		},
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: ""}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if len(msg.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(msg.Files))
+	}
+	if msg.Files[0].MimeType != "image/jpeg" {
+		t.Errorf("mime = %q, want image/jpeg", msg.Files[0].MimeType)
+	}
+	if msg.Files[0].Name != "photo.jpg" {
+		t.Errorf("name = %q, want photo.jpg", msg.Files[0].Name)
+	}
+	if string(msg.Files[0].Data) != string(fileData) {
+		t.Errorf("data mismatch")
+	}
+	// Content should be the description since original was empty
+	if msg.Content != "[Photo]" {
+		t.Errorf("content = %q, want [Photo]", msg.Content)
+	}
+}
+
+func TestResolveMedia_ResolveFallsBackToDescription(t *testing.T) {
+	// Server returns 500 for getFile — resolve should fail gracefully
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			Inbound: InboundSpec{
+				Media: []MediaRule{
+					{
+						When:        "photo",
+						Description: "[Photo failed to load]",
+						Resolve: &MediaResolveSpec{
+							MimeType: "image/jpeg",
+							Name:     "photo.jpg",
+							Steps: []MediaResolveStep{
+								{
+									Method: "GET",
+									URL:    server.URL + "/getFile",
+									Store:  map[string]string{"file_path": "result.file_path"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		selfVars: make(map[string]string),
+		config:   make(map[string]string),
+		client:   &http.Client{},
+		ctx:      ctx,
+	}
+
+	event := map[string]interface{}{
+		"photo": []interface{}{map[string]interface{}{"file_id": "abc"}},
+	}
+	eventCtx := flattenToStringMap(event)
+	msg := pkg.InboundMessage{Content: ""}
+
+	ch.resolveMedia(event, eventCtx, &msg)
+
+	if len(msg.Files) != 0 {
+		t.Errorf("expected no files on resolve failure, got %d", len(msg.Files))
+	}
+	if msg.Content != "[Photo failed to load]" {
+		t.Errorf("content = %q, want fallback description", msg.Content)
+	}
+}

--- a/internal/channel/yaml_spec.go
+++ b/internal/channel/yaml_spec.go
@@ -68,8 +68,45 @@ type InboundSpec struct {
 	ProcessWhen       []ProcessRule       `yaml:"process_when"`
 	Skip              []SkipRule          `yaml:"skip"`
 	Mapping           MappingSpec         `yaml:"mapping"`
+	Media             []MediaRule         `yaml:"media"` // detect non-text messages, resolve files or inject descriptions
 	Transforms        []Transform         `yaml:"transforms"`
 	Dedup             DedupSpec           `yaml:"dedup"`
+}
+
+// MediaRule describes how to handle a non-text message type (e.g. photo, voice, sticker).
+// Rules are evaluated in order; the first matching rule wins.
+type MediaRule struct {
+	// When is the event field whose presence triggers this rule (e.g. "photo", "voice", "sticker").
+	When string `yaml:"when"`
+	// Description is a template injected as message content when the original text is empty.
+	// The LLM sees this and responds naturally. Supports {{event.*}} templates.
+	Description string `yaml:"description"`
+	// Resolve optionally downloads binary data (images, documents) to attach as a file.
+	// When absent, only the description text is injected (for unsupported types like voice/video).
+	Resolve *MediaResolveSpec `yaml:"resolve"`
+}
+
+// MediaResolveSpec describes how to download a media file via HTTP.
+type MediaResolveSpec struct {
+	// MimeType of the resolved file. Static (e.g. "image/jpeg") or template (e.g. "{{event.document.mime_type}}").
+	MimeType string `yaml:"mime_type"`
+	// Name of the resolved file. Optional template (e.g. "{{event.document.file_name}}").
+	Name string `yaml:"name"`
+	// Steps are sequential HTTP calls to resolve a file reference to binary data.
+	// Intermediate steps (with Store) parse JSON and store fields in a "resolve" template context.
+	// The final step (without Store) captures the raw response body as binary.
+	Steps []MediaResolveStep `yaml:"steps"`
+}
+
+// MediaResolveStep is one HTTP call in a media resolution chain.
+type MediaResolveStep struct {
+	Method  string            `yaml:"method"`
+	URL     string            `yaml:"url"`
+	Headers map[string]string `yaml:"headers"`
+	// Store maps self-var names to JSON response fields (like init step Store).
+	// When present, the response is parsed as JSON. When absent, the response
+	// body is treated as raw binary (this should be the final step).
+	Store map[string]string `yaml:"store"`
 }
 
 // ProcessRule defines when to process an event (allowlist). If any

--- a/internal/channel/yaml_ws.go
+++ b/internal/channel/yaml_ws.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -218,6 +219,11 @@ func (ch *YAMLChannel) processInboundFrame(frame map[string]interface{}) {
 	// Extract fields via mapping
 	eventCtx := flattenToStringMap(event)
 	msg := ch.extractMessage(event, eventCtx)
+
+	// Resolve media: detect non-text messages, download files or inject descriptions
+	if len(ch.spec.Inbound.Media) > 0 {
+		ch.resolveMedia(event, eventCtx, &msg)
+	}
 
 	// Apply transforms
 	msg.Content = ch.applyTransforms(msg.Content, eventCtx)
@@ -592,8 +598,179 @@ func getStringField(m map[string]interface{}, key string) string {
 		if nested, ok := m[parts[0]].(map[string]interface{}); ok {
 			return getStringField(nested, parts[1])
 		}
+		// Array indexing: "photo.-1.file_id" or "photo.0.width"
+		if arr, ok := m[parts[0]].([]interface{}); ok {
+			subParts := strings.SplitN(parts[1], ".", 2)
+			idx, err := strconv.Atoi(subParts[0])
+			if err == nil {
+				if idx < 0 {
+					idx = len(arr) + idx
+				}
+				if idx >= 0 && idx < len(arr) {
+					if len(subParts) == 2 {
+						if nested, ok := arr[idx].(map[string]interface{}); ok {
+							return getStringField(nested, subParts[1])
+						}
+					}
+					return fmt.Sprintf("%v", arr[idx])
+				}
+			}
+		}
 	}
 	return ""
+}
+
+// navigateToValue checks whether a dotted path leads to any non-nil value
+// (including objects and arrays that getStringField would return "" for).
+func navigateToValue(m map[string]interface{}, path string) (interface{}, bool) {
+	if val, ok := m[path]; ok && val != nil {
+		return val, true
+	}
+	parts := strings.SplitN(path, ".", 2)
+	if len(parts) == 2 {
+		if nested, ok := m[parts[0]].(map[string]interface{}); ok {
+			return navigateToValue(nested, parts[1])
+		}
+		// Check arrays too (e.g. "photo" is []interface{})
+		if arr, ok := m[parts[0]].([]interface{}); ok && len(arr) > 0 {
+			return arr, true
+		}
+	}
+	return nil, false
+}
+
+// resolveMedia processes media rules for an inbound event. It detects non-text
+// message types, downloads binary data (if configured), and injects a text
+// description so the LLM can respond naturally to unsupported media types.
+// The first matching rule wins.
+func (ch *YAMLChannel) resolveMedia(event map[string]interface{}, eventCtx map[string]string, msg *pkg.InboundMessage) {
+	for _, rule := range ch.spec.Inbound.Media {
+		if _, exists := navigateToValue(event, rule.When); !exists {
+			continue
+		}
+		// Pre-resolve {{event.X.Y.Z}} template references against the raw event,
+		// because flattenToStringMap only captures top-level keys.
+		enrichEventCtx(event, eventCtx, rule)
+
+		contexts := ch.buildContexts()
+		contexts["event"] = eventCtx
+
+		if rule.Resolve != nil {
+			file, err := ch.resolveFile(rule.Resolve, contexts, event, eventCtx)
+			if err != nil {
+				slog.Warn("yaml-channel media resolve failed, falling back to description",
+					"channel", ch.spec.ID, "when", rule.When, "error", err)
+			} else if file != nil {
+				msg.Files = append(msg.Files, *file)
+			}
+		}
+		// Inject description as content if text is still empty
+		if msg.Content == "" && rule.Description != "" {
+			msg.Content = substituteTemplate(rule.Description, contexts)
+		}
+		return
+	}
+}
+
+// enrichEventCtx pre-resolves nested event paths referenced in a media rule's
+// templates so that {{event.photo.-1.file_id}} works in the template engine
+// (which only does flat map lookups). It scans all template strings in the rule
+// for {{event.X}} references and resolves them via getStringField on the raw event.
+func enrichEventCtx(event map[string]interface{}, eventCtx map[string]string, rule MediaRule) {
+	// Collect all template strings from the rule
+	templates := []string{rule.Description}
+	if rule.Resolve != nil {
+		templates = append(templates, rule.Resolve.MimeType, rule.Resolve.Name)
+		for _, step := range rule.Resolve.Steps {
+			templates = append(templates, step.URL)
+			for _, v := range step.Headers {
+				templates = append(templates, v)
+			}
+		}
+	}
+	for _, tmpl := range templates {
+		for _, match := range contextRe.FindAllStringSubmatch(tmpl, -1) {
+			if len(match) == 3 && match[1] == "event" {
+				key := match[2]
+				if _, exists := eventCtx[key]; !exists {
+					if val := getStringField(event, key); val != "" {
+						eventCtx[key] = val
+					}
+				}
+			}
+		}
+	}
+}
+
+// resolveFile executes the resolve steps to download binary media data.
+// Intermediate steps (with Store) parse JSON responses; the final step (without
+// Store) captures the raw body. Returns nil if no binary data was obtained.
+func (ch *YAMLChannel) resolveFile(spec *MediaResolveSpec, contexts map[string]map[string]string, event map[string]interface{}, eventCtx map[string]string) (*pkg.FileAttachment, error) {
+	resolveCtx := make(map[string]string)
+	contexts["resolve"] = resolveCtx
+
+	var data []byte
+	for _, step := range spec.Steps {
+		url := substituteTemplate(step.URL, contexts)
+		if url == "" {
+			return nil, fmt.Errorf("empty URL after template substitution")
+		}
+
+		method := strings.ToUpper(step.Method)
+		if method == "" {
+			method = "GET"
+		}
+
+		req, err := http.NewRequestWithContext(ch.ctx, method, url, nil)
+		if err != nil {
+			return nil, fmt.Errorf("build request: %w", err)
+		}
+		for k, v := range step.Headers {
+			req.Header.Set(k, substituteTemplate(v, contexts))
+		}
+
+		resp, err := ch.client.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("request %s: %w", url, err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("HTTP %d from %s: %s", resp.StatusCode, url, bytes.TrimSpace(body))
+		}
+
+		if len(step.Store) > 0 {
+			var result map[string]interface{}
+			if err := json.Unmarshal(body, &result); err != nil {
+				return nil, fmt.Errorf("parse response from %s: %w", url, err)
+			}
+			for selfKey, jsonField := range step.Store {
+				if val := getStringField(result, jsonField); val != "" {
+					resolveCtx[selfKey] = val
+				}
+			}
+		} else {
+			data = body
+		}
+	}
+
+	if data == nil {
+		return nil, fmt.Errorf("no binary data from resolve steps")
+	}
+	if len(data) > maxFileAttachmentSize {
+		return nil, fmt.Errorf("file too large (%d bytes, max %d)", len(data), maxFileAttachmentSize)
+	}
+
+	mimeType := substituteTemplate(spec.MimeType, contexts)
+	name := substituteTemplate(spec.Name, contexts)
+
+	return &pkg.FileAttachment{
+		Name:     name,
+		MimeType: mimeType,
+		Data:     data,
+		Size:     int64(len(data)),
+	}, nil
 }
 
 // flattenToStringMap converts a map[string]interface{} to map[string]string,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -472,6 +472,19 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		// If "direct" or error or single step, fall through to normal agent loop
 	}
 
+	// Guard: never send empty user content to the LLM (would cause API errors).
+	// Channels with media rules should always produce non-empty content, but this
+	// catches misconfigured channels or unexpected message types.
+	if content == "" && len(files) == 0 {
+		log.Debug("empty content and no files, returning fallback")
+		return &RunResult{
+			Response: "I received your message but couldn't read its content. Could you try sending it as text?",
+		}, nil
+	}
+	if content == "" && len(files) > 0 {
+		content = "[The user sent a file attachment.]"
+	}
+
 	if err := o.sessions.AddMessage(sessionID, provider.Message{
 		Role:    provider.RoleUser,
 		Content: content,


### PR DESCRIPTION
## Summary

- Non-text messages (photos, voice, stickers, video, documents, locations) no longer crash with `"user messages must have non-empty content"`
- New `inbound.media` YAML spec: each rule has `when` (detect media field), `description` (text for LLM), and optional `resolve` (HTTP steps to download binary)
- LLM-supported types (images, PDFs): downloaded and attached as file — LLM processes natively via vision/document understanding
- Unsupported types (voice, video, stickers): description text injected as content — LLM responds naturally (e.g. "I can't listen to voice, could you type that?"), no hardcoded error messages
- `getStringField` extended with array indexing (`photo.-1.file_id`) for Telegram's photo array
- Orchestrator guard: empty content never reaches the LLM API (safety net for misconfigured channels)
- Fully YAML-driven: adding media support to a new channel = writing media rules in that channel's YAML, zero Go code

## Channel YAML changes (separate repos)

Telegram `channel.yaml` needs: `content: { field: "text", fallback: "caption" }` + `media:` rules. Working example in `channels/telegram-channel/channel.yaml` (not committed here — lives in channel repo).

Slack `channel.yaml` works the same way with different resolve steps (single-step download with auth header vs Telegram's two-step getFile → download).

## Test plan

- [x] 19 unit tests: array indexing, navigateToValue, enrichEventCtx, resolveMedia with mock HTTP, fallback on resolve failure
- [x] Full test suite passes (lint, build, all packages)
- [x] Integration: send photo/sticker/voice/video/document/location to Telegram bot
- [x] Regression: text messages still work unchanged