### PR TITLE
fix MCP server plugin resolution and sidecar retry (#87)

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -319,7 +319,7 @@ func main() {
 	if err := pluginManager.LoadAll(ctx, pluginEntries); err != nil {
 		slog.Warn("some plugins failed to load", "error", err)
 	}
-	pluginManager.StartRetryLoop(retryCtx, 30*time.Second)
+	pluginManager.StartRetryLoop(retryCtx, 10*time.Second)
 
 	if err := requestpkg.Register(toolRegistry, requestSets); err != nil {
 		slog.Warn("request_packages registration failed", "error", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1446,7 +1446,19 @@ func (o *Orchestrator) pluginAllowed(cap PluginCapability, allowed cachedAllowed
 		// Non-strict mode: capability has no group restriction — always visible.
 		return true
 	}
-	return allowed.m[cap.Name]
+	if allowed.m[cap.Name] {
+		return true
+	}
+	// Check aliases: if the capability is an alias target (e.g. "mcp") and any
+	// of its aliases (e.g. "jira", "appsignal") are in the allowlist, allow it.
+	// This shouldn't normally fire because ListCapabilities already replaces
+	// alias targets with per-alias entries, but it's defense-in-depth.
+	for _, alias := range o.registry.AliasesFor(cap.Name) {
+		if allowed.m[alias] {
+			return true
+		}
+	}
+	return false
 }
 
 // mapKeys returns the keys of a map as a sorted slice (for debug logging).

--- a/internal/orchestrator/plugin_filter_test.go
+++ b/internal/orchestrator/plugin_filter_test.go
@@ -223,6 +223,39 @@ func TestPluginAllowed_NonStrictMode_PublicAlwaysVisible(t *testing.T) {
 	}
 }
 
+// --- pluginAllowed with aliases ---
+
+func TestPluginAllowed_StrictMode_AliasInAllowlist(t *testing.T) {
+	reg := buildFilterRegistry()
+	// Register "mcp" with an alias "mymcp-alias"
+	_ = reg.Register(PluginCapability{
+		Name:    "mcpbridge",
+		Actions: []Action{{Name: "call", Description: "call it"}},
+	}, &echoExecutor{})
+	_ = reg.RegisterAlias("my-jira", "mcpbridge")
+
+	o := newFilterOrch(reg, nil)
+
+	// Strict mode: allowlist has "my-jira" (alias), not "mcpbridge" (parent).
+	allowed := cachedAllowedPlugins{m: map[string]bool{"my-jira": true}, strict: true}
+
+	// The parent capability should be allowed because its alias is in the allowlist.
+	// capByName won't find it via ListCapabilities (replaced by alias), construct directly.
+	parentCap := PluginCapability{Name: "mcpbridge"}
+	if !o.pluginAllowed(parentCap, allowed) {
+		t.Error("mcpbridge should be allowed via its alias my-jira being in the allowlist")
+	}
+
+	// The alias capability itself should also be allowed.
+	aliasCap, ok := reg.GetCapability("my-jira")
+	if !ok {
+		t.Fatal("expected to find alias capability")
+	}
+	if !o.pluginAllowed(aliasCap, allowed) {
+		t.Error("my-jira alias capability should be allowed directly")
+	}
+}
+
 // --- end-to-end: system prompt ---
 
 func TestSystemPrompt_StrictMode_OnlyListedPluginsVisible(t *testing.T) {
@@ -299,6 +332,94 @@ func TestExecute_StrictMode_GuardNotInWhoAmI_StillRuns(t *testing.T) {
 	}
 	if !guardCalled {
 		t.Error("guard plugin should have been called even though it is not in the WhoAmI Plugins list")
+	}
+}
+
+func TestSystemPrompt_StrictMode_MCPAliasVisible(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{
+		Name:        "mcp",
+		Description: "MCP bridge",
+		Actions:     []Action{{Name: "search_issues", Description: "Search Jira issues"}},
+	}, &echoExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	mem := state.NewMemoryStore("")
+	sess := state.NewSessionStore("")
+	sess.Create("s-alias")
+
+	llm := &capturingLLM{responses: []string{"done"}}
+	o := NewWithRules(llm, &fakeParser{parseFn: func(_ string) []ToolCall { return nil }},
+		reg, mem, sess, OrchestratorOpts{})
+
+	// WhoAmI says plugins=["jira"] — which is an alias for "mcp".
+	p := &profile.Profile{EntityID: "u1", Plugins: []string{"jira"}}
+	ctx := profile.WithProfile(context.Background(), p)
+
+	if _, err := o.Run(ctx, "s-alias", "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(llm.requests) == 0 {
+		t.Fatal("LLM was never called")
+	}
+	system := llm.requests[0].Messages[0].Content
+
+	if !strings.Contains(system, "jira") {
+		t.Error("system prompt should mention 'jira' (alias name)")
+	}
+	if strings.Contains(system, "## mcp") {
+		t.Error("system prompt should NOT mention 'mcp' (parent is replaced by alias)")
+	}
+	if !strings.Contains(system, "search_issues") {
+		t.Error("system prompt should include actions from the MCP plugin under the jira alias")
+	}
+}
+
+func TestExecute_StrictMode_MCPAlias_ToolCallAllowed(t *testing.T) {
+	reg := NewToolRegistry()
+	mcpExec := &callbackExecutor{fn: func(call ToolCall) ToolResult {
+		return ToolResult{CallID: call.ID, Content: "jira result"}
+	}}
+	_ = reg.Register(PluginCapability{
+		Name:    "mcp",
+		Actions: []Action{{Name: "search_issues", Description: "Search"}},
+	}, mcpExec)
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	mem := state.NewMemoryStore("")
+	sess := state.NewSessionStore("")
+	sess.Create("s-alias-exec")
+
+	callNum := 0
+	llm := &capturingLLM{responses: []string{"[tool] jira.search_issues", "done"}}
+	parser := &fakeParser{parseFn: func(_ string) []ToolCall {
+		callNum++
+		if callNum == 1 {
+			return []ToolCall{{ID: "c1", Plugin: "jira", Action: "search_issues", FromLLM: true}}
+		}
+		return nil
+	}}
+	o := NewWithRules(llm, parser, reg, mem, sess, OrchestratorOpts{})
+
+	// WhoAmI: plugins=["jira"]
+	p := &profile.Profile{EntityID: "u1", Plugins: []string{"jira"}}
+	ctx := profile.WithProfile(context.Background(), p)
+
+	result, err := o.Run(ctx, "s-alias-exec", "search jira")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the tool call was executed, not blocked.
+	if len(result.Results) == 0 {
+		t.Fatal("expected at least one tool result")
+	}
+	if result.Results[0].Error != "" {
+		t.Errorf("tool call should not have been blocked, got error: %s", result.Results[0].Error)
+	}
+	if result.Results[0].Content != "jira result" {
+		t.Errorf("Content = %q, want 'jira result'", result.Results[0].Content)
 	}
 }
 

--- a/internal/orchestrator/registry.go
+++ b/internal/orchestrator/registry.go
@@ -14,12 +14,16 @@ type ToolRegistry struct {
 	mu        sync.RWMutex
 	plugins   map[string]PluginCapability
 	executors map[string]PluginExecutor
+	// aliases maps a virtual plugin name (e.g. "jira") to the real plugin name
+	// (e.g. "mcp"). Used for MCP servers so each server appears as its own plugin.
+	aliases map[string]string // alias → target
 }
 
 func NewToolRegistry() *ToolRegistry {
 	return &ToolRegistry{
 		plugins:   make(map[string]PluginCapability),
 		executors: make(map[string]PluginExecutor),
+		aliases:   make(map[string]string),
 	}
 }
 
@@ -40,29 +44,124 @@ func (r *ToolRegistry) Deregister(name string) {
 	defer r.mu.Unlock()
 	delete(r.plugins, name)
 	delete(r.executors, name)
+	// Also remove any aliases pointing to this plugin.
+	for alias, target := range r.aliases {
+		if target == name {
+			delete(r.aliases, alias)
+		}
+	}
+}
+
+// RegisterAlias adds a virtual plugin name that resolves to an existing plugin.
+// The alias shares the target's executor and capability (with the name rewritten).
+// Useful for MCP servers: each server name (e.g. "jira") aliases "mcp".
+func (r *ToolRegistry) RegisterAlias(alias, target string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.plugins[alias]; exists {
+		return fmt.Errorf("cannot alias %q: a plugin with that name is already registered", alias)
+	}
+	if _, exists := r.aliases[alias]; exists {
+		return fmt.Errorf("alias %q already registered", alias)
+	}
+	if _, exists := r.plugins[target]; !exists {
+		return fmt.Errorf("alias target %q not registered", target)
+	}
+	r.aliases[alias] = target
+	return nil
+}
+
+// DeregisterAlias removes a single alias.
+func (r *ToolRegistry) DeregisterAlias(alias string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.aliases, alias)
+}
+
+// AliasesFor returns the alias names pointing to the given plugin.
+func (r *ToolRegistry) AliasesFor(target string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []string
+	for alias, t := range r.aliases {
+		if t == target {
+			out = append(out, alias)
+		}
+	}
+	return out
+}
+
+// resolveAlias returns the target plugin name if name is an alias, or name itself.
+func (r *ToolRegistry) resolveAlias(name string) string {
+	if target, ok := r.aliases[name]; ok {
+		return target
+	}
+	return name
 }
 
 func (r *ToolRegistry) GetCapability(name string) (PluginCapability, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	cap, ok := r.plugins[name]
-	return cap, ok
+	if ok {
+		return cap, true
+	}
+	// Resolve alias: return target capability with the alias name.
+	if target, isAlias := r.aliases[name]; isAlias {
+		cap, ok = r.plugins[target]
+		if ok {
+			aliased := cap
+			aliased.Name = name
+			return aliased, true
+		}
+	}
+	return PluginCapability{}, false
 }
 
 func (r *ToolRegistry) GetExecutor(name string) (PluginExecutor, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	exec, ok := r.executors[name]
-	return exec, ok
+	if ok {
+		return exec, true
+	}
+	// Resolve alias.
+	if target, isAlias := r.aliases[name]; isAlias {
+		exec, ok = r.executors[target]
+		return exec, ok
+	}
+	return nil, false
 }
 
+// ListCapabilities returns all registered capabilities. Plugins that have
+// aliases (e.g. MCP servers) are replaced by one entry per alias, each with
+// the alias name but the parent's actions, so the LLM sees "jira" and
+// "appsignal" instead of "mcp".
 func (r *ToolRegistry) ListCapabilities() []PluginCapability {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	caps := make([]PluginCapability, 0, len(r.plugins))
+	// Collect which plugins are alias targets so we can skip them.
+	aliasTargets := make(map[string]struct{})
+	for _, target := range r.aliases {
+		aliasTargets[target] = struct{}{}
+	}
+
+	caps := make([]PluginCapability, 0, len(r.plugins)+len(r.aliases))
 	for _, cap := range r.plugins {
+		if _, isTarget := aliasTargets[cap.Name]; isTarget {
+			// Skip parent — aliases will represent it.
+			continue
+		}
 		caps = append(caps, cap)
+	}
+	// Add one entry per alias, inheriting the parent's capability.
+	for alias, target := range r.aliases {
+		if parent, ok := r.plugins[target]; ok {
+			aliased := parent
+			aliased.Name = alias
+			caps = append(caps, aliased)
+		}
 	}
 	return caps
 }
@@ -71,7 +170,8 @@ func (r *ToolRegistry) HasAction(plugin, action string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	cap, ok := r.plugins[plugin]
+	resolved := r.resolveAlias(plugin)
+	cap, ok := r.plugins[resolved]
 	if !ok {
 		return false
 	}

--- a/internal/orchestrator/registry_test.go
+++ b/internal/orchestrator/registry_test.go
@@ -122,3 +122,144 @@ func TestRegistryHasAction(t *testing.T) {
 		t.Error("expected HasAction(unknown, analyze_code) = false")
 	}
 }
+
+// --- Alias tests ---
+
+func TestRegistryAlias_GetExecutor(t *testing.T) {
+	reg := NewToolRegistry()
+	exec := &mockExecutor{result: ToolResult{Content: "mcp-result"}}
+	_ = reg.Register(PluginCapability{
+		Name:    "mcp",
+		Actions: []Action{{Name: "search_issues", Description: "Search"}},
+	}, exec)
+	if err := reg.RegisterAlias("jira", "mcp"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := reg.GetExecutor("jira")
+	if !ok {
+		t.Fatal("expected to find executor via alias")
+	}
+	result := got.Execute(context.Background(), ToolCall{ID: "1"})
+	if result.Content != "mcp-result" {
+		t.Errorf("Content = %q, want mcp-result", result.Content)
+	}
+}
+
+func TestRegistryAlias_GetCapability(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{
+		Name:        "mcp",
+		Description: "MCP bridge",
+		Actions:     []Action{{Name: "search_issues", Description: "Search"}},
+	}, &mockExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	cap, ok := reg.GetCapability("jira")
+	if !ok {
+		t.Fatal("expected to find capability via alias")
+	}
+	if cap.Name != "jira" {
+		t.Errorf("Name = %q, want jira (alias should rewrite name)", cap.Name)
+	}
+	if cap.Description != "MCP bridge" {
+		t.Errorf("Description = %q, want MCP bridge", cap.Description)
+	}
+	if len(cap.Actions) != 1 || cap.Actions[0].Name != "search_issues" {
+		t.Error("alias capability should inherit parent actions")
+	}
+}
+
+func TestRegistryAlias_HasAction(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{
+		Name:    "mcp",
+		Actions: []Action{{Name: "search_issues", Description: "Search"}},
+	}, &mockExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	if !reg.HasAction("jira", "search_issues") {
+		t.Error("expected HasAction(jira, search_issues) = true via alias")
+	}
+	if reg.HasAction("jira", "nonexistent") {
+		t.Error("expected HasAction(jira, nonexistent) = false")
+	}
+}
+
+func TestRegistryAlias_ListCapabilities_ReplacesParent(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{
+		Name:    "mcp",
+		Actions: []Action{{Name: "search", Description: "s"}},
+	}, &mockExecutor{})
+	_ = reg.Register(PluginCapability{
+		Name:    "other",
+		Actions: []Action{{Name: "go", Description: "g"}},
+	}, &mockExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+	_ = reg.RegisterAlias("appsignal", "mcp")
+
+	caps := reg.ListCapabilities()
+	names := make(map[string]bool)
+	for _, c := range caps {
+		names[c.Name] = true
+	}
+
+	if names["mcp"] {
+		t.Error("ListCapabilities should NOT include parent 'mcp' when it has aliases")
+	}
+	if !names["jira"] {
+		t.Error("ListCapabilities should include alias 'jira'")
+	}
+	if !names["appsignal"] {
+		t.Error("ListCapabilities should include alias 'appsignal'")
+	}
+	if !names["other"] {
+		t.Error("ListCapabilities should still include non-aliased 'other'")
+	}
+}
+
+func TestRegistryAlias_Deregister_CleansUpAliases(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{Name: "mcp"}, &mockExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	reg.Deregister("mcp")
+
+	if _, ok := reg.GetExecutor("jira"); ok {
+		t.Error("alias should be removed when target is deregistered")
+	}
+	if aliases := reg.AliasesFor("mcp"); len(aliases) != 0 {
+		t.Errorf("AliasesFor should be empty after deregister, got %v", aliases)
+	}
+}
+
+func TestRegistryAlias_DuplicateAlias(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{Name: "mcp"}, &mockExecutor{})
+	_ = reg.RegisterAlias("jira", "mcp")
+
+	err := reg.RegisterAlias("jira", "mcp")
+	if err == nil {
+		t.Error("expected error on duplicate alias registration")
+	}
+}
+
+func TestRegistryAlias_ConflictsWithPlugin(t *testing.T) {
+	reg := NewToolRegistry()
+	_ = reg.Register(PluginCapability{Name: "mcp"}, &mockExecutor{})
+	_ = reg.Register(PluginCapability{Name: "jira"}, &mockExecutor{})
+
+	err := reg.RegisterAlias("jira", "mcp")
+	if err == nil {
+		t.Error("expected error when alias conflicts with existing plugin name")
+	}
+}
+
+func TestRegistryAlias_TargetNotFound(t *testing.T) {
+	reg := NewToolRegistry()
+	err := reg.RegisterAlias("jira", "mcp")
+	if err == nil {
+		t.Error("expected error when alias target not registered")
+	}
+}

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -143,6 +143,19 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 		return fmt.Errorf("register %s: %w", entry.Name, err)
 	}
 
+	// Register per-server aliases for MCP plugins so that each MCP server
+	// (e.g. "jira", "appsignal") appears as its own plugin in the registry.
+	// This allows WhoAmI plugin lists to use server names instead of "mcp".
+	for _, name := range mcpServerNames(entry) {
+		if err := m.registry.RegisterAlias(name, cap.Name); err != nil {
+			slog.Warn("mcp alias registration failed", "component", "plugin-manager",
+				"alias", name, "target", cap.Name, "error", err)
+		} else {
+			slog.Info("mcp server alias registered", "component", "plugin-manager",
+				"alias", name, "target", cap.Name)
+		}
+	}
+
 	mg := &managed{
 		entry:   entry,
 		process: proc,
@@ -307,24 +320,63 @@ func (m *Manager) Unload(name string) error {
 	return nil
 }
 
-// StartRetryLoop starts a background goroutine that periodically retries
-// loading any plugin recorded in the known map that is not currently loaded.
-// This recovers from transient startup failures (e.g. a remote MCP server
-// that wasn't ready yet). The loop stops when ctx is cancelled.
+// StartRetryLoop starts a background goroutine that periodically:
+//  1. Retries loading any plugin in the known map that failed to load.
+//  2. Reloads MCP plugins whose sidecars may not have been ready at startup.
+//     MCP plugins often load successfully using cached specs even when servers
+//     are down; reloading forces a fresh connection attempt. Uses exponential
+//     backoff: 10s, 30s, 1m, 2m, 5m (then stops).
+//
+// The loop ticks every 10s (the base interval) and each MCP plugin tracks its
+// own next-retry time independently.
+//
+// The loop stops when ctx is cancelled.
 func (m *Manager) StartRetryLoop(ctx context.Context, interval time.Duration) {
+	// mcpBackoffSchedule defines the delay before each successive MCP reload attempt.
+	// After the last entry the plugin is no longer retried.
+	mcpBackoffSchedule := []time.Duration{
+		10 * time.Second,
+		30 * time.Second,
+		1 * time.Minute,
+		2 * time.Minute,
+		5 * time.Minute,
+	}
+
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
+
+		type mcpState struct {
+			attempt int
+			nextAt  time.Time
+		}
+		mcpRetries := make(map[string]*mcpState) // plugin name → state
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
+				now := time.Now()
+
 				m.mu.Lock()
 				var pending []PluginEntry
+				var mcpReload []PluginEntry
 				for name, entry := range m.known {
 					if _, loaded := m.plugins[name]; !loaded {
 						pending = append(pending, entry)
+						continue
+					}
+					// MCP plugins with servers: reload to retry sidecar connections.
+					if servers := mcpServerNames(entry); len(servers) > 0 {
+						st, exists := mcpRetries[name]
+						if !exists {
+							st = &mcpState{nextAt: now}
+							mcpRetries[name] = st
+						}
+						if st.attempt < len(mcpBackoffSchedule) && !now.Before(st.nextAt) {
+							mcpReload = append(mcpReload, entry)
+						}
 					}
 				}
 				m.mu.Unlock()
@@ -333,6 +385,26 @@ func (m *Manager) StartRetryLoop(ctx context.Context, interval time.Duration) {
 					slog.Info("retrying failed plugin load", "component", "plugin-manager", "plugin", entry.Name)
 					if err := m.Load(ctx, entry); err != nil {
 						slog.Warn("plugin retry failed", "component", "plugin-manager", "plugin", entry.Name, "error", err)
+					}
+				}
+
+				for _, entry := range mcpReload {
+					st := mcpRetries[entry.Name]
+					st.attempt++
+					nextDelay := mcpBackoffSchedule[st.attempt-1]
+					if st.attempt < len(mcpBackoffSchedule) {
+						st.nextAt = now.Add(mcpBackoffSchedule[st.attempt])
+					}
+					slog.Info("reloading MCP plugin for sidecar retry",
+						"component", "plugin-manager", "plugin", entry.Name,
+						"attempt", st.attempt, "max", len(mcpBackoffSchedule),
+						"next_retry_in", nextDelay)
+					if err := m.Reload(ctx, entry.Name); err != nil {
+						slog.Warn("MCP plugin reload failed", "component", "plugin-manager",
+							"plugin", entry.Name, "error", err)
+					} else {
+						slog.Info("MCP plugin reloaded successfully",
+							"component", "plugin-manager", "plugin", entry.Name)
 					}
 				}
 			}
@@ -381,4 +453,29 @@ func detectPluginMode(path string) pluginMode {
 		return modeRemoteGRPC
 	}
 	return modeBinary
+}
+
+// mcpServerNames extracts MCP server names from a plugin entry's Config["servers"].
+// Returns nil when the entry is not an MCP plugin or has no configured servers.
+func mcpServerNames(entry PluginEntry) []string {
+	servers, _ := entry.Config["servers"].([]interface{})
+	if len(servers) == 0 {
+		return nil
+	}
+	var names []string
+	for _, raw := range servers {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// Try "server" key (inline request packages) then "name" key (static config).
+		name, _ := m["server"].(string)
+		if name == "" {
+			name, _ = m["name"].(string)
+		}
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }

--- a/internal/plugin/manager_test.go
+++ b/internal/plugin/manager_test.go
@@ -195,6 +195,63 @@ func TestWatchProcessIgnoresStaleProcess(t *testing.T) {
 	}
 }
 
+func TestMCPServerNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry PluginEntry
+		want  []string
+	}{
+		{
+			name:  "no config",
+			entry: PluginEntry{Name: "mcp"},
+			want:  nil,
+		},
+		{
+			name:  "no servers key",
+			entry: PluginEntry{Name: "mcp", Config: map[string]interface{}{"foo": "bar"}},
+			want:  nil,
+		},
+		{
+			name: "inline servers with server key",
+			entry: PluginEntry{
+				Name: "mcp",
+				Config: map[string]interface{}{
+					"servers": []interface{}{
+						map[string]interface{}{"server": "jira", "url": "http://localhost:8001"},
+						map[string]interface{}{"server": "appsignal", "url": "http://localhost:8002"},
+					},
+				},
+			},
+			want: []string{"jira", "appsignal"},
+		},
+		{
+			name: "static servers with name key",
+			entry: PluginEntry{
+				Name: "mcp",
+				Config: map[string]interface{}{
+					"servers": []interface{}{
+						map[string]interface{}{"name": "gitlab", "url": "http://localhost:9000"},
+					},
+				},
+			},
+			want: []string{"gitlab"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mcpServerNames(tt.entry)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mcpServerNames() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mcpServerNames()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestConfigJSON(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
MCP servers (jira, appsignal) were invisible to the LLM because the registry only knew about "mcp" while WhoAmI strict mode listed per-server names. The LLM retried the same failing tool call in a loop.

- Add alias support to ToolRegistry: each MCP server name (e.g. "jira") aliases the parent plugin ("mcp"), resolving through GetExecutor, GetCapability, HasAction, and ListCapabilities
- pluginAllowed checks aliases so strict-mode allowlists with server names correctly permit the parent plugin's capabilities
- Manager registers per-server aliases after loading an MCP plugin
- StartRetryLoop now reloads MCP plugins with exponential backoff (10s, 30s, 1m, 2m, 5m) to handle sidecar startup races