### PR TITLE
Parse bare JSON tool calls emitted without [tool_call] tags (#95)

### DIFF
--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -100,7 +100,22 @@ func (defaultParser) Parse(response string) []ToolCall {
 			}
 		}
 	}
+	// Fallback: the entire response is a bare JSON tool call without [tool_call] tags.
+	// LLMs sometimes emit {"tool": "plugin.action", "args": {...}} as plain text.
 	if len(calls) == 0 {
+		trimmed := strings.TrimSpace(response)
+		var block toolCallJSON
+		if json.Unmarshal([]byte(trimmed), &block) == nil && block.Tool != "" {
+			plugin, action, err := parseToolName(block.Tool)
+			if err == nil {
+				return []ToolCall{{
+					ID:     "call-1",
+					Plugin: plugin,
+					Action: action,
+					Args:   toStringMap(block.Args),
+				}}
+			}
+		}
 		return nil
 	}
 	return calls

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -424,3 +424,40 @@ func TestParseToolName(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBareJSONToolCall(t *testing.T) {
+	// LLM emits a bare JSON tool call without [tool_call] tags.
+	response := `{"tool": "myapp.myapp__list-org-units", "args": {}}`
+
+	calls := DefaultParser.Parse(response)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].Plugin != "myapp" {
+		t.Errorf("plugin = %q, want %q", calls[0].Plugin, "myapp")
+	}
+	if calls[0].Action != "myapp__list-org-units" {
+		t.Errorf("action = %q, want %q", calls[0].Action, "myapp__list-org-units")
+	}
+}
+
+func TestParseBareJSONToolCall_WithSurroundingText(t *testing.T) {
+	// Bare JSON mixed with text should NOT be parsed (avoid false positives).
+	response := `Let me look that up.
+{"tool": "myapp.search", "args": {"q": "test"}}`
+
+	calls := DefaultParser.Parse(response)
+	if calls != nil {
+		t.Errorf("expected nil for bare JSON with surrounding text, got %v", calls)
+	}
+}
+
+func TestParseBareJSONToolCall_NoToolKey(t *testing.T) {
+	// Bare JSON without a "tool" key should NOT be parsed.
+	response := `{"name": "myapp.search", "args": {"q": "test"}}`
+
+	calls := DefaultParser.Parse(response)
+	if calls != nil {
+		t.Errorf("expected nil for JSON without tool key, got %v", calls)
+	}
+}


### PR DESCRIPTION
When the LLM outputs {"tool": "plugin.action", "args": {...}} as plain text instead of wrapping it in [tool_call] tags, the parser now detects and executes it rather than forwarding raw JSON to the user.