### PR TITLE
Expand env vars in MCP and request package configs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -396,6 +396,25 @@ func expandTilde(s string) string {
 	return s
 }
 
+func expandEnvInRequestPackages(cfg *Config) {
+	for i, inl := range cfg.RequestPackages.Inline {
+		if inl.MCP != nil {
+			inl.MCP.URL = expandEnv(inl.MCP.URL)
+			for k, v := range inl.MCP.Headers {
+				inl.MCP.Headers[k] = expandEnv(v)
+			}
+			cfg.RequestPackages.Inline[i] = inl
+		}
+		for j, p := range inl.Packages {
+			p.URL = expandEnv(p.URL)
+			for k, v := range p.Headers {
+				p.Headers[k] = expandEnv(v)
+			}
+			cfg.RequestPackages.Inline[i].Packages[j] = p
+		}
+	}
+}
+
 func expandEnvInProviders(cfg *Config) {
 	for name, p := range cfg.Models.Providers {
 		p.BaseURL = expandEnv(p.BaseURL)
@@ -422,6 +441,7 @@ func Parse(data []byte) (*Config, error) {
 	expandEnvInChannels(&cfg)
 	expandEnvInBootstrap(&cfg)
 	expandEnvInRedis(&cfg)
+	expandEnvInRequestPackages(&cfg)
 	cfg.Cluster.DedupTTL = expandEnv(cfg.Cluster.DedupTTL)
 	cfg.Metrics.Addr = expandEnv(cfg.Metrics.Addr)
 	if cfg.Metrics.Enabled && cfg.Metrics.Addr == "" {

--- a/internal/requestpkg/loader.go
+++ b/internal/requestpkg/loader.go
@@ -4,10 +4,39 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/opentalon/opentalon/internal/orchestrator"
 	"gopkg.in/yaml.v3"
 )
+
+var envVarPattern = regexp.MustCompile(`\$\{([^}]+)}`)
+
+func expandEnv(s string) string {
+	return envVarPattern.ReplaceAllStringFunc(s, func(match string) string {
+		varName := envVarPattern.FindStringSubmatch(match)[1]
+		if val, ok := os.LookupEnv(varName); ok {
+			return val
+		}
+		return match
+	})
+}
+
+func expandEnvInSet(s *Set) {
+	if s.MCP != nil {
+		s.MCP.URL = expandEnv(s.MCP.URL)
+		for k, v := range s.MCP.Headers {
+			s.MCP.Headers[k] = expandEnv(v)
+		}
+	}
+	for i, p := range s.Packages {
+		p.URL = expandEnv(p.URL)
+		for k, v := range p.Headers {
+			p.Headers[k] = expandEnv(v)
+		}
+		s.Packages[i] = p
+	}
+}
 
 // LoadDir loads all request package sets from a directory. Each .yaml file is one Set.
 func LoadDir(dir string) ([]Set, error) {
@@ -38,6 +67,7 @@ func LoadDir(dir string) ([]Set, error) {
 		if s.MCP != nil && s.MCP.URL == "" {
 			return nil, fmt.Errorf("%s: mcp section requires a non-empty url", path)
 		}
+		expandEnvInSet(&s)
 		sets = append(sets, s)
 	}
 	return sets, nil


### PR DESCRIPTION
The expandEnv() call was missing for request_packages/MCP headers, so ${VAR} references like ${OPENTALON_MCP_TOKEN} were passed through as literal strings. Add expansion for both inline and file-based request package configs.