### PR TITLE
Structured credential headers from WhoAmI + LLM format reminder (#90)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -784,6 +784,17 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	}
 	messages = append(messages, sess.Messages...)
 
+	// For weaker / OSS models that tend to ignore system-prompt formatting
+	// instructions, repeat the channel format hint as a trailing system
+	// reminder right before the context-window trim so it sits close to the
+	// most recent user message.
+	if hint := channelFormatHint(ctx); hint != "" {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "[IMPORTANT — output format reminder] " + hint,
+		})
+	}
+
 	if o.contextWindow > 0 {
 		messages = trimToContextWindow(ctx, messages, o.contextWindow)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1782,34 +1782,38 @@ func TestBuildSystemPromptIncludesFormatSection(t *testing.T) {
 		t.Fatalf("get session: %v", err)
 	}
 
-	// Without format hint — system prompt must not contain OUTPUT FORMAT.
-	msgs := o.buildMessages(context.Background(), sess, "hi")
-	systemContent := ""
-	for _, m := range msgs {
-		if m.Role == provider.RoleSystem {
-			systemContent = m.Content
+	// collectSystem concatenates all system messages so assertions work
+	// regardless of whether the hint lives in the main system prompt or in
+	// the trailing format-reminder message.
+	collectSystem := func(msgs []provider.Message) string {
+		var sb strings.Builder
+		for _, m := range msgs {
+			if m.Role == provider.RoleSystem {
+				sb.WriteString(m.Content)
+				sb.WriteString("\n")
+			}
 		}
+		return sb.String()
 	}
-	if strings.Contains(systemContent, "OUTPUT FORMAT") {
+
+	// Without format hint — system messages must not contain OUTPUT FORMAT.
+	msgs := o.buildMessages(context.Background(), sess, "hi")
+	allSystem := collectSystem(msgs)
+	if strings.Contains(allSystem, "OUTPUT FORMAT") {
 		t.Error("system prompt should not contain OUTPUT FORMAT when no format is set")
 	}
 
-	// With Slack format — system prompt must contain the section.
+	// With Slack format — system messages must contain the section.
 	ctx := pkgchannel.WithCapabilities(context.Background(), pkgchannel.Capabilities{
 		ResponseFormat: pkgchannel.FormatSlack,
 	})
 	msgs = o.buildMessages(ctx, sess, "hi")
-	systemContent = ""
-	for _, m := range msgs {
-		if m.Role == provider.RoleSystem {
-			systemContent = m.Content
-		}
+	allSystem = collectSystem(msgs)
+	if !strings.Contains(allSystem, "OUTPUT FORMAT") {
+		t.Error("system messages should contain OUTPUT FORMAT for Slack channel")
 	}
-	if !strings.Contains(systemContent, "OUTPUT FORMAT") {
-		t.Error("system prompt should contain OUTPUT FORMAT for Slack channel")
-	}
-	if !strings.Contains(systemContent, "Slack") {
-		t.Error("system prompt should mention Slack formatting")
+	if !strings.Contains(allSystem, "Slack") {
+		t.Error("system messages should mention Slack formatting")
 	}
 }
 

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -105,16 +105,19 @@ func (c *Client) Execute(ctx context.Context, call orchestrator.ToolCall) orches
 
 // ExecuteContext is like Execute but respects context cancellation.
 func (c *Client) ExecuteContext(ctx context.Context, call orchestrator.ToolCall) orchestrator.ToolResult {
-	var credentials map[string]string
-	if p := profile.FromContext(ctx); p != nil {
-		credentials = p.Credentials
+	var credHeaders map[string]*pluginpb.CredentialHeader
+	if p := profile.FromContext(ctx); p != nil && len(p.Credentials) > 0 {
+		credHeaders = make(map[string]*pluginpb.CredentialHeader, len(p.Credentials))
+		for k, v := range p.Credentials {
+			credHeaders[k] = &pluginpb.CredentialHeader{Header: v.Header, Value: v.Value}
+		}
 	}
 	resp, err := c.client.Execute(ctx, &pluginpb.ToolCallRequest{
-		Id:          call.ID,
-		Plugin:      call.Plugin,
-		Action:      call.Action,
-		Args:        call.Args,
-		Credentials: credentials,
+		Id:                call.ID,
+		Plugin:            call.Plugin,
+		Action:            call.Action,
+		Args:              call.Args,
+		CredentialHeaders: credHeaders,
 	})
 	if err != nil {
 		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("grpc: %v", err)}

--- a/internal/plugin/client_test.go
+++ b/internal/plugin/client_test.go
@@ -270,17 +270,17 @@ func TestUserOnlyMappedFromProto(t *testing.T) {
 	}
 }
 
-// credCapturingPluginService records the credentials map from each Execute call.
-type credCapturingPluginService struct {
+// credHeaderCapturingPluginService records the credential headers from each Execute call.
+type credHeaderCapturingPluginService struct {
 	pluginpb.UnimplementedPluginServiceServer
-	received chan map[string]string
+	received chan map[string]*pluginpb.CredentialHeader
 }
 
-func (s *credCapturingPluginService) Init(_ context.Context, _ *pluginpb.PluginInitRequest) (*emptypb.Empty, error) {
+func (s *credHeaderCapturingPluginService) Init(_ context.Context, _ *pluginpb.PluginInitRequest) (*emptypb.Empty, error) {
 	return &emptypb.Empty{}, nil
 }
 
-func (s *credCapturingPluginService) Capabilities(_ context.Context, _ *emptypb.Empty) (*pluginpb.PluginCapabilities, error) {
+func (s *credHeaderCapturingPluginService) Capabilities(_ context.Context, _ *emptypb.Empty) (*pluginpb.PluginCapabilities, error) {
 	return &pluginpb.PluginCapabilities{
 		Name: "cred-echo",
 		Actions: []*pluginpb.Action{
@@ -289,17 +289,17 @@ func (s *credCapturingPluginService) Capabilities(_ context.Context, _ *emptypb.
 	}, nil
 }
 
-func (s *credCapturingPluginService) Execute(_ context.Context, req *pluginpb.ToolCallRequest) (*pluginpb.ToolResultResponse, error) {
-	s.received <- req.Credentials
+func (s *credHeaderCapturingPluginService) Execute(_ context.Context, req *pluginpb.ToolCallRequest) (*pluginpb.ToolResultResponse, error) {
+	s.received <- req.CredentialHeaders
 	return &pluginpb.ToolResultResponse{CallId: req.Id, Content: "ok"}, nil
 }
 
-func startCredCapturingServer(t *testing.T) (*grpc.ClientConn, chan map[string]string) {
+func startCredCapturingServer(t *testing.T) (*grpc.ClientConn, chan map[string]*pluginpb.CredentialHeader) {
 	t.Helper()
-	received := make(chan map[string]string, 1)
+	received := make(chan map[string]*pluginpb.CredentialHeader, 1)
 	lis := bufconn.Listen(bufSize)
 	srv := grpc.NewServer()
-	pluginpb.RegisterPluginServiceServer(srv, &credCapturingPluginService{received: received})
+	pluginpb.RegisterPluginServiceServer(srv, &credHeaderCapturingPluginService{received: received})
 	go func() { _ = srv.Serve(lis) }()
 	t.Cleanup(func() { srv.Stop() })
 
@@ -314,9 +314,9 @@ func startCredCapturingServer(t *testing.T) (*grpc.ClientConn, chan map[string]s
 	return cc, received
 }
 
-// TestExecuteForwardsCredentialsFromProfile verifies that credentials stored
+// TestExecuteForwardsCredentialHeadersFromProfile verifies that credential headers stored
 // on the profile in context are forwarded to the plugin via ToolCallRequest.
-func TestExecuteForwardsCredentialsFromProfile(t *testing.T) {
+func TestExecuteForwardsCredentialHeadersFromProfile(t *testing.T) {
 	cc, received := startCredCapturingServer(t)
 	c := &Client{conn: cc, client: pluginpb.NewPluginServiceClient(cc)}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -327,9 +327,9 @@ func TestExecuteForwardsCredentialsFromProfile(t *testing.T) {
 
 	p := &profile.Profile{
 		EntityID: "u1",
-		Credentials: map[string]string{
-			"mymcp": "user-api-token-abc",
-			"jira":  "user-jira-token-xyz",
+		Credentials: map[string]profile.CredentialHeader{
+			"myapp": {Header: "X-App-User", Value: "user-123"},
+			"jira":  {Header: "Authorization", Value: "Bearer jira-xyz"},
 		},
 	}
 	ctx = profile.WithProfile(context.Background(), p)
@@ -340,17 +340,17 @@ func TestExecuteForwardsCredentialsFromProfile(t *testing.T) {
 	}
 
 	creds := <-received
-	if creds["mymcp"] != "user-api-token-abc" {
-		t.Errorf("credentials[mymcp] = %q, want user-api-token-abc", creds["mymcp"])
+	if c := creds["myapp"]; c == nil || c.Header != "X-App-User" || c.Value != "user-123" {
+		t.Errorf("credential_headers[myapp] = %+v, want {X-App-User user-123}", c)
 	}
-	if creds["jira"] != "user-jira-token-xyz" {
-		t.Errorf("credentials[jira] = %q, want user-jira-token-xyz", creds["jira"])
+	if c := creds["jira"]; c == nil || c.Header != "Authorization" || c.Value != "Bearer jira-xyz" {
+		t.Errorf("credential_headers[jira] = %+v, want {Authorization Bearer jira-xyz}", c)
 	}
 }
 
-// TestExecuteNoCredentialsWithoutProfile verifies that nil credentials are sent
+// TestExecuteNoCredentialHeadersWithoutProfile verifies that nil credential headers are sent
 // when no profile is in the context.
-func TestExecuteNoCredentialsWithoutProfile(t *testing.T) {
+func TestExecuteNoCredentialHeadersWithoutProfile(t *testing.T) {
 	cc, received := startCredCapturingServer(t)
 	c := &Client{conn: cc, client: pluginpb.NewPluginServiceClient(cc)}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -365,7 +365,7 @@ func TestExecuteNoCredentialsWithoutProfile(t *testing.T) {
 	}
 
 	if creds := <-received; len(creds) != 0 {
-		t.Errorf("credentials = %v, want empty when no profile in context", creds)
+		t.Errorf("credential_headers = %v, want empty when no profile in context", creds)
 	}
 }
 

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -6,16 +6,25 @@ package profile
 
 import "time"
 
+// CredentialHeader is a per-MCP-server credential returned by the WhoAmI server.
+// Header is the HTTP header name to set (e.g. "X-Timly-User") and Value is the
+// header value. When making requests to the named MCP server, these are merged
+// with the server's static config headers; WhoAmI-returned headers take priority.
+type CredentialHeader struct {
+	Header string `json:"header"` // HTTP header name (e.g. "X-App-User", "Authorization")
+	Value  string `json:"value"`  // header value (e.g. "user-123", "Bearer tok")
+}
+
 // Profile is the verified identity of an inbound message's sender.
 type Profile struct {
-	EntityID    string            // stable identifier from the WhoAmI server (used for session/memory scoping)
-	Group       string            // group name from the WhoAmI server (used for tool-access control)
-	Token       string            // original bearer token (may be forwarded to MCP servers)
-	Plugins     []string          // plugin IDs returned by WhoAmI (auto-saved to group_plugins table)
-	ChannelID   string            // set by the handler; used for usage statistics
-	Model       string            // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
-	ChannelType string            // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
-	Limit       int               // token spend limit per LimitWindow (0 = unlimited)
-	LimitWindow time.Duration     // rolling window for Limit (0 = unlimited)
-	Credentials map[string]string // per-MCP-server tokens from WhoAmI (e.g. {"mymcp": "user-api-token"})
+	EntityID    string                      // stable identifier from the WhoAmI server (used for session/memory scoping)
+	Group       string                      // group name from the WhoAmI server (used for tool-access control)
+	Token       string                      // original bearer token (may be forwarded to MCP servers)
+	Plugins     []string                    // plugin IDs returned by WhoAmI (auto-saved to group_plugins table)
+	ChannelID   string                      // set by the handler; used for usage statistics
+	Model       string                      // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
+	ChannelType string                      // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
+	Limit       int                         // token spend limit per LimitWindow (0 = unlimited)
+	LimitWindow time.Duration               // rolling window for Limit (0 = unlimited)
+	Credentials map[string]CredentialHeader // per-MCP-server credentials from WhoAmI, keyed by server name
 }

--- a/internal/profile/verifier.go
+++ b/internal/profile/verifier.go
@@ -45,7 +45,7 @@ type VerifierConfig struct {
 	ChannelTypeHeader string            // optional header name to send channel type to WhoAmI server (e.g. "X-Channel-Type")
 	LimitField        string            // optional JSON field for token spend limit; default "limit"
 	LimitTimeField    string            // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
-	CredentialsField  string            // optional JSON field for per-MCP-server tokens map; default "credentials"
+	CredentialsField  string            // optional JSON field for per-MCP-server credential headers; default "credentials"
 	ExtraHeaders      map[string]string // static headers sent on every WhoAmI call; ${ENV_VAR} expanded once at construction
 }
 
@@ -339,7 +339,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 		}
 	}
 
-	var credentials map[string]string
+	var credentials map[string]CredentialHeader
 	if craw, ok := raw[v.cfg.CredentialsField]; ok {
 		if err := json.Unmarshal(craw, &credentials); err != nil {
 			credentials = nil

--- a/internal/profile/verifier_test.go
+++ b/internal/profile/verifier_test.go
@@ -378,16 +378,16 @@ func TestVerifier_ChannelTypeResponse(t *testing.T) {
 	}
 }
 
-// TestVerifier_Credentials verifies that a credentials map returned by WhoAmI
-// is parsed and stored on the profile.
-func TestVerifier_Credentials(t *testing.T) {
+// TestVerifier_CredentialHeaders verifies that credential headers returned by WhoAmI
+// are parsed and stored on the profile.
+func TestVerifier_CredentialHeaders(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"entity_id": "u1",
 			"group":     "g1",
-			"credentials": map[string]string{
-				"mymcp": "user-api-token-abc",
-				"jira":  "user-jira-token-xyz",
+			"credentials": map[string]interface{}{
+				"myapp": map[string]string{"header": "X-App-User", "value": "user-123"},
+				"jira":  map[string]string{"header": "Authorization", "value": "Bearer jira-xyz"},
 			},
 		})
 	}))
@@ -403,17 +403,17 @@ func TestVerifier_Credentials(t *testing.T) {
 	if len(p.Credentials) != 2 {
 		t.Fatalf("Credentials len = %d, want 2", len(p.Credentials))
 	}
-	if p.Credentials["mymcp"] != "user-api-token-abc" {
-		t.Errorf("Credentials[mymcp] = %q, want user-api-token-abc", p.Credentials["mymcp"])
+	if c := p.Credentials["myapp"]; c.Header != "X-App-User" || c.Value != "user-123" {
+		t.Errorf("Credentials[myapp] = %+v, want {X-App-User user-123}", c)
 	}
-	if p.Credentials["jira"] != "user-jira-token-xyz" {
-		t.Errorf("Credentials[jira] = %q, want user-jira-token-xyz", p.Credentials["jira"])
+	if c := p.Credentials["jira"]; c.Header != "Authorization" || c.Value != "Bearer jira-xyz" {
+		t.Errorf("Credentials[jira] = %+v, want {Authorization Bearer jira-xyz}", c)
 	}
 }
 
-// TestVerifier_Credentials_Missing verifies that an absent credentials field
+// TestVerifier_CredentialHeaders_Missing verifies that an absent credentials field
 // results in a nil map (no credentials, no error).
-func TestVerifier_Credentials_Missing(t *testing.T) {
+func TestVerifier_CredentialHeaders_Missing(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"entity_id": "u1",
@@ -434,15 +434,15 @@ func TestVerifier_Credentials_Missing(t *testing.T) {
 	}
 }
 
-// TestVerifier_Credentials_CustomField verifies that credentials_field can be
+// TestVerifier_CredentialHeaders_CustomField verifies that credentials_field can be
 // overridden to read from a different JSON key.
-func TestVerifier_Credentials_CustomField(t *testing.T) {
+func TestVerifier_CredentialHeaders_CustomField(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"entity_id": "u1",
 			"group":     "g1",
-			"tokens": map[string]string{
-				"mymcp": "custom-field-token",
+			"tokens": map[string]interface{}{
+				"myapp": map[string]string{"header": "X-App-Token", "value": "custom-tok"},
 			},
 		})
 	}))
@@ -455,22 +455,22 @@ func TestVerifier_Credentials_CustomField(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
-	if p.Credentials["mymcp"] != "custom-field-token" {
-		t.Errorf("Credentials[mymcp] = %q, want custom-field-token", p.Credentials["mymcp"])
+	if c := p.Credentials["myapp"]; c.Header != "X-App-Token" || c.Value != "custom-tok" {
+		t.Errorf("Credentials[myapp] = %+v, want {X-App-Token custom-tok}", c)
 	}
 }
 
-// TestVerifier_Credentials_Malformed verifies that an unparseable credentials
-// field (array instead of object, non-string values) yields nil credentials
-// with no error — the call succeeds and the bad field is silently ignored.
-func TestVerifier_Credentials_Malformed(t *testing.T) {
+// TestVerifier_CredentialHeaders_Malformed verifies that an unparseable credentials
+// field yields nil credentials with no error — the call succeeds and the bad field
+// is silently ignored.
+func TestVerifier_CredentialHeaders_Malformed(t *testing.T) {
 	cases := []struct {
 		name        string
 		credentials interface{}
 	}{
-		{"array", []string{"mymcp", "jira"}},
-		{"non-string values", map[string]interface{}{"mymcp": 123}},
-		{"nested object", map[string]interface{}{"mymcp": map[string]string{"token": "abc"}}},
+		{"array", []string{"myapp", "jira"}},
+		{"plain strings", map[string]string{"myapp": "token-only"}},
+		{"number values", map[string]interface{}{"myapp": 123}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/plugin/convert.go
+++ b/pkg/plugin/convert.go
@@ -40,13 +40,20 @@ func requestFromProto(pb *pluginpb.ToolCallRequest) Request {
 	if pb == nil {
 		return Request{}
 	}
+	var creds map[string]CredentialHeader
+	if len(pb.CredentialHeaders) > 0 {
+		creds = make(map[string]CredentialHeader, len(pb.CredentialHeaders))
+		for k, v := range pb.CredentialHeaders {
+			creds[k] = CredentialHeader{Header: v.Header, Value: v.Value}
+		}
+	}
 	return Request{
-		Method:      "execute",
-		ID:          pb.Id,
-		Plugin:      pb.Plugin,
-		Action:      pb.Action,
-		Args:        pb.Args,
-		Credentials: pb.Credentials,
+		Method:            "execute",
+		ID:                pb.Id,
+		Plugin:            pb.Plugin,
+		Action:            pb.Action,
+		Args:              pb.Args,
+		CredentialHeaders: creds,
 	}
 }
 

--- a/pkg/plugin/convert_test.go
+++ b/pkg/plugin/convert_test.go
@@ -6,49 +6,49 @@ import (
 	"github.com/opentalon/opentalon/proto/pluginpb"
 )
 
-func TestRequestFromProto_Credentials(t *testing.T) {
+func TestRequestFromProto_CredentialHeaders(t *testing.T) {
 	pb := &pluginpb.ToolCallRequest{
 		Id:     "r1",
 		Plugin: "mcp",
 		Action: "call",
-		Credentials: map[string]string{
-			"mymcp": "user-token-abc",
-			"jira":  "user-jira-xyz",
+		CredentialHeaders: map[string]*pluginpb.CredentialHeader{
+			"myapp": {Header: "X-App-User", Value: "user-123"},
+			"jira":  {Header: "Authorization", Value: "Bearer jira-xyz"},
 		},
 	}
 	req := requestFromProto(pb)
 
-	if req.Credentials["mymcp"] != "user-token-abc" {
-		t.Errorf("Credentials[mymcp] = %q, want user-token-abc", req.Credentials["mymcp"])
+	if c := req.CredentialHeaders["myapp"]; c.Header != "X-App-User" || c.Value != "user-123" {
+		t.Errorf("CredentialHeaders[myapp] = %+v, want {X-App-User user-123}", c)
 	}
-	if req.Credentials["jira"] != "user-jira-xyz" {
-		t.Errorf("Credentials[jira] = %q, want user-jira-xyz", req.Credentials["jira"])
+	if c := req.CredentialHeaders["jira"]; c.Header != "Authorization" || c.Value != "Bearer jira-xyz" {
+		t.Errorf("CredentialHeaders[jira] = %+v, want {Authorization Bearer jira-xyz}", c)
 	}
 }
 
-func TestRequestFromProto_NoCredentials(t *testing.T) {
+func TestRequestFromProto_NoCredentialHeaders(t *testing.T) {
 	pb := &pluginpb.ToolCallRequest{Id: "r2", Plugin: "mcp", Action: "call"}
 	req := requestFromProto(pb)
-	if len(req.Credentials) != 0 {
-		t.Errorf("Credentials = %v, want empty", req.Credentials)
+	if len(req.CredentialHeaders) != 0 {
+		t.Errorf("CredentialHeaders = %v, want empty", req.CredentialHeaders)
 	}
 }
 
 func TestRequestFromProto_NilProto(t *testing.T) {
 	req := requestFromProto(nil)
-	if req.Method != "" || req.ID != "" || req.Credentials != nil {
+	if req.Method != "" || req.ID != "" || req.CredentialHeaders != nil {
 		t.Errorf("nil proto should return zero Request, got %+v", req)
 	}
 }
 
-func TestRequestFromProto_CredentialsWithArgs(t *testing.T) {
+func TestRequestFromProto_CredentialHeadersWithArgs(t *testing.T) {
 	pb := &pluginpb.ToolCallRequest{
 		Id:     "r3",
 		Plugin: "mcp",
 		Action: "search",
 		Args:   map[string]string{"query": "hello"},
-		Credentials: map[string]string{
-			"mymcp": "tok",
+		CredentialHeaders: map[string]*pluginpb.CredentialHeader{
+			"myapp": {Header: "X-App-User", Value: "u1"},
 		},
 	}
 	req := requestFromProto(pb)
@@ -56,8 +56,8 @@ func TestRequestFromProto_CredentialsWithArgs(t *testing.T) {
 	if req.Args["query"] != "hello" {
 		t.Errorf("Args[query] = %q, want hello", req.Args["query"])
 	}
-	if req.Credentials["mymcp"] != "tok" {
-		t.Errorf("Credentials[mymcp] = %q, want tok", req.Credentials["mymcp"])
+	if c := req.CredentialHeaders["myapp"]; c.Header != "X-App-User" || c.Value != "u1" {
+		t.Errorf("CredentialHeaders[myapp] = %+v, want {X-App-User u1}", c)
 	}
 }
 

--- a/pkg/plugin/grpc_server_test.go
+++ b/pkg/plugin/grpc_server_test.go
@@ -10,17 +10,17 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// credCapturingHandler records the Credentials map from each Execute call.
-type credCapturingHandler struct {
-	received chan map[string]string
+// credHeaderCapturingHandler records the CredentialHeaders from each Execute call.
+type credHeaderCapturingHandler struct {
+	received chan map[string]CredentialHeader
 }
 
-func (h *credCapturingHandler) Capabilities() CapabilitiesMsg {
+func (h *credHeaderCapturingHandler) Capabilities() CapabilitiesMsg {
 	return CapabilitiesMsg{Name: "test"}
 }
 
-func (h *credCapturingHandler) Execute(req Request) Response {
-	h.received <- req.Credentials
+func (h *credHeaderCapturingHandler) Execute(req Request) Response {
+	h.received <- req.CredentialHeaders
 	return Response{CallID: req.ID, Content: "ok"}
 }
 
@@ -43,19 +43,19 @@ func startGRPCServer(t *testing.T, handler Handler) pluginpb.PluginServiceClient
 	return pluginpb.NewPluginServiceClient(cc)
 }
 
-// TestGRPCServer_CredentialsReachHandler verifies that credentials sent in
-// ToolCallRequest are forwarded to Handler.Execute via Request.Credentials.
-func TestGRPCServer_CredentialsReachHandler(t *testing.T) {
-	received := make(chan map[string]string, 1)
-	client := startGRPCServer(t, &credCapturingHandler{received: received})
+// TestGRPCServer_CredentialHeadersReachHandler verifies that credential headers sent in
+// ToolCallRequest are forwarded to Handler.Execute via Request.CredentialHeaders.
+func TestGRPCServer_CredentialHeadersReachHandler(t *testing.T) {
+	received := make(chan map[string]CredentialHeader, 1)
+	client := startGRPCServer(t, &credHeaderCapturingHandler{received: received})
 
 	_, err := client.Execute(context.Background(), &pluginpb.ToolCallRequest{
 		Id:     "c1",
 		Plugin: "mcp",
 		Action: "call",
-		Credentials: map[string]string{
-			"mymcp": "user-token-abc",
-			"jira":  "user-jira-xyz",
+		CredentialHeaders: map[string]*pluginpb.CredentialHeader{
+			"myapp": {Header: "X-App-User", Value: "user-123"},
+			"jira":  {Header: "Authorization", Value: "Bearer jira-xyz"},
 		},
 	})
 	if err != nil {
@@ -63,19 +63,19 @@ func TestGRPCServer_CredentialsReachHandler(t *testing.T) {
 	}
 
 	creds := <-received
-	if creds["mymcp"] != "user-token-abc" {
-		t.Errorf("Credentials[mymcp] = %q, want user-token-abc", creds["mymcp"])
+	if c := creds["myapp"]; c.Header != "X-App-User" || c.Value != "user-123" {
+		t.Errorf("CredentialHeaders[myapp] = %+v, want {X-App-User user-123}", c)
 	}
-	if creds["jira"] != "user-jira-xyz" {
-		t.Errorf("Credentials[jira] = %q, want user-jira-xyz", creds["jira"])
+	if c := creds["jira"]; c.Header != "Authorization" || c.Value != "Bearer jira-xyz" {
+		t.Errorf("CredentialHeaders[jira] = %+v, want {Authorization Bearer jira-xyz}", c)
 	}
 }
 
-// TestGRPCServer_NoCredentials verifies that nil credentials are forwarded as
-// nil (not an empty map) when the request carries no credentials.
-func TestGRPCServer_NoCredentials(t *testing.T) {
-	received := make(chan map[string]string, 1)
-	client := startGRPCServer(t, &credCapturingHandler{received: received})
+// TestGRPCServer_NoCredentialHeaders verifies that nil credential headers are forwarded as
+// nil (not an empty map) when the request carries none.
+func TestGRPCServer_NoCredentialHeaders(t *testing.T) {
+	received := make(chan map[string]CredentialHeader, 1)
+	client := startGRPCServer(t, &credHeaderCapturingHandler{received: received})
 
 	_, err := client.Execute(context.Background(), &pluginpb.ToolCallRequest{
 		Id:     "c2",
@@ -87,6 +87,6 @@ func TestGRPCServer_NoCredentials(t *testing.T) {
 	}
 
 	if creds := <-received; len(creds) != 0 {
-		t.Errorf("Credentials = %v, want empty when none sent", creds)
+		t.Errorf("CredentialHeaders = %v, want empty when none sent", creds)
 	}
 }

--- a/pkg/plugin/protocol.go
+++ b/pkg/plugin/protocol.go
@@ -11,14 +11,22 @@ const (
 	HandshakeVersion = 1
 )
 
+// CredentialHeader is a per-MCP-server credential specifying an HTTP header
+// name and value to inject into requests to that server. The plugin merges
+// these with its static configured headers; credential headers take priority.
+type CredentialHeader struct {
+	Header string `json:"header"` // HTTP header name (e.g. "X-App-User", "Authorization")
+	Value  string `json:"value"`  // header value (e.g. "user-123", "Bearer tok")
+}
+
 // Request is the logical request from the host to the plugin.
 type Request struct {
-	Method      string            `json:"method"`
-	ID          string            `json:"id,omitempty"`
-	Plugin      string            `json:"plugin,omitempty"`
-	Action      string            `json:"action,omitempty"`
-	Args        map[string]string `json:"args,omitempty"`
-	Credentials map[string]string `json:"credentials,omitempty"` // per-MCP-server tokens from WhoAmI, keyed by server name
+	Method            string                      `json:"method"`
+	ID                string                      `json:"id,omitempty"`
+	Plugin            string                      `json:"plugin,omitempty"`
+	Action            string                      `json:"action,omitempty"`
+	Args              map[string]string           `json:"args,omitempty"`
+	CredentialHeaders map[string]CredentialHeader `json:"credential_headers,omitempty"` // per-MCP-server credential headers from WhoAmI, keyed by server name
 }
 
 // Response is the logical response from the plugin back to the host.

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -22,9 +22,19 @@ message ToolCallRequest {
   string plugin = 2;
   string action = 3;
   map<string, string> args = 4;
-  // Per-request credentials from the verified profile (e.g. {"mymcp": "user-api-token"}).
-  // Keyed by MCP server name; the plugin merges these with its static configured headers.
-  map<string, string> credentials = 5;
+  reserved 5; // was: map<string, string> credentials (replaced by credential_headers)
+  // Per-request credential headers from the verified profile, keyed by MCP server name.
+  // Each entry specifies an HTTP header name and value to inject when calling that server.
+  // Example: {"myapp": {header: "X-App-User", value: "123"}}.
+  // The plugin merges these with its static configured headers; credential headers take priority.
+  map<string, CredentialHeader> credential_headers = 6;
+}
+
+// CredentialHeader is a per-MCP-server credential specifying an HTTP header
+// name and value to inject into requests to that server.
+message CredentialHeader {
+  string header = 1; // HTTP header name (e.g. "X-App-User", "Authorization")
+  string value = 2;  // header value (e.g. "user-123", "Bearer tok")
 }
 
 message ToolResultResponse {

--- a/proto/pluginpb/plugin.pb.go
+++ b/proto/pluginpb/plugin.pb.go
@@ -72,11 +72,13 @@ type ToolCallRequest struct {
 	Plugin string                 `protobuf:"bytes,2,opt,name=plugin,proto3" json:"plugin,omitempty"`
 	Action string                 `protobuf:"bytes,3,opt,name=action,proto3" json:"action,omitempty"`
 	Args   map[string]string      `protobuf:"bytes,4,rep,name=args,proto3" json:"args,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	// Per-request credentials from the verified profile (e.g. {"mymcp": "user-api-token"}).
-	// Keyed by MCP server name; the plugin merges these with its static configured headers.
-	Credentials   map[string]string `protobuf:"bytes,5,rep,name=credentials,proto3" json:"credentials,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Per-request credential headers from the verified profile, keyed by MCP server name.
+	// Each entry specifies an HTTP header name and value to inject when calling that server.
+	// Example: {"myapp": {header: "X-App-User", value: "123"}}.
+	// The plugin merges these with its static configured headers; credential headers take priority.
+	CredentialHeaders map[string]*CredentialHeader `protobuf:"bytes,6,rep,name=credential_headers,json=credentialHeaders,proto3" json:"credential_headers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *ToolCallRequest) Reset() {
@@ -137,11 +139,65 @@ func (x *ToolCallRequest) GetArgs() map[string]string {
 	return nil
 }
 
-func (x *ToolCallRequest) GetCredentials() map[string]string {
+func (x *ToolCallRequest) GetCredentialHeaders() map[string]*CredentialHeader {
 	if x != nil {
-		return x.Credentials
+		return x.CredentialHeaders
 	}
 	return nil
+}
+
+// CredentialHeader is a per-MCP-server credential specifying an HTTP header
+// name and value to inject into requests to that server.
+type CredentialHeader struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Header        string                 `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"` // HTTP header name (e.g. "X-App-User", "Authorization")
+	Value         string                 `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`   // header value (e.g. "user-123", "Bearer tok")
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CredentialHeader) Reset() {
+	*x = CredentialHeader{}
+	mi := &file_plugin_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CredentialHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CredentialHeader) ProtoMessage() {}
+
+func (x *CredentialHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CredentialHeader.ProtoReflect.Descriptor instead.
+func (*CredentialHeader) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *CredentialHeader) GetHeader() string {
+	if x != nil {
+		return x.Header
+	}
+	return ""
+}
+
+func (x *CredentialHeader) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
 }
 
 type ToolResultResponse struct {
@@ -155,7 +211,7 @@ type ToolResultResponse struct {
 
 func (x *ToolResultResponse) Reset() {
 	*x = ToolResultResponse{}
-	mi := &file_plugin_proto_msgTypes[2]
+	mi := &file_plugin_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -167,7 +223,7 @@ func (x *ToolResultResponse) String() string {
 func (*ToolResultResponse) ProtoMessage() {}
 
 func (x *ToolResultResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[2]
+	mi := &file_plugin_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -180,7 +236,7 @@ func (x *ToolResultResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ToolResultResponse.ProtoReflect.Descriptor instead.
 func (*ToolResultResponse) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{2}
+	return file_plugin_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ToolResultResponse) GetCallId() string {
@@ -222,7 +278,7 @@ type PluginCapabilities struct {
 
 func (x *PluginCapabilities) Reset() {
 	*x = PluginCapabilities{}
-	mi := &file_plugin_proto_msgTypes[3]
+	mi := &file_plugin_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -234,7 +290,7 @@ func (x *PluginCapabilities) String() string {
 func (*PluginCapabilities) ProtoMessage() {}
 
 func (x *PluginCapabilities) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[3]
+	mi := &file_plugin_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -247,7 +303,7 @@ func (x *PluginCapabilities) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PluginCapabilities.ProtoReflect.Descriptor instead.
 func (*PluginCapabilities) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{3}
+	return file_plugin_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *PluginCapabilities) GetName() string {
@@ -291,7 +347,7 @@ type Action struct {
 
 func (x *Action) Reset() {
 	*x = Action{}
-	mi := &file_plugin_proto_msgTypes[4]
+	mi := &file_plugin_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -303,7 +359,7 @@ func (x *Action) String() string {
 func (*Action) ProtoMessage() {}
 
 func (x *Action) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[4]
+	mi := &file_plugin_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -316,7 +372,7 @@ func (x *Action) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Action.ProtoReflect.Descriptor instead.
 func (*Action) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{4}
+	return file_plugin_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *Action) GetName() string {
@@ -366,7 +422,7 @@ type Parameter struct {
 
 func (x *Parameter) Reset() {
 	*x = Parameter{}
-	mi := &file_plugin_proto_msgTypes[5]
+	mi := &file_plugin_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -378,7 +434,7 @@ func (x *Parameter) String() string {
 func (*Parameter) ProtoMessage() {}
 
 func (x *Parameter) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[5]
+	mi := &file_plugin_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -391,7 +447,7 @@ func (x *Parameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Parameter.ProtoReflect.Descriptor instead.
 func (*Parameter) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{5}
+	return file_plugin_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Parameter) GetName() string {
@@ -429,19 +485,22 @@ const file_plugin_proto_rawDesc = "" +
 	"\fplugin.proto\x12\x13opentalon.plugin.v1\x1a\x1bgoogle/protobuf/empty.proto\"4\n" +
 	"\x11PluginInitRequest\x12\x1f\n" +
 	"\vconfig_json\x18\x01 \x01(\tR\n" +
-	"configJson\"\xe7\x02\n" +
+	"configJson\"\xad\x03\n" +
 	"\x0fToolCallRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06plugin\x18\x02 \x01(\tR\x06plugin\x12\x16\n" +
 	"\x06action\x18\x03 \x01(\tR\x06action\x12B\n" +
-	"\x04args\x18\x04 \x03(\v2..opentalon.plugin.v1.ToolCallRequest.ArgsEntryR\x04args\x12W\n" +
-	"\vcredentials\x18\x05 \x03(\v25.opentalon.plugin.v1.ToolCallRequest.CredentialsEntryR\vcredentials\x1a7\n" +
+	"\x04args\x18\x04 \x03(\v2..opentalon.plugin.v1.ToolCallRequest.ArgsEntryR\x04args\x12j\n" +
+	"\x12credential_headers\x18\x06 \x03(\v2;.opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntryR\x11credentialHeaders\x1a7\n" +
 	"\tArgsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a>\n" +
-	"\x10CredentialsEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"]\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1ak\n" +
+	"\x16CredentialHeadersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12;\n" +
+	"\x05value\x18\x02 \x01(\v2%.opentalon.plugin.v1.CredentialHeaderR\x05value:\x028\x01J\x04\b\x05\x10\x06\"@\n" +
+	"\x10CredentialHeader\x12\x16\n" +
+	"\x06header\x18\x01 \x01(\tR\x06header\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"]\n" +
 	"\x12ToolResultResponse\x12\x17\n" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x12\x14\n" +
@@ -481,34 +540,36 @@ func file_plugin_proto_rawDescGZIP() []byte {
 	return file_plugin_proto_rawDescData
 }
 
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_plugin_proto_goTypes = []any{
 	(*PluginInitRequest)(nil),  // 0: opentalon.plugin.v1.PluginInitRequest
 	(*ToolCallRequest)(nil),    // 1: opentalon.plugin.v1.ToolCallRequest
-	(*ToolResultResponse)(nil), // 2: opentalon.plugin.v1.ToolResultResponse
-	(*PluginCapabilities)(nil), // 3: opentalon.plugin.v1.PluginCapabilities
-	(*Action)(nil),             // 4: opentalon.plugin.v1.Action
-	(*Parameter)(nil),          // 5: opentalon.plugin.v1.Parameter
-	nil,                        // 6: opentalon.plugin.v1.ToolCallRequest.ArgsEntry
-	nil,                        // 7: opentalon.plugin.v1.ToolCallRequest.CredentialsEntry
-	(*emptypb.Empty)(nil),      // 8: google.protobuf.Empty
+	(*CredentialHeader)(nil),   // 2: opentalon.plugin.v1.CredentialHeader
+	(*ToolResultResponse)(nil), // 3: opentalon.plugin.v1.ToolResultResponse
+	(*PluginCapabilities)(nil), // 4: opentalon.plugin.v1.PluginCapabilities
+	(*Action)(nil),             // 5: opentalon.plugin.v1.Action
+	(*Parameter)(nil),          // 6: opentalon.plugin.v1.Parameter
+	nil,                        // 7: opentalon.plugin.v1.ToolCallRequest.ArgsEntry
+	nil,                        // 8: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
+	(*emptypb.Empty)(nil),      // 9: google.protobuf.Empty
 }
 var file_plugin_proto_depIdxs = []int32{
-	6, // 0: opentalon.plugin.v1.ToolCallRequest.args:type_name -> opentalon.plugin.v1.ToolCallRequest.ArgsEntry
-	7, // 1: opentalon.plugin.v1.ToolCallRequest.credentials:type_name -> opentalon.plugin.v1.ToolCallRequest.CredentialsEntry
-	4, // 2: opentalon.plugin.v1.PluginCapabilities.actions:type_name -> opentalon.plugin.v1.Action
-	5, // 3: opentalon.plugin.v1.Action.parameters:type_name -> opentalon.plugin.v1.Parameter
-	0, // 4: opentalon.plugin.v1.PluginService.Init:input_type -> opentalon.plugin.v1.PluginInitRequest
-	1, // 5: opentalon.plugin.v1.PluginService.Execute:input_type -> opentalon.plugin.v1.ToolCallRequest
-	8, // 6: opentalon.plugin.v1.PluginService.Capabilities:input_type -> google.protobuf.Empty
-	8, // 7: opentalon.plugin.v1.PluginService.Init:output_type -> google.protobuf.Empty
-	2, // 8: opentalon.plugin.v1.PluginService.Execute:output_type -> opentalon.plugin.v1.ToolResultResponse
-	3, // 9: opentalon.plugin.v1.PluginService.Capabilities:output_type -> opentalon.plugin.v1.PluginCapabilities
-	7, // [7:10] is the sub-list for method output_type
-	4, // [4:7] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	7, // 0: opentalon.plugin.v1.ToolCallRequest.args:type_name -> opentalon.plugin.v1.ToolCallRequest.ArgsEntry
+	8, // 1: opentalon.plugin.v1.ToolCallRequest.credential_headers:type_name -> opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
+	5, // 2: opentalon.plugin.v1.PluginCapabilities.actions:type_name -> opentalon.plugin.v1.Action
+	6, // 3: opentalon.plugin.v1.Action.parameters:type_name -> opentalon.plugin.v1.Parameter
+	2, // 4: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry.value:type_name -> opentalon.plugin.v1.CredentialHeader
+	0, // 5: opentalon.plugin.v1.PluginService.Init:input_type -> opentalon.plugin.v1.PluginInitRequest
+	1, // 6: opentalon.plugin.v1.PluginService.Execute:input_type -> opentalon.plugin.v1.ToolCallRequest
+	9, // 7: opentalon.plugin.v1.PluginService.Capabilities:input_type -> google.protobuf.Empty
+	9, // 8: opentalon.plugin.v1.PluginService.Init:output_type -> google.protobuf.Empty
+	3, // 9: opentalon.plugin.v1.PluginService.Execute:output_type -> opentalon.plugin.v1.ToolResultResponse
+	4, // 10: opentalon.plugin.v1.PluginService.Capabilities:output_type -> opentalon.plugin.v1.PluginCapabilities
+	8, // [8:11] is the sub-list for method output_type
+	5, // [5:8] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -522,7 +583,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
Two changes:

1. **Credential headers**: WhoAmI credentials now carry an explicit HTTP header name and value per MCP server instead of a plain token string. The plugin merges these with its static config headers (WhoAmI takes priority). Proto field 5 (map<string,string>) is reserved; new field 6 uses map<string, CredentialHeader>.

   WhoAmI response format: ```json {"credentials": {"myapp": {"header": "X-App-User", "value": "123"}}} ```

2. **Format reminder for weak models**: the channel format hint is now also injected as a trailing system message right before the last user message, so OSS/smaller models that ignore the main system prompt still see the formatting instruction.