### PR TITLE
Allow hyphens in tool action names so MCP tools like list-org-units p…

### DIFF
--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -270,7 +270,7 @@ func stripTaggedBlocks(s, open, close string) string {
 
 // parseToolName splits "plugin.action" or "plugin__action" into ("plugin", "action").
 // Both parts must be valid identifiers: plugin allows [a-zA-Z0-9_.-],
-// action allows [a-zA-Z0-9_]. This rejects natural-language fragments
+// action allows [a-zA-Z0-9_-]. This rejects natural-language fragments
 // that an LLM might accidentally emit inside [tool_call] blocks.
 //
 // The dot separator is preferred; double-underscore is a fallback because
@@ -307,7 +307,7 @@ func isValidPluginName(s string) bool {
 
 func isValidActionName(s string) bool {
 	for _, c := range s {
-		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+		if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' && c != '-' {
 			return false
 		}
 	}

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -220,6 +220,24 @@ func TestParseFormatA_InlineNoClosingTag(t *testing.T) {
 	}
 }
 
+func TestParseFormatA_HyphenatedMCPAction(t *testing.T) {
+	// MCP tools commonly use hyphens in action names (e.g. list-org-units).
+	response := `[tool_call]
+{"tool": "myapp.myapp__list-org-units", "args": {}}
+[/tool_call]`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "myapp" {
+		t.Errorf("plugin = %q, want %q", calls[0].Plugin, "myapp")
+	}
+	if calls[0].Action != "myapp__list-org-units" {
+		t.Errorf("action = %q, want %q", calls[0].Action, "myapp__list-org-units")
+	}
+}
+
 func TestParseFormatA_DoubleUnderscore(t *testing.T) {
 	// LLMs trained on OpenAI function calling often emit "plugin__action"
 	// instead of "plugin.action".
@@ -368,6 +386,9 @@ func TestParseToolName(t *testing.T) {
 		{"jira__search_issues", "jira", "search_issues", false},
 		{"appsignal__get_applications", "appsignal", "get_applications", false},
 		{"brave_search__search", "brave_search", "search", false},
+		// hyphenated MCP action names
+		{"myapp.myapp__list-org-units", "myapp", "myapp__list-org-units", false},
+		{"jira__get-issue-details", "jira", "get-issue-details", false},
 		// dot is preferred over double-underscore when both could apply
 		{"mcp.jira__search", "mcp", "jira__search", false},
 		// natural-language fragments must be rejected


### PR DESCRIPTION
…arse correctly

isValidActionName rejected hyphens, causing well-formed tool calls with hyphenated MCP action names (e.g. timly.timly__list-org-units) to be silently dropped by the parser, triggering the "could not be executed" strip-retry loop.