### PR TITLE
Handle bare JSON args in [tool_call] blocks with format-hint error

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1096,6 +1096,12 @@ func rejectUnknownArgs(call ToolCall, action *Action) error {
 }
 
 func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResult {
+	if call.Plugin == "" {
+		return ToolResult{
+			CallID: call.ID,
+			Error:  `tool call missing tool name. Use format: [tool_call] plugin.action(key=value, key=value) [/tool_call] or [tool_call] {"tool": "plugin.action", "args": {"key": "value"}} [/tool_call]`,
+		}
+	}
 	exec, ok := o.registry.GetExecutor(call.Plugin)
 	if !ok {
 		return ToolResult{

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -81,8 +81,18 @@ func (defaultParser) Parse(response string) []ToolCall {
 
 		// Format B: plugin.action\n{json_args}
 		// Format C: plugin.action(key=value, key=value)
-		// Skip if body starts with '{' — that's malformed Format A, not an inline call.
-		if !strings.HasPrefix(body, "{") {
+		if strings.HasPrefix(body, "{") {
+			// Body is a bare JSON object without a "tool" key — the LLM emitted
+			// just the args and dropped the tool name. Return a ToolCall with an
+			// empty Plugin so executeCall can give a specific format-hint error
+			// instead of the generic "could not be executed" strip-retry message.
+			calls = append(calls, ToolCall{
+				ID:     fmt.Sprintf("call-%d", len(calls)+1),
+				Plugin: "",
+				Action: "",
+				Args:   make(map[string]string),
+			})
+		} else {
 			if call, ok := parseInlineToolCall(body, len(calls)+1); ok {
 				calls = append(calls, call)
 			}

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -121,6 +121,26 @@ func TestParseInvalidToolName(t *testing.T) {
 	}
 }
 
+func TestParseBareJSONArgs_ReturnsMissingToolCall(t *testing.T) {
+	// When the LLM emits [tool_call]{...}[/tool_call] with just args (no "tool" key),
+	// the parser should return a ToolCall with empty Plugin/Action so executeCall
+	// can return a specific "missing tool name" error instead of dropping it silently.
+	response := `[tool_call]
+{
+  "app_name": "MyApp",
+  "app_environment": "production"
+}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call for bare JSON args, got %d", len(calls))
+	}
+	if calls[0].Plugin != "" || calls[0].Action != "" {
+		t.Errorf("expected empty Plugin/Action, got %q/%q", calls[0].Plugin, calls[0].Action)
+	}
+}
+
 func TestParseEmptyBody(t *testing.T) {
 	response := `[tool_call][/tool_call]`
 	calls := DefaultParser.Parse(response)


### PR DESCRIPTION
When the LLM emits a [tool_call] block with just JSON args (no "tool" key), the parser was silently dropping it and triggering the unhelpful strip-retry message ("respond in natural language without tool calls").

Now the parser returns a ToolCall with empty Plugin/Action, and executeCall returns a specific error with the correct format hint. This goes through the normal tool error → LLM retry path, giving the LLM a chance to fix its format instead of giving up.