### PR TITLE
Fix large numeric tool args rendered as scientific notation (e.g. 2.0…

### DIFF
--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -3,6 +3,8 @@ package orchestrator
 import (
 	"encoding/json"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 )
 
@@ -183,7 +185,13 @@ func toStringMap(m map[string]interface{}) map[string]string {
 			if val == 0 {
 				continue
 			}
-			result[k] = fmt.Sprintf("%v", val)
+			// Use decimal notation to avoid scientific notation (e.g. 2.004555e+06)
+			// that breaks downstream consumers expecting plain integers.
+			if val == math.Trunc(val) && !math.IsInf(val, 0) && !math.IsNaN(val) {
+				result[k] = strconv.FormatInt(int64(val), 10)
+			} else {
+				result[k] = strconv.FormatFloat(val, 'f', -1, 64)
+			}
 		case bool:
 			if !val {
 				continue

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -171,6 +171,22 @@ func TestParseFormatA_MixedArgTypes(t *testing.T) {
 	}
 }
 
+func TestParseFormatA_LargeNumericID(t *testing.T) {
+	// Large numeric IDs must not be converted to scientific notation (e.g. 2.004555e+06).
+	response := `[tool_call] {"tool": "timly.timly__assign-item", "args": {"item_id": 2004555, "container_id": 170909}}
+`
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Args["item_id"] != "2004555" {
+		t.Errorf("item_id = %q, want %q", calls[0].Args["item_id"], "2004555")
+	}
+	if calls[0].Args["container_id"] != "170909" {
+		t.Errorf("container_id = %q, want %q", calls[0].Args["container_id"], "170909")
+	}
+}
+
 func TestParseFormatC_ParenArgs(t *testing.T) {
 	response := `[tool_call] brave-search.search(query=SpaceX launch today, freshness=pd)
 `


### PR DESCRIPTION
…04555e+06)

Go's json.Unmarshal decodes JSON numbers as float64, and fmt.Sprintf("%v") formats large values with exponents. Use strconv.FormatInt for whole numbers and strconv.FormatFloat with 'f' verb for fractional values to preserve the original decimal representation.