### PR TITLE
Add response_formatters post-processing plugin system (#96)

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -358,6 +358,18 @@ func main() {
 		}
 		contentPreparers = append(contentPreparers, entry)
 	}
+	responseFormatters := make([]orchestrator.ResponseFormatterEntry, 0, len(cfg.Orchestrator.ResponseFormatters))
+	for _, f := range cfg.Orchestrator.ResponseFormatters {
+		failOpen := true
+		if f.FailOpen != nil {
+			failOpen = *f.FailOpen
+		}
+		responseFormatters = append(responseFormatters, orchestrator.ResponseFormatterEntry{
+			Plugin:   f.Plugin,
+			Action:   f.Action,
+			FailOpen: failOpen,
+		})
+	}
 	luaScriptPaths := buildLuaScriptPaths(ctx, dataDir, cfg)
 	var permChecker orchestrator.PermissionChecker
 	permPluginName := cfg.Orchestrator.PermissionPlugin
@@ -415,6 +427,7 @@ func main() {
 	orch := orchestrator.NewWithRules(llm, orchestrator.DefaultParser, toolRegistry, memory, sessions, orchestrator.OrchestratorOpts{
 		CustomRules:             cfg.Orchestrator.Rules,
 		ContentPreparers:        contentPreparers,
+		ResponseFormatters:      responseFormatters,
 		LuaScriptPaths:          luaScriptPaths,
 		PermissionChecker:       permChecker,
 		PermissionPluginName:    permPluginName,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -51,6 +51,18 @@ orchestrator:
     - plugin: hello-world
       action: prepare
       arg_key: text
+  # Run these plugin actions after the LLM response to transform the output before
+  # it reaches the channel. Useful for fixing formatting when cheap models ignore
+  # system prompt hints (e.g. outputting Markdown ** bold ** in a Slack channel).
+  # List order = execution order; each formatter's output is the next one's input.
+  # Formatters receive two args: "text" (the response) and "response_format" (e.g. "slack").
+  # response_formatters:
+  #   - plugin: "lua:format-response"    # built-in Lua formatter (see scripts/format-response.lua)
+  #     fail_open: true                  # default true; log and skip on failure (never blocks responses)
+  #   # Or use a gRPC plugin:
+  #   # - plugin: my-formatter
+  #   #   action: format
+  #   #   fail_open: true
   # Pipeline execution: LLM-planned multi-step workflows with confirmation and retry.
   # When enabled, the planner decomposes multi-step requests into a DAG of plugin actions,
   # asks the user for confirmation, and executes with per-step retry and timeout.

--- a/docs/design/channels.md
+++ b/docs/design/channels.md
@@ -173,7 +173,54 @@ This is where company rules, vocabulary enforcement, and compliance checks can r
 
 **Insecure preparers:** Preparers are **insecure by default** (they cannot run invoke). This is only about invoking other plugins: an insecure preparer can change the message and block with a message, but **cannot** run invoke steps. To allow a plugin to run invoke when used as a preparer, set `insecure: false` (trusted) in that plugin's config.
 
-**How this fits with orchestration:** The only place the core does a **pre-check call** to a plugin (or Lua) before the LLM is this content-preparer pipeline. All other plugin invocations are **orchestration-driven**: the LLM decides which tools to call during the turn, and the core runs those actions in the agent loop. There is no separate “after” hook—the response to the user is the LLM’s final output (and any tool results). So “before” in config is the only special pipeline that runs plugins/Lua ahead of the LLM; everything else is normal tool use decided by the LLM.
+**How this fits with orchestration:** Content preparers run **before** the LLM; response formatters (see below) run **after** the LLM. All other plugin invocations are **orchestration-driven**: the LLM decides which tools to call during the turn, and the core runs those actions in the agent loop.
+
+## Post-LLM processing (response formatters)
+
+After the LLM response is generated, it can be **transformed** before reaching the channel. This is the counterpart to content preparers — symmetric in config, but runs after the LLM instead of before.
+
+**Why:** Cheap/small LLMs often ignore system prompt formatting hints (e.g. `## OUTPUT FORMAT`) and output standard Markdown (`**bold**`, `## Heading`) regardless of the channel. Response formatters fix this deterministically — no extra LLM call needed.
+
+**Configuration:**
+
+```yaml
+orchestrator:
+  response_formatters:
+    - plugin: "lua:format-response"    # Lua script (ships with OpenTalon)
+      fail_open: true                  # default true; never block responses on formatter failure
+    # Or a gRPC plugin:
+    - plugin: my-formatter
+      action: format
+      fail_open: true
+```
+
+**How it works:**
+
+1. Each formatter receives the LLM response text and the channel's `response_format` (e.g. `"slack"`, `"teams"`, `"text"`).
+2. For **Lua scripts** (`plugin: "lua:my-script"`): the core calls the script's `format(text, response_format)` function and expects a string return.
+3. For **gRPC plugins** (`plugin: my-plugin`, `action: format`): the core calls the plugin action with args `{"text": "...", "response_format": "..."}`.
+4. Order is significant: the first entry receives the LLM response; each formatter's output is passed to the next.
+5. Only LLM-generated and pipeline-execution responses are formatted. System messages (pipeline confirmation, cancelled, blocked by guard, errors) are **not** formatted.
+
+**Error handling:** `fail_open` defaults to `true` — if a formatter fails, the error is logged and the response is passed through unchanged. Set `fail_open: false` to make formatter failures block the response (returns an error to the user).
+
+**Built-in Lua formatter:** OpenTalon ships `scripts/format-response.lua`, a deterministic Markdown-to-channel converter that handles:
+
+| Channel format | Transformations |
+|---|---|
+| `slack` | `**text**` → `*text*`, `## Heading` → `*Heading*` (mrkdwn) |
+| `teams` | `## Heading` → `**Heading**` |
+| `whatsapp` | `**text**` → `*text*`, `## Heading` → `*Heading*` |
+| `text` | Strip all formatting |
+| `html` / `telegram` | `**text**` → `<b>text</b>`, `*text*` → `<i>text</i>` |
+| `markdown` / `discord` | No-op (already correct) |
+
+Code blocks (fenced ` ``` ` and inline `` ` ``) are protected from transformation.
+
+**Custom formatters:** To customize, either:
+- Fork `scripts/format-response.lua` and adjust the patterns.
+- Write a gRPC plugin that implements a `format` action returning transformed text.
+- Chain multiple formatters (e.g. format-response first, then a compliance check).
 
 ## Actor and permission plugin
 

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -240,11 +240,10 @@ User message
     │
     ▼
 ┌──────────────────────────────────────┐
-│  Lua pre-hooks                       │
-│  - Expert rules (pattern matching,   │
-│    decision trees, scoring)          │
-│  - Small LLM calls (classify,       │
-│    translate, normalize)             │
+│  Content preparers (pre-hooks)       │
+│  - gRPC plugin actions or Lua        │
+│  - Expert rules, classify, translate │
+│  - Config: content_preparers         │
 └──────────┬───────────────────────────┘
            │  refined message
            ▼
@@ -256,11 +255,12 @@ User message
            │  raw response
            ▼
 ┌──────────────────────────────────────┐
-│  Lua post-hooks                      │
-│  - Expert rules (compliance check,   │
-│    vocabulary enforcement)           │
-│  - Small LLM calls (summarize,      │
-│    validate, rewrite)                │
+│  Response formatters (post-hooks)    │
+│  - gRPC plugin actions or Lua        │
+│  - Format conversion (Markdown →     │
+│    Slack mrkdwn, Teams, HTML, etc.)  │
+│  - Compliance, vocabulary, rewrite   │
+│  - Config: response_formatters       │
 └──────────┬───────────────────────────┘
            │  final response
            ▼
@@ -426,7 +426,7 @@ Both plugin tiers share the same set of extension points. Each point defines whe
 |---|---|---|---|
 | **Tool actions** | Primary | -- | LLM-callable capabilities (code analysis, issue creation, search) |
 | **Request hooks** | Supported | Primary | Pre-process user messages before the orchestrator |
-| **Response hooks** | Supported | Primary | Post-process LLM responses before delivery |
+| **Response formatters** | Supported | Primary | Post-process LLM responses before delivery (config: `orchestrator.response_formatters`) |
 | **Auth providers** | Primary | -- | Custom authentication backends |
 | **Storage backends** | Primary | -- | Custom persistence (S3, database, etc.) |
 | **Notification sinks** | Supported | Supported | Send alerts/notifications to external systems |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -282,9 +282,18 @@ type ContentPreparerEntry struct {
 	FailOpen bool   `yaml:"fail_open,omitempty"` // default false (fail-closed): block request if guard/preparer fails
 }
 
+// ResponseFormatterEntry configures a plugin or Lua script that transforms the LLM
+// response text before it reaches the channel (post-processing, symmetric with content preparers).
+type ResponseFormatterEntry struct {
+	Plugin   string `yaml:"plugin"`              // "my-plugin" for gRPC or "lua:my-script" for Lua
+	Action   string `yaml:"action"`              // gRPC action name; ignored for Lua scripts
+	FailOpen *bool  `yaml:"fail_open,omitempty"` // pointer; defaults to true when nil (don't block responses on formatter failure)
+}
+
 type OrchestratorConfig struct {
 	Rules                 []string                   `yaml:"rules"`
 	ContentPreparers      []ContentPreparerEntry     `yaml:"content_preparers,omitempty"`
+	ResponseFormatters    []ResponseFormatterEntry   `yaml:"response_formatters,omitempty"`
 	PermissionPlugin      string                     `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
 	MaxConcurrentSessions int                        `yaml:"max_concurrent_sessions,omitempty"` // max sessions running in parallel (default 1 = sequential)
 	Pipeline              PipelineOrchestratorConfig `yaml:"pipeline,omitempty"`

--- a/internal/lua/runner.go
+++ b/internal/lua/runner.go
@@ -136,6 +136,47 @@ func getTableString(tbl *lua.LTable, key string) string {
 	return ""
 }
 
+// RunFormat runs the Lua script at scriptPath, calling the global format(text, response_format)
+// function. The script must return a string (the formatted text). This is the post-LLM counterpart
+// of RunPrepare — simpler because formatters are text-in/text-out with no blocking or invoke.
+func RunFormat(scriptPath, text, responseFormat string) (string, error) {
+	lState := lua.NewState()
+	defer lState.Close()
+
+	lState.PreloadModule("os", osModuleLoader)
+
+	absPath, err := filepath.Abs(scriptPath)
+	if err != nil {
+		return "", fmt.Errorf("script path: %w", err)
+	}
+	if err := lState.DoFile(absPath); err != nil {
+		return "", fmt.Errorf("load script: %w", err)
+	}
+
+	fn := lState.GetGlobal("format")
+	if fn.Type() == lua.LTNil {
+		return "", fmt.Errorf("script must define global function format(text, response_format)")
+	}
+	if fn.Type() != lua.LTFunction {
+		return "", fmt.Errorf("format must be a function, got %s", fn.Type().String())
+	}
+
+	lState.Push(fn)
+	lState.Push(lua.LString(text))
+	lState.Push(lua.LString(responseFormat))
+	if err := lState.PCall(2, 1, nil); err != nil {
+		return "", fmt.Errorf("format(): %w", err)
+	}
+
+	ret := lState.Get(-1)
+	lState.Pop(1)
+
+	if ret.Type() != lua.LTString {
+		return "", fmt.Errorf("format() must return a string, got %s", ret.Type().String())
+	}
+	return ret.String(), nil
+}
+
 // osModuleLoader provides a minimal os module: getenv and time (for math.randomseed).
 func osModuleLoader(lState *lua.LState) int {
 	mod := lState.NewTable()

--- a/internal/lua/runner_test.go
+++ b/internal/lua/runner_test.go
@@ -134,3 +134,102 @@ end
 		t.Errorf("expected no invoke steps, got %d", len(result.InvokeSteps))
 	}
 }
+
+func TestRunFormatReturnsString(t *testing.T) {
+	script := `
+function format(text, response_format)
+  return "formatted(" .. response_format .. "): " .. text
+end
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmt.lua")
+	if err := os.WriteFile(path, []byte(script), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RunFormat(path, "hello **world**", "slack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "formatted(slack): hello **world**" {
+		t.Errorf("result = %q", result)
+	}
+}
+
+func TestRunFormatReceivesResponseFormat(t *testing.T) {
+	script := `
+function format(text, response_format)
+  return response_format
+end
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmt.lua")
+	if err := os.WriteFile(path, []byte(script), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RunFormat(path, "anything", "teams")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "teams" {
+		t.Errorf("expected response_format 'teams', got %q", result)
+	}
+}
+
+func TestRunFormatMissingFunction(t *testing.T) {
+	script := `function prepare(text) return text end`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmt.lua")
+	if err := os.WriteFile(path, []byte(script), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RunFormat(path, "hello", "slack")
+	if err == nil {
+		t.Fatal("expected error for missing format function")
+	}
+}
+
+func TestRunFormatNonStringReturn(t *testing.T) {
+	script := `
+function format(text, response_format)
+  return { message = "oops" }
+end
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmt.lua")
+	if err := os.WriteFile(path, []byte(script), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RunFormat(path, "hello", "slack")
+	if err == nil {
+		t.Fatal("expected error for non-string return")
+	}
+}
+
+func TestRunFormatEmptyFormat(t *testing.T) {
+	// Verify empty response_format is passed correctly
+	script := `
+function format(text, response_format)
+  if response_format == "" then
+    return text
+  end
+  return "changed"
+end
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fmt.lua")
+	if err := os.WriteFile(path, []byte(script), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := RunFormat(path, "keep me", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "keep me" {
+		t.Errorf("expected no-op for empty format, got %q", result)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -144,7 +144,7 @@ type Orchestrator struct {
 	guard                   *Guard
 	rules                   *RulesConfig
 	preparers               []ContentPreparerEntry
-	formatters              []ResponseFormatterEntry       // run after final response; text-in/text-out
+	formatters              []ResponseFormatterEntry      // run after final response; text-in/text-out
 	guards                  []ContentPreparerEntry        // subset of preparers with Guard:true; run before every LLM call
 	luaScriptPaths          map[string]string             // optional; plugin name -> path to .lua script (for "lua:name" preparers)
 	permissionChecker       PermissionChecker             // optional; when set, executeCall checks permission before running
@@ -419,7 +419,7 @@ func (o *Orchestrator) formatResponse(ctx context.Context, result *RunResult) er
 			scriptName := strings.TrimPrefix(f.Plugin, "lua:")
 			scriptPath := o.luaScriptPaths[scriptName]
 			if scriptPath == "" {
-				err = fmt.Errorf("Lua script path not found for %q", scriptName)
+				err = fmt.Errorf("lua script path not found for %q", scriptName)
 			} else {
 				formatted, err = lua.RunFormat(scriptPath, result.Response, responseFormat)
 			}
@@ -456,6 +456,9 @@ func (o *Orchestrator) formatResponse(ctx context.Context, result *RunResult) er
 			}
 			return fmt.Errorf("response formatter %s: %w", name, err)
 		}
+		// Guard: ignore empty results so a broken formatter can't blank the
+		// response. A formatter that intentionally returns "" is treated as a
+		// no-op, preserving the previous response text.
 		if formatted != "" {
 			result.Response = formatted
 		}
@@ -533,7 +536,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			res, err := o.executePipeline(ctx, sessionID, p)
 			if err == nil && res != nil {
 				if fmtErr := o.formatResponse(ctx, res); fmtErr != nil {
-					return nil, fmt.Errorf("response formatter: %w", fmtErr)
+					return nil, fmtErr
 				}
 			}
 			return res, err
@@ -723,7 +726,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			})
 			o.maybeRecordWorkflow(ctx, result, userMessage)
 			if fmtErr := o.formatResponse(ctx, result); fmtErr != nil {
-				return nil, fmt.Errorf("response formatter: %w", fmtErr)
+				return nil, fmtErr
 			}
 			return result, nil
 		}
@@ -1210,8 +1213,11 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	}
 
 	actorID := actor.Actor(ctx)
-	// permission_plugin gates all plugin actions (including e.g. install_skill); configure it for team deployments.
-	if actorID != "" && o.permissionChecker != nil && call.Plugin != o.permissionPluginName {
+	// permission_plugin gates LLM-originated plugin actions (including e.g.
+	// install_skill); configure it for team deployments.  Internal calls
+	// (guards, preparers, formatters, pipelines) are exempt — they are
+	// constructed programmatically by the host, not by the LLM.
+	if call.FromLLM && actorID != "" && o.permissionChecker != nil && call.Plugin != o.permissionPluginName {
 		allowed, err := o.permissionChecker.Allowed(ctx, actorID, call.Plugin)
 		if err != nil {
 			slog.Warn("permission check failed", "actor", actorID, "plugin", call.Plugin, "error", err)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -36,6 +36,14 @@ type ContentPreparerEntry struct {
 	FailOpen bool   // if true, guard/preparer failures are logged and skipped; default false (fail-closed)
 }
 
+// ResponseFormatterEntry configures a plugin or Lua script that transforms the
+// LLM response text after the agent loop, before returning to the channel handler.
+type ResponseFormatterEntry struct {
+	Plugin   string // "my-plugin" for gRPC or "lua:my-script" for Lua
+	Action   string // gRPC action name; ignored for Lua scripts
+	FailOpen bool   // default true: log and skip on failure (don't block responses)
+}
+
 type LLMClient interface {
 	Complete(ctx context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error)
 }
@@ -83,6 +91,7 @@ type PluginCallObserver interface {
 type OrchestratorOpts struct {
 	CustomRules             []string
 	ContentPreparers        []ContentPreparerEntry
+	ResponseFormatters      []ResponseFormatterEntry
 	LuaScriptPaths          map[string]string
 	PermissionChecker       PermissionChecker
 	PermissionPluginName    string
@@ -135,6 +144,7 @@ type Orchestrator struct {
 	guard                   *Guard
 	rules                   *RulesConfig
 	preparers               []ContentPreparerEntry
+	formatters              []ResponseFormatterEntry       // run after final response; text-in/text-out
 	guards                  []ContentPreparerEntry        // subset of preparers with Guard:true; run before every LLM call
 	luaScriptPaths          map[string]string             // optional; plugin name -> path to .lua script (for "lua:name" preparers)
 	permissionChecker       PermissionChecker             // optional; when set, executeCall checks permission before running
@@ -237,6 +247,7 @@ func NewWithRules(
 		guard:                   NewGuard(),
 		rules:                   NewRulesConfig(opts.CustomRules),
 		preparers:               preparers,
+		formatters:              opts.ResponseFormatters,
 		guards:                  guards,
 		luaScriptPaths:          opts.LuaScriptPaths,
 		permissionChecker:       opts.PermissionChecker,
@@ -390,6 +401,68 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 	return toolResult.Content, nil, nil
 }
 
+// formatResponse runs all configured response formatters on result.Response.
+// Each formatter receives the response text and the channel's response_format.
+// Formatters are text-in/text-out (no invoke, no blocking). On error the
+// formatter is skipped (FailOpen true) or the error is returned (FailOpen false).
+func (o *Orchestrator) formatResponse(ctx context.Context, result *RunResult) error {
+	if len(o.formatters) == 0 || result == nil || result.Response == "" {
+		return nil
+	}
+	responseFormat := string(pkgchannel.CapabilitiesFromContext(ctx).ResponseFormat)
+
+	for _, f := range o.formatters {
+		var formatted string
+		var err error
+
+		if strings.HasPrefix(f.Plugin, "lua:") {
+			scriptName := strings.TrimPrefix(f.Plugin, "lua:")
+			scriptPath := o.luaScriptPaths[scriptName]
+			if scriptPath == "" {
+				err = fmt.Errorf("Lua script path not found for %q", scriptName)
+			} else {
+				formatted, err = lua.RunFormat(scriptPath, result.Response, responseFormat)
+			}
+		} else {
+			if !o.registry.HasAction(f.Plugin, f.Action) {
+				err = fmt.Errorf("action %s.%s not found", f.Plugin, f.Action)
+			} else {
+				call := ToolCall{
+					ID:     fmt.Sprintf("formatter-%s-%s", f.Plugin, f.Action),
+					Plugin: f.Plugin,
+					Action: f.Action,
+					Args: map[string]string{
+						"text":            result.Response,
+						"response_format": responseFormat,
+					},
+				}
+				toolResult := o.executeCall(ctx, call)
+				if toolResult.Error != "" {
+					err = fmt.Errorf("%s", toolResult.Error)
+				} else {
+					formatted = toolResult.Content
+				}
+			}
+		}
+
+		if err != nil {
+			name := f.Plugin
+			if f.Action != "" {
+				name += "." + f.Action
+			}
+			if f.FailOpen {
+				slog.Warn("response formatter failed, skipping", "formatter", name, "error", err)
+				continue
+			}
+			return fmt.Errorf("response formatter %s: %w", name, err)
+		}
+		if formatted != "" {
+			result.Response = formatted
+		}
+	}
+	return nil
+}
+
 // acquireSessionLock returns the per-session mutex for sessionID, locked.
 func (o *Orchestrator) acquireSessionLock(sessionID string) *sessionMutex {
 	o.sessionMuxMu.Lock()
@@ -457,7 +530,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
 		if decision == pipeline.Approved {
 			log.Debug("pipeline executing", "pipeline_id", p.ID, "steps", len(p.Steps))
-			return o.executePipeline(ctx, sessionID, p)
+			res, err := o.executePipeline(ctx, sessionID, p)
+			if err == nil && res != nil {
+				if fmtErr := o.formatResponse(ctx, res); fmtErr != nil {
+					return nil, fmt.Errorf("response formatter: %w", fmtErr)
+				}
+			}
+			return res, err
 		}
 		resp := "Pipeline cancelled (expected y/yes to confirm)."
 		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
@@ -643,6 +722,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				Content: resp.Content,
 			})
 			o.maybeRecordWorkflow(ctx, result, userMessage)
+			if fmtErr := o.formatResponse(ctx, result); fmtErr != nil {
+				return nil, fmt.Errorf("response formatter: %w", fmtErr)
+			}
 			return result, nil
 		}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1975,3 +1975,190 @@ func TestPluginCallObserverCalledForEachCallInMultiStep(t *testing.T) {
 		}
 	}
 }
+
+// --- Response formatter tests ---
+
+// formatterExecutor transforms text by wrapping it with the response_format.
+type formatterExecutor struct{}
+
+func (e *formatterExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
+	text := call.Args["text"]
+	rf := call.Args["response_format"]
+	return ToolResult{CallID: call.ID, Content: fmt.Sprintf("[%s]%s[/%s]", rf, text, rf)}
+}
+
+// errorFormatterExecutor always returns an error.
+type errorFormatterExecutor struct{}
+
+func (e *errorFormatterExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
+	return ToolResult{CallID: call.ID, Error: "formatter broke"}
+}
+
+func setupOrchestratorWithFormatters(llm LLMClient, parser ToolCallParser, formatters []ResponseFormatterEntry) (*Orchestrator, string) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:        "gitlab",
+		Description: "GitLab integration",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code", Parameters: []Parameter{{Name: "repo", Description: "Repository"}}},
+			{Name: "create_pr", Description: "Create PR"},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "jira",
+		Description: "Jira integration",
+		Actions:     []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "my-formatter",
+		Description: "Test formatter",
+		Actions:     []Action{{Name: "format", Description: "Format response", Parameters: []Parameter{{Name: "text"}, {Name: "response_format"}}}},
+	}, &formatterExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "bad-formatter",
+		Description: "Broken formatter",
+		Actions:     []Action{{Name: "format", Description: "Format response", Parameters: []Parameter{{Name: "text"}, {Name: "response_format"}}}},
+	}, &errorFormatterExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("test-session")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		ResponseFormatters: formatters,
+	})
+	return orch, "test-session"
+}
+
+func TestResponseFormatterGRPCPlugin(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"**Hello world**"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "my-formatter", Action: "format", FailOpen: true},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	ctx := pkgchannel.WithCapabilities(context.Background(), pkgchannel.Capabilities{
+		ResponseFormat: pkgchannel.FormatSlack,
+	})
+	result, err := orch.Run(ctx, sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "[slack]**Hello world**[/slack]"
+	if result.Response != expected {
+		t.Errorf("Response = %q, want %q", result.Response, expected)
+	}
+}
+
+func TestResponseFormatterChaining(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"original"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "my-formatter", Action: "format", FailOpen: true},
+		{Plugin: "my-formatter", Action: "format", FailOpen: true},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	ctx := pkgchannel.WithCapabilities(context.Background(), pkgchannel.Capabilities{
+		ResponseFormat: pkgchannel.FormatTeams,
+	})
+	result, err := orch.Run(ctx, sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// First formatter: [teams]original[/teams]
+	// Second formatter: [teams][teams]original[/teams][/teams]
+	expected := "[teams][teams]original[/teams][/teams]"
+	if result.Response != expected {
+		t.Errorf("Response = %q, want %q", result.Response, expected)
+	}
+}
+
+func TestResponseFormatterFailOpenTrue(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"keep me"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "bad-formatter", Action: "format", FailOpen: true},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	result, err := orch.Run(context.Background(), sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// FailOpen=true: error is logged, response unchanged
+	if result.Response != "keep me" {
+		t.Errorf("Response = %q, want %q", result.Response, "keep me")
+	}
+}
+
+func TestResponseFormatterFailOpenFalse(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"will fail"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "bad-formatter", Action: "format", FailOpen: false},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	_, err := orch.Run(context.Background(), sessID, "Hi")
+	if err == nil {
+		t.Fatal("expected error when FailOpen is false")
+	}
+	if !strings.Contains(err.Error(), "response formatter") {
+		t.Errorf("error = %q, want to contain 'response formatter'", err.Error())
+	}
+}
+
+func TestResponseFormatterMissingAction(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"keep me"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "nonexistent", Action: "format", FailOpen: true},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	result, err := orch.Run(context.Background(), sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// FailOpen=true: missing plugin is logged and skipped
+	if result.Response != "keep me" {
+		t.Errorf("Response = %q, want %q", result.Response, "keep me")
+	}
+}
+
+func TestResponseFormatterNoFormatters(t *testing.T) {
+	llm := &fakeLLM{responses: []string{"untouched"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, nil)
+	result, err := orch.Run(context.Background(), sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response != "untouched" {
+		t.Errorf("Response = %q, want %q", result.Response, "untouched")
+	}
+}
+
+func TestResponseFormatterLuaScript(t *testing.T) {
+	// Test Lua formatter via the orchestrator (requires a temp script file)
+	import_os := false
+	_ = import_os // Lua test is covered in runner_test.go; here we test the wiring for missing script
+	llm := &fakeLLM{responses: []string{"keep me"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	formatters := []ResponseFormatterEntry{
+		{Plugin: "lua:nonexistent-script", Action: "", FailOpen: true},
+	}
+
+	orch, sessID := setupOrchestratorWithFormatters(llm, parser, formatters)
+	result, err := orch.Run(context.Background(), sessID, "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// FailOpen=true: missing Lua script is logged and skipped
+	if result.Response != "keep me" {
+		t.Errorf("Response = %q, want %q", result.Response, "keep me")
+	}
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1618,6 +1618,63 @@ func TestUnknownArgsNotRejectedForInternalCall(t *testing.T) {
 	}
 }
 
+// Permission plugin must NOT block internal calls (preparers, formatters,
+// pipelines) — only LLM-originated calls should be checked.
+func TestPermissionCheckerSkippedForInternalCalls(t *testing.T) {
+	// A permission checker that always denies.
+	deny := &denyAllPermissionChecker{}
+
+	var invoked bool
+	captureExec := &capturingExecutor{fn: func(c ToolCall) ToolResult {
+		invoked = true
+		return ToolResult{CallID: c.ID, Content: "ok"}
+	}}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "formatter", Description: "Formatter plugin",
+		Actions: []Action{{Name: "format", Description: "Format response"}},
+	}, captureExec)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		PermissionChecker: deny,
+	})
+
+	ctx := actor.WithActor(context.Background(), "user:alice")
+
+	// Internal call (FromLLM=false) — should bypass permission check.
+	result := orch.executeCall(ctx, ToolCall{
+		ID: "c1", Plugin: "formatter", Action: "format",
+		Args: map[string]string{"text": "hello"},
+	})
+	if result.Error != "" {
+		t.Fatalf("internal call should bypass permission checker; got error %q", result.Error)
+	}
+	if !invoked {
+		t.Error("plugin should have been invoked for internal call")
+	}
+
+	// LLM-originated call — should be denied.
+	invoked = false
+	result = orch.executeCall(ctx, ToolCall{
+		ID: "c2", Plugin: "formatter", Action: "format",
+		Args:    map[string]string{"text": "hello"},
+		FromLLM: true,
+	})
+	if result.Error == "" {
+		t.Error("LLM call should be denied by permission checker")
+	}
+	if invoked {
+		t.Error("plugin should NOT have been invoked for denied LLM call")
+	}
+}
+
+type denyAllPermissionChecker struct{}
+
+func (d *denyAllPermissionChecker) Allowed(ctx context.Context, actorID, plugin string) (bool, error) {
+	return false, nil
+}
+
 func TestRejectUnknownArgsErrorFormat(t *testing.T) {
 	action := &Action{
 		Name: "do", Parameters: []Parameter{
@@ -2142,10 +2199,7 @@ func TestResponseFormatterNoFormatters(t *testing.T) {
 	}
 }
 
-func TestResponseFormatterLuaScript(t *testing.T) {
-	// Test Lua formatter via the orchestrator (requires a temp script file)
-	import_os := false
-	_ = import_os // Lua test is covered in runner_test.go; here we test the wiring for missing script
+func TestResponseFormatterLuaMissingScript(t *testing.T) {
 	llm := &fakeLLM{responses: []string{"keep me"}}
 	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
 	formatters := []ResponseFormatterEntry{

--- a/scripts/format-response.lua
+++ b/scripts/format-response.lua
@@ -1,0 +1,238 @@
+-- format-response.lua: Post-LLM response formatter.
+-- Converts standard Markdown to the target channel's native format.
+-- Cheap/small models often ignore system prompt formatting hints and output
+-- standard Markdown regardless — this script fixes it deterministically.
+--
+-- Usage in config.yaml:
+--   orchestrator:
+--     response_formatters:
+--       - plugin: "lua:format-response"
+--
+-- Supports: slack, teams, whatsapp, telegram, html, text.
+-- No-op for: markdown, discord, or empty (already standard Markdown).
+
+-- Split text into segments: protected (inside code blocks/inline code) and
+-- unprotected (regular text that can be transformed).
+local function split_segments(text)
+  local segments = {}
+  local pos = 1
+  local len = #text
+
+  while pos <= len do
+    -- Look for fenced code block (```)
+    local fence_start = text:find("```", pos, true)
+    -- Look for inline code (`)
+    local inline_start = text:find("`", pos, true)
+
+    -- Pick whichever comes first
+    if fence_start and (not inline_start or fence_start <= inline_start) then
+      -- Add unprotected segment before the fence
+      if fence_start > pos then
+        table.insert(segments, { text = text:sub(pos, fence_start - 1), protected = false })
+      end
+      -- Find closing fence
+      local fence_end = text:find("```", fence_start + 3, true)
+      if fence_end then
+        table.insert(segments, { text = text:sub(fence_start, fence_end + 2), protected = true })
+        pos = fence_end + 3
+      else
+        -- No closing fence: rest of text is protected
+        table.insert(segments, { text = text:sub(fence_start), protected = true })
+        pos = len + 1
+      end
+    elseif inline_start then
+      -- Check if it's actually a fence start (handled above)
+      if text:sub(inline_start, inline_start + 2) == "```" then
+        -- Should have been caught above; safety fallback
+        if inline_start > pos then
+          table.insert(segments, { text = text:sub(pos, inline_start - 1), protected = false })
+        end
+        local fence_end = text:find("```", inline_start + 3, true)
+        if fence_end then
+          table.insert(segments, { text = text:sub(inline_start, fence_end + 2), protected = true })
+          pos = fence_end + 3
+        else
+          table.insert(segments, { text = text:sub(inline_start), protected = true })
+          pos = len + 1
+        end
+      else
+        -- Inline code
+        if inline_start > pos then
+          table.insert(segments, { text = text:sub(pos, inline_start - 1), protected = false })
+        end
+        local inline_end = text:find("`", inline_start + 1, true)
+        if inline_end then
+          table.insert(segments, { text = text:sub(inline_start, inline_end), protected = true })
+          pos = inline_end + 1
+        else
+          -- No closing backtick: treat rest as unprotected
+          table.insert(segments, { text = text:sub(inline_start), protected = false })
+          pos = len + 1
+        end
+      end
+    else
+      -- No more code markers
+      table.insert(segments, { text = text:sub(pos), protected = false })
+      pos = len + 1
+    end
+  end
+
+  return segments
+end
+
+-- Apply a transform function to unprotected segments only, then reassemble.
+local function apply_transform(text, transform_fn)
+  local segments = split_segments(text)
+  local parts = {}
+  for _, seg in ipairs(segments) do
+    if seg.protected then
+      table.insert(parts, seg.text)
+    else
+      table.insert(parts, transform_fn(seg.text))
+    end
+  end
+  return table.concat(parts)
+end
+
+-- Slack mrkdwn: **bold** -> *bold*, ## Heading -> *Heading*
+local function format_slack(s)
+  -- Headings: # ... or ## ... -> *...*
+  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+    -- Strip any bold markers from heading text
+    heading = heading:gsub("%*%*(.-)%*%*", "%1")
+    return nl .. "*" .. heading .. "*"
+  end)
+  -- Handle heading at start of string (no preceding newline)
+  if s:sub(1, 1) == "#" then
+    s = s:gsub("^#+%s+([^\n]+)", function(heading)
+      heading = heading:gsub("%*%*(.-)%*%*", "%1")
+      return "*" .. heading .. "*"
+    end)
+  end
+  -- Bold: **text** -> *text* (non-greedy)
+  s = s:gsub("%*%*(.-)%*%*", "*%1*")
+  -- Bold underscore: __text__ -> _text_
+  s = s:gsub("__(.-)__", "_%1_")
+  return s
+end
+
+-- Teams: ## Heading -> **Heading** (Teams renders bold but not # headings well)
+local function format_teams(s)
+  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+    heading = heading:gsub("%*%*(.-)%*%*", "%1")
+    return nl .. "**" .. heading .. "**"
+  end)
+  if s:sub(1, 1) == "#" then
+    s = s:gsub("^#+%s+([^\n]+)", function(heading)
+      heading = heading:gsub("%*%*(.-)%*%*", "%1")
+      return "**" .. heading .. "**"
+    end)
+  end
+  return s
+end
+
+-- WhatsApp: **text** -> *text*, ## Heading -> *Heading*
+local function format_whatsapp(s)
+  -- Headings
+  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+    heading = heading:gsub("%*%*(.-)%*%*", "%1")
+    return nl .. "*" .. heading .. "*"
+  end)
+  if s:sub(1, 1) == "#" then
+    s = s:gsub("^#+%s+([^\n]+)", function(heading)
+      heading = heading:gsub("%*%*(.-)%*%*", "%1")
+      return "*" .. heading .. "*"
+    end)
+  end
+  -- Bold: **text** -> *text*
+  s = s:gsub("%*%*(.-)%*%*", "*%1*")
+  return s
+end
+
+-- Plain text: strip all formatting
+local function format_text(s)
+  -- Headings
+  s = s:gsub("(\n?)#+%s+([^\n]+)", "%1%2")
+  if s:sub(1, 1) == "#" then
+    s = s:gsub("^#+%s+([^\n]+)", "%1")
+  end
+  -- Bold
+  s = s:gsub("%*%*(.-)%*%*", "%1")
+  -- Italic
+  s = s:gsub("%*(.-)%*", "%1")
+  -- Bold/italic underscore
+  s = s:gsub("__(.-)__", "%1")
+  s = s:gsub("_(.-)_", "%1")
+  -- Strikethrough
+  s = s:gsub("~~(.-)~~", "%1")
+  -- Links: [text](url) -> text (url)
+  s = s:gsub("%[(.-)%]%((.-)%)", "%1 (%2)")
+  return s
+end
+
+-- HTML: **text** -> <b>text</b>, *text* -> <i>text</i>, etc.
+local function format_html(s)
+  -- Headings: # Heading -> <b>Heading</b>
+  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+    heading = heading:gsub("%*%*(.-)%*%*", "%1")
+    return nl .. "<b>" .. heading .. "</b>"
+  end)
+  if s:sub(1, 1) == "#" then
+    s = s:gsub("^#+%s+([^\n]+)", function(heading)
+      heading = heading:gsub("%*%*(.-)%*%*", "%1")
+      return "<b>" .. heading .. "</b>"
+    end)
+  end
+  -- Bold: **text** -> <b>text</b>
+  s = s:gsub("%*%*(.-)%*%*", "<b>%1</b>")
+  -- Italic: *text* -> <i>text</i>
+  s = s:gsub("%*(.-)%*", "<i>%1</i>")
+  return s
+end
+
+-- Telegram: same as HTML (Telegram supports <b>, <i>, <code>, <pre>)
+local function format_telegram(s)
+  return format_html(s)
+end
+
+-- Main entry point called by OpenTalon's response formatter pipeline.
+-- text: the LLM response
+-- response_format: channel format string ("slack", "teams", "text", etc.)
+function format(text, response_format)
+  if not text or text == "" then
+    return text
+  end
+
+  if response_format == "slack" then
+    return apply_transform(text, format_slack)
+  elseif response_format == "teams" then
+    return apply_transform(text, format_teams)
+  elseif response_format == "whatsapp" then
+    return apply_transform(text, format_whatsapp)
+  elseif response_format == "text" then
+    -- For plain text, also strip code delimiters from protected segments
+    local segments = split_segments(text)
+    local parts = {}
+    for _, seg in ipairs(segments) do
+      if seg.protected then
+        -- Strip fences and backticks but keep content
+        local inner = seg.text
+        inner = inner:gsub("^```[^\n]*\n?", "")
+        inner = inner:gsub("\n?```$", "")
+        inner = inner:gsub("^`", "")
+        inner = inner:gsub("`$", "")
+        table.insert(parts, inner)
+      else
+        table.insert(parts, format_text(seg.text))
+      end
+    end
+    return table.concat(parts)
+  elseif response_format == "html" then
+    return apply_transform(text, format_html)
+  elseif response_format == "telegram" then
+    return apply_transform(text, format_telegram)
+  else
+    -- markdown, discord, empty: no-op
+    return text
+  end
+end

--- a/scripts/format-response.lua
+++ b/scripts/format-response.lua
@@ -96,21 +96,23 @@ end
 
 -- Slack mrkdwn: **bold** -> *bold*, ## Heading -> *Heading*
 local function format_slack(s)
-  -- Headings: # ... or ## ... -> *...*
-  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
-    -- Strip any bold markers from heading text
+  -- Headings: # ... or ## ... -> *...* (placeholder to protect from italic pass)
+  s = s:gsub("(\n)#+%s+([^\n]+)", function(nl, heading)
     heading = heading:gsub("%*%*(.-)%*%*", "%1")
-    return nl .. "*" .. heading .. "*"
+    return nl .. "\0HEAD\0" .. heading .. "\0HEAD\0"
   end)
-  -- Handle heading at start of string (no preceding newline)
   if s:sub(1, 1) == "#" then
     s = s:gsub("^#+%s+([^\n]+)", function(heading)
       heading = heading:gsub("%*%*(.-)%*%*", "%1")
-      return "*" .. heading .. "*"
+      return "\0HEAD\0" .. heading .. "\0HEAD\0"
     end)
   end
-  -- Bold: **text** -> *text* (non-greedy)
-  s = s:gsub("%*%*(.-)%*%*", "*%1*")
+  -- Italic: *text* -> _text_ (Slack italic is _text_, not *text*)
+  -- Protect **bold** first, convert *italic*, then restore bold and headings.
+  s = s:gsub("%*%*(.-)%*%*", "\0BOLD\0%1\0BOLD\0")
+  s = s:gsub("%*(.-)%*", "_%1_")
+  s = s:gsub("\0BOLD\0(.-)\0BOLD\0", "*%1*")
+  s = s:gsub("\0HEAD\0(.-)\0HEAD\0", "*%1*")
   -- Bold underscore: __text__ -> _text_
   s = s:gsub("__(.-)__", "_%1_")
   return s
@@ -118,7 +120,7 @@ end
 
 -- Teams: ## Heading -> **Heading** (Teams renders bold but not # headings well)
 local function format_teams(s)
-  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+  s = s:gsub("(\n)#+%s+([^\n]+)", function(nl, heading)
     heading = heading:gsub("%*%*(.-)%*%*", "%1")
     return nl .. "**" .. heading .. "**"
   end)
@@ -134,7 +136,7 @@ end
 -- WhatsApp: **text** -> *text*, ## Heading -> *Heading*
 local function format_whatsapp(s)
   -- Headings
-  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+  s = s:gsub("(\n)#+%s+([^\n]+)", function(nl, heading)
     heading = heading:gsub("%*%*(.-)%*%*", "%1")
     return nl .. "*" .. heading .. "*"
   end)
@@ -152,7 +154,7 @@ end
 -- Plain text: strip all formatting
 local function format_text(s)
   -- Headings
-  s = s:gsub("(\n?)#+%s+([^\n]+)", "%1%2")
+  s = s:gsub("(\n)#+%s+([^\n]+)", "%1%2")
   if s:sub(1, 1) == "#" then
     s = s:gsub("^#+%s+([^\n]+)", "%1")
   end
@@ -173,7 +175,7 @@ end
 -- HTML: **text** -> <b>text</b>, *text* -> <i>text</i>, etc.
 local function format_html(s)
   -- Headings: # Heading -> <b>Heading</b>
-  s = s:gsub("(\n?)#+%s+([^\n]+)", function(nl, heading)
+  s = s:gsub("(\n)#+%s+([^\n]+)", function(nl, heading)
     heading = heading:gsub("%*%*(.-)%*%*", "%1")
     return nl .. "<b>" .. heading .. "</b>"
   end)


### PR DESCRIPTION
Add a response_formatters hook symmetric with content_preparers that runs after the LLM response. Supports gRPC plugins and Lua scripts. Ships a built-in Lua formatter (scripts/format-response.lua) that converts standard Markdown to Slack mrkdwn, Teams, WhatsApp, HTML, Telegram, and plain text — fixing output from cheap models that ignore format hints.