### PR TITLE
feat(metrics): expose entity_id label on LLM/orchestrator metrics

### DIFF
--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -20,11 +20,11 @@ When enabled, OpenTalon starts an HTTP server on the configured address. Prometh
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `opentalon_llm_input_tokens_total` | Counter | `model`, `channel`, `group` | Total input (prompt) tokens sent to the LLM |
-| `opentalon_llm_output_tokens_total` | Counter | `model`, `channel`, `group` | Total output (completion) tokens received from the LLM |
-| `opentalon_llm_input_cost_usd_total` | Counter | `model`, `channel`, `group` | Total input spend in USD |
-| `opentalon_llm_output_cost_usd_total` | Counter | `model`, `channel`, `group` | Total output spend in USD |
-| `opentalon_orchestrator_runs_total` | Counter | `model`, `channel`, `group` | Total completed orchestrator runs |
+| `opentalon_llm_input_tokens_total` | Counter | `model`, `channel`, `group`, `entity_id` | Total input (prompt) tokens sent to the LLM |
+| `opentalon_llm_output_tokens_total` | Counter | `model`, `channel`, `group`, `entity_id` | Total output (completion) tokens received from the LLM |
+| `opentalon_llm_input_cost_usd_total` | Counter | `model`, `channel`, `group`, `entity_id` | Total input spend in USD |
+| `opentalon_llm_output_cost_usd_total` | Counter | `model`, `channel`, `group`, `entity_id` | Total output spend in USD |
+| `opentalon_orchestrator_runs_total` | Counter | `model`, `channel`, `group`, `entity_id` | Total completed orchestrator runs |
 | `opentalon_plugin_calls_total` | Counter | `plugin`, `action`, `status` | Total plugin/tool calls; `status` is `success` or `error` |
 | `opentalon_plugin_input_tokens_total` | Counter | `plugin`, `action` | LLM input tokens attributed to each plugin/tool call |
 | `opentalon_plugin_output_tokens_total` | Counter | `plugin`, `action` | LLM output tokens attributed to each plugin/tool call |
@@ -32,6 +32,15 @@ When enabled, OpenTalon starts an HTTP server on the configured address. Prometh
 Standard Go runtime and process metrics (`go_*`, `process_*`) are also exposed.
 
 > **Note:** Cost metrics are only non-zero when model `cost.input` / `cost.output` pricing is configured in `models.providers.<id>.models[*].cost`. Zero-cost (free-tier) models still emit the series with a value of `0`.
+
+### Label semantics
+
+- `model` — the LLM model that served the run (e.g. `gpt-oss-120b`).
+- `channel` — the channel plugin that initiated the run (e.g. `slack`, `msteams`, `console`, `websocket`).
+- `group` — the channel-scoped group identifier (e.g. Slack team/workspace ID). Stable per tenant.
+- `entity_id` — the channel-scoped actor identifier (e.g. the Slack user ID that sent the message). Use this to attribute spend to individual users. Empty for runs without a resolved actor.
+
+> **Cardinality:** `entity_id` adds one series per unique user. For deployments with a bounded user base this is fine; for public-facing deployments with unbounded users, consider dropping the label via `metric_relabel_configs` in your Prometheus scrape config.
 
 ## Prometheus sidecar / Docker Compose example
 

--- a/internal/metrics/collector.go
+++ b/internal/metrics/collector.go
@@ -37,27 +37,27 @@ func New() *Collector {
 		llmInputTokens: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_llm_input_tokens_total",
 			Help: "Total LLM input tokens consumed.",
-		}, []string{"model", "channel", "group"}),
+		}, []string{"model", "channel", "group", "entity_id"}),
 
 		llmOutputTokens: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_llm_output_tokens_total",
 			Help: "Total LLM output tokens produced.",
-		}, []string{"model", "channel", "group"}),
+		}, []string{"model", "channel", "group", "entity_id"}),
 
 		llmInputCostUSD: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_llm_input_cost_usd_total",
 			Help: "Total LLM input spend in USD.",
-		}, []string{"model", "channel", "group"}),
+		}, []string{"model", "channel", "group", "entity_id"}),
 
 		llmOutputCostUSD: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_llm_output_cost_usd_total",
 			Help: "Total LLM output spend in USD.",
-		}, []string{"model", "channel", "group"}),
+		}, []string{"model", "channel", "group", "entity_id"}),
 
 		orchestratorRuns: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_orchestrator_runs_total",
 			Help: "Total completed orchestrator runs.",
-		}, []string{"model", "channel", "group"}),
+		}, []string{"model", "channel", "group", "entity_id"}),
 
 		pluginCalls: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "opentalon_plugin_calls_total",
@@ -90,11 +90,12 @@ func New() *Collector {
 }
 
 // RecordUsage implements orchestrator.UsageRecorder.
-func (c *Collector) RecordUsage(_ context.Context, _, groupID, channelID, _, modelID string, inputTokens, outputTokens, _ int, inputCostUSD, outputCostUSD float64) {
+func (c *Collector) RecordUsage(_ context.Context, entityID, groupID, channelID, _, modelID string, inputTokens, outputTokens, _ int, inputCostUSD, outputCostUSD float64) {
 	labels := prometheus.Labels{
-		"model":   modelID,
-		"channel": channelID,
-		"group":   groupID,
+		"model":     modelID,
+		"channel":   channelID,
+		"group":     groupID,
+		"entity_id": entityID,
 	}
 	c.llmInputTokens.With(labels).Add(float64(inputTokens))
 	c.llmOutputTokens.With(labels).Add(float64(outputTokens))

--- a/internal/metrics/collector_test.go
+++ b/internal/metrics/collector_test.go
@@ -35,7 +35,7 @@ func TestRecordUsageSingleCall(t *testing.T) {
 	c := New()
 	c.RecordUsage(context.Background(), "entity1", "g1", "ch1", "sess1", "m1", 100, 50, 3, 0.01, 0.02)
 
-	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1"}
+	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1", "entity_id": "entity1"}
 	if got := testutil.ToFloat64(c.llmInputTokens.With(labels)); got != 100 {
 		t.Errorf("inputTokens = %v, want 100", got)
 	}
@@ -58,7 +58,7 @@ func TestRecordUsageAccumulates(t *testing.T) {
 	c.RecordUsage(context.Background(), "e", "g1", "ch1", "s", "m1", 100, 50, 1, 0.0, 0.0)
 	c.RecordUsage(context.Background(), "e", "g1", "ch1", "s", "m1", 200, 80, 2, 0.0, 0.0)
 
-	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1"}
+	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1", "entity_id": "e"}
 	if got := testutil.ToFloat64(c.llmInputTokens.With(labels)); got != 300 {
 		t.Errorf("inputTokens = %v, want 300", got)
 	}
@@ -84,7 +84,7 @@ func TestRecordUsagePartialCost(t *testing.T) {
 	c := New()
 	c.RecordUsage(context.Background(), "e", "g1", "ch1", "s", "m1", 10, 5, 0, 0.05, 0.0)
 
-	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1"}
+	labels := prometheus.Labels{"model": "m1", "channel": "ch1", "group": "g1", "entity_id": "e"}
 	if got := testutil.ToFloat64(c.llmInputCostUSD.With(labels)); got != 0.05 {
 		t.Errorf("inputCost = %v, want 0.05", got)
 	}
@@ -176,7 +176,7 @@ func TestCollectAndCompareAfterUsage(t *testing.T) {
 	expected := `
 		# HELP opentalon_orchestrator_runs_total Total completed orchestrator runs.
 		# TYPE opentalon_orchestrator_runs_total counter
-		opentalon_orchestrator_runs_total{channel="ch1",group="g1",model="m1"} 1
+		opentalon_orchestrator_runs_total{channel="ch1",entity_id="entity1",group="g1",model="m1"} 1
 	`
 	if err := testutil.GatherAndCompare(c.reg, strings.NewReader(expected), "opentalon_orchestrator_runs_total"); err != nil {
 		t.Errorf("metric mismatch: %v", err)


### PR DESCRIPTION
## Summary

The orchestrator already passes `entityID` to `UsageRecorder.RecordUsage`
(see `internal/orchestrator/orchestrator.go:626`), but the Prometheus
collector currently discards it. This means LLM spend and usage cannot
be attributed to individual actors (e.g. the Slack user ID that sent
the message).

This PR adds `entity_id` as a fourth label on the five LLM/orchestrator
counter vectors:

- `opentalon_llm_input_tokens_total`
- `opentalon_llm_output_tokens_total`
- `opentalon_llm_input_cost_usd_total`
- `opentalon_llm_output_cost_usd_total`
- `opentalon_orchestrator_runs_total`

`sessionID` remains discarded — session IDs rotate frequently and would
blow up Prometheus cardinality; session-level attribution is better
served by tracing.

## Compatibility

The new label is **appended** at the end of the label set, so existing
Prometheus queries that `sum()` across labels or filter by
`{model, channel, group}` keep working unchanged. Dashboards need no
updates unless operators want to add the new dimension.

## Cardinality note

For deployments with a bounded user base (internal Slack workspaces,
enterprise tenants) the label is safe. Operators running OpenTalon
against public channels with unbounded users can drop the label via
Prometheus `metric_relabel_configs`. This is now documented in
`docs/prometheus-metrics.md`.

## Test plan

- [x] `go test ./internal/metrics/...` — all green
- [x] `go build ./...` — all green
- [x] `go test ./...` — full suite green