### PR TITLE
feat(orchestrator): add knowledge-augmented RAG core support (#97)

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -454,6 +454,12 @@ func main() {
 
 	// Sync plugin capabilities to the vector store and ingest knowledge articles
 	// from the configured directory. Both are fire-and-forget at startup.
+	//
+	// These calls use guard.ExecuteWithTimeout directly (not executeCall) because
+	// there is no actor/session at startup. This intentionally skips permission
+	// checks, audit logging, arg validation, and plugin-allowed filtering.
+	// If the sync or ingest plugin ever declares AuditLog=true, those calls
+	// will not be logged — acceptable for host-initiated startup work.
 	go func() {
 		orch.SyncActions(ctx)
 		orch.IngestKnowledgeDir(ctx)

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -443,7 +443,21 @@ func main() {
 		GroupPluginLookup:       groupPluginStore,
 		UsageRecorder:           usageRecorder,
 		PluginCallObserver:      pluginObserver,
+		SyncActionsPlugin:       cfg.Orchestrator.Knowledge.SyncPlugin,
+		SyncActionsAction:       cfg.Orchestrator.Knowledge.SyncAction,
+		Knowledge: orchestrator.KnowledgeConfig{
+			Plugin: cfg.Orchestrator.Knowledge.Plugin,
+			Action: cfg.Orchestrator.Knowledge.Action,
+			Dir:    cfg.Orchestrator.Knowledge.Dir,
+		},
 	})
+
+	// Sync plugin capabilities to the vector store and ingest knowledge articles
+	// from the configured directory. Both are fire-and-forget at startup.
+	go func() {
+		orch.SyncActions(ctx)
+		orch.IngestKnowledgeDir(ctx)
+	}()
 
 	// Scheduler: wired after orchestrator so it can route job actions through orch.
 	// Personal reminders bypass the approver policy via AddPersonalJob.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,6 +70,17 @@ orchestrator:
   #   enabled: true
   #   max_step_retries: 3    # retries per step before giving up (default 3)
   #   step_timeout: "60s"    # per-step timeout as Go duration (default "60s")
+  # Knowledge-augmented RAG: sync plugin actions to vector store on startup and
+  # optionally ingest markdown files from a directory. Articles can also arrive
+  # via the weaviate plugin's HTTP API (POST /api/v1/articles).
+  # The prepare action (configured as a content_preparer above) returns relevant_tools
+  # to filter the system prompt to only the tools the query needs.
+  # knowledge:
+  #   sync_plugin: weaviate        # plugin that has sync_actions action
+  #   sync_action: sync_actions    # action name for capability sync
+  #   plugin: weaviate             # plugin for knowledge article ingestion
+  #   action: ingest               # action name for single-article ingestion
+  #   dir: ./knowledge             # optional: scan .md files at startup
 
 channels:
   console:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,6 +75,8 @@ orchestrator:
   # via the weaviate plugin's HTTP API (POST /api/v1/articles).
   # The prepare action (configured as a content_preparer above) returns relevant_tools
   # to filter the system prompt to only the tools the query needs.
+  # NOTE: If multiple content_preparers return relevant_tools, the last one wins.
+  # Place the RAG preparer last in the content_preparers list to control precedence.
   # knowledge:
   #   sync_plugin: weaviate        # plugin that has sync_actions action
   #   sync_action: sync_actions    # action name for capability sync

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,6 +290,16 @@ type ResponseFormatterEntry struct {
 	FailOpen *bool  `yaml:"fail_open,omitempty"` // pointer; defaults to true when nil (don't block responses on formatter failure)
 }
 
+// KnowledgeConfig configures knowledge-augmented RAG: startup action sync and
+// optional knowledge directory scanning.
+type KnowledgeConfig struct {
+	SyncPlugin string `yaml:"sync_plugin"` // plugin name for action sync (e.g. "weaviate")
+	SyncAction string `yaml:"sync_action"` // action name for sync (e.g. "sync_actions")
+	Plugin     string `yaml:"plugin"`      // plugin name for knowledge ingestion (e.g. "weaviate")
+	Action     string `yaml:"action"`      // action name for single-article ingestion (e.g. "ingest")
+	Dir        string `yaml:"dir"`         // optional directory of .md files to ingest at startup
+}
+
 type OrchestratorConfig struct {
 	Rules                 []string                   `yaml:"rules"`
 	ContentPreparers      []ContentPreparerEntry     `yaml:"content_preparers,omitempty"`
@@ -297,6 +307,7 @@ type OrchestratorConfig struct {
 	PermissionPlugin      string                     `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
 	MaxConcurrentSessions int                        `yaml:"max_concurrent_sessions,omitempty"` // max sessions running in parallel (default 1 = sequential)
 	Pipeline              PipelineOrchestratorConfig `yaml:"pipeline,omitempty"`
+	Knowledge             KnowledgeConfig            `yaml:"knowledge,omitempty"` // knowledge-augmented RAG configuration
 }
 
 // PipelineOrchestratorConfig enables structured multi-step pipeline execution.
@@ -464,6 +475,9 @@ func Parse(data []byte) (*Config, error) {
 	}
 	if cfg.Log.Level != "" {
 		cfg.Log.Level = expandEnv(cfg.Log.Level)
+	}
+	if cfg.Orchestrator.Knowledge.Dir != "" {
+		cfg.Orchestrator.Knowledge.Dir = expandTilde(expandEnv(cfg.Orchestrator.Knowledge.Dir))
 	}
 	if cfg.Lua != nil {
 		if cfg.Lua.ScriptsDir != "" {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -87,6 +87,13 @@ type PluginCallObserver interface {
 	ObservePluginCall(plugin, action string, failed bool, inputTokens, outputTokens int)
 }
 
+// KnowledgeConfig configures the knowledge directory scanning feature.
+type KnowledgeConfig struct {
+	Plugin string // plugin name to call for ingestion (e.g. "weaviate")
+	Action string // action name for single-article ingestion (e.g. "ingest")
+	Dir    string // directory to scan for .md files
+}
+
 // OrchestratorOpts holds optional configuration for NewWithRules. Zero values mean defaults (no permission check, no summarization).
 type OrchestratorOpts struct {
 	CustomRules             []string
@@ -108,6 +115,9 @@ type OrchestratorOpts struct {
 	GroupPluginLookup       GroupPluginLookup  // optional; when set, filters tool list by profile group
 	UsageRecorder           UsageRecorder      // optional; when set, records LLM usage after each run
 	PluginCallObserver      PluginCallObserver // optional; when set, notified after each plugin/tool call
+	SyncActionsPlugin       string             // optional; plugin name for action sync (e.g. "weaviate")
+	SyncActionsAction       string             // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
+	Knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -163,6 +173,9 @@ type Orchestrator struct {
 	groupPluginLookup       GroupPluginLookup  // optional; nil = no group-based filtering
 	usageRecorder           UsageRecorder      // optional; nil = no usage tracking
 	pluginCallObserver      PluginCallObserver // optional; nil = no plugin call observation
+	syncActionsPlugin       string             // optional; plugin name for action sync
+	syncActionsAction       string             // optional; action name for action sync
+	knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
 }
 
 const (
@@ -170,11 +183,28 @@ const (
 	defaultSummarizeUpdatePrompt = "Update the given conversation summary with the following new exchange. Keep the result to a short paragraph."
 )
 
+// resolveAllowedPluginNames returns a JSON array of allowed plugin names for the
+// current profile, or "" when unrestricted. Used to inject allowed_plugins into
+// preparer and LLM-called actions so RAG plugins can filter by profile.
+func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
+	allowed := o.resolveAllowedPlugins(ctx)
+	if allowed.m == nil {
+		return ""
+	}
+	names := mapKeys(allowed.m)
+	sort.Strings(names)
+	b, _ := json.Marshal(names)
+	return string(b)
+}
+
 // defaultContextArgProviders returns built-in providers only for opaque identifiers (e.g. session_id).
 // No session messages, conversation text, or other sensitive content is exposed to plugins via this mechanism.
-func defaultContextArgProviders(custom map[string]ContextArgProvider) map[string]ContextArgProvider {
+func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgProvider) map[string]ContextArgProvider {
 	builtin := map[string]ContextArgProvider{
 		"session_id": func(ctx context.Context, _ string) string { return actor.SessionID(ctx) },
+		"allowed_plugins": func(ctx context.Context, _ string) string {
+			return resolveAllowedPluginNames(ctx, o)
+		},
 	}
 	if len(custom) == 0 {
 		return builtin
@@ -236,7 +266,7 @@ func NewWithRules(
 	// Always create a semaphore. cap=1 = sequential (default); cap=N = N parallel sessions.
 	semaphore := make(chan struct{}, maxConcurrent)
 
-	return &Orchestrator{
+	o := &Orchestrator{
 		sessionMuxes:            make(map[string]*sessionMutex),
 		semaphore:               semaphore,
 		llm:                     llm,
@@ -253,7 +283,6 @@ func NewWithRules(
 		permissionChecker:       opts.PermissionChecker,
 		permissionPluginName:    opts.PermissionPluginName,
 		runtimePromptPath:       opts.RuntimePromptPath,
-		contextArgProviders:     defaultContextArgProviders(opts.ContextArgProviders),
 		summarizeAfterMessages:  opts.SummarizeAfterMessages,
 		maxMessagesAfterSummary: opts.MaxMessagesAfterSummary,
 		summarizePrompt:         opts.SummarizePrompt,
@@ -265,7 +294,13 @@ func NewWithRules(
 		groupPluginLookup:       opts.GroupPluginLookup,
 		usageRecorder:           opts.UsageRecorder,
 		pluginCallObserver:      opts.PluginCallObserver,
+		syncActionsPlugin:       opts.SyncActionsPlugin,
+		syncActionsAction:       opts.SyncActionsAction,
+		knowledge:               opts.Knowledge,
 	}
+	// Context arg providers need access to 'o' for allowed_plugins resolution.
+	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)
+	return o
 }
 
 type RunResult struct {
@@ -301,9 +336,10 @@ func (s *invokeStepsUnmarshal) UnmarshalJSON(data []byte) error {
 
 // preparerResponse is the optional JSON shape from a content preparer (guard or invoke).
 type preparerResponse struct {
-	SendToLLM *bool                `json:"send_to_llm"`
-	Message   string               `json:"message"`
-	Invoke    invokeStepsUnmarshal `json:"invoke"`
+	SendToLLM     *bool                `json:"send_to_llm"`
+	Message       string               `json:"message"`
+	Invoke        invokeStepsUnmarshal `json:"invoke"`
+	RelevantTools []string             `json:"relevant_tools,omitempty"` // optional: filter system prompt to these tools (format: "plugin.action")
 }
 
 func (o *Orchestrator) handlePreparerFailure(prep ContentPreparerEntry, details string) *RunResult {
@@ -318,22 +354,24 @@ func (o *Orchestrator) handlePreparerFailure(prep ContentPreparerEntry, details 
 	return &RunResult{Response: fmt.Sprintf("Request blocked: guard %s failed.", name)}
 }
 
-func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPreparerEntry, content, callPrefix string, allowInvoke bool) (string, *RunResult, error) {
+// runSinglePreparer executes one content preparer. Returns (new content, blocked result, relevant tools, error).
+// relevantTools is non-nil only when the preparer explicitly returns a relevant_tools list.
+func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPreparerEntry, content, callPrefix string, allowInvoke bool) (string, *RunResult, []string, error) {
 	if strings.HasPrefix(prep.Plugin, "lua:") {
 		scriptName := strings.TrimPrefix(prep.Plugin, "lua:")
 		scriptPath := o.luaScriptPaths[scriptName]
 		if scriptPath == "" {
 			if blocked := o.handlePreparerFailure(prep, "Lua script path not found"); blocked != nil {
-				return content, blocked, nil
+				return content, blocked, nil, nil
 			}
-			return content, nil, nil
+			return content, nil, nil, nil
 		}
 		result, err := lua.RunPrepare(scriptPath, content)
 		if err != nil {
 			if blocked := o.handlePreparerFailure(prep, err.Error()); blocked != nil {
-				return content, blocked, nil
+				return content, blocked, nil, nil
 			}
-			return content, nil, nil
+			return content, nil, nil, nil
 		}
 		if !result.SendToLLM {
 			if allowInvoke && len(result.InvokeSteps) > 0 {
@@ -342,15 +380,15 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 					steps[i] = InvokeStep{Plugin: s.Plugin, Action: s.Action, Args: s.Args}
 				}
 				invokeResult, err := o.runInvokeSteps(ctx, steps)
-				return "", invokeResult, err
+				return "", invokeResult, nil, err
 			}
 			msg := result.Content
 			if msg == "" {
 				msg = "Request blocked by guard."
 			}
-			return "", &RunResult{Response: msg}, nil
+			return "", &RunResult{Response: msg}, nil, nil
 		}
-		return result.Content, nil, nil
+		return result.Content, nil, nil, nil
 	}
 
 	argKey := prep.ArgKey
@@ -359,9 +397,9 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 	}
 	if !o.registry.HasAction(prep.Plugin, prep.Action) {
 		if blocked := o.handlePreparerFailure(prep, "action not found"); blocked != nil {
-			return content, blocked, nil
+			return content, blocked, nil, nil
 		}
-		return content, nil, nil
+		return content, nil, nil, nil
 	}
 	call := ToolCall{
 		ID:     fmt.Sprintf("%s-%s-%s", callPrefix, prep.Plugin, prep.Action),
@@ -369,22 +407,26 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 		Action: prep.Action,
 		Args:   map[string]string{argKey: content},
 	}
+	// Inject allowed_plugins for preparers so RAG plugins can filter by profile.
+	if allowed := resolveAllowedPluginNames(ctx, o); allowed != "" {
+		call.Args["allowed_plugins"] = allowed
+	}
 	toolResult := o.executeCall(ctx, call)
 	if toolResult.Error != "" {
 		if blocked := o.handlePreparerFailure(prep, toolResult.Error); blocked != nil {
-			return content, blocked, nil
+			return content, blocked, nil, nil
 		}
-		return content, nil, nil
+		return content, nil, nil, nil
 	}
 	var pr preparerResponse
 	if err := json.Unmarshal([]byte(toolResult.Content), &pr); err == nil && pr.SendToLLM != nil && !*pr.SendToLLM {
 		if allowInvoke && len(pr.Invoke) > 0 {
 			if prep.Insecure {
 				slog.Warn("insecure preparer cannot run invoke, ignoring", "plugin", prep.Plugin, "action", prep.Action)
-				return content, nil, nil
+				return content, nil, nil, nil
 			}
 			invokeResult, err := o.runInvokeSteps(ctx, pr.Invoke)
-			return "", invokeResult, err
+			return "", invokeResult, nil, err
 		}
 		msg := pr.Message
 		if msg == "" {
@@ -393,12 +435,12 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 		if msg == "" {
 			msg = "Request blocked by guard."
 		}
-		return "", &RunResult{Response: msg}, nil
+		return "", &RunResult{Response: msg}, nil, nil
 	}
 	if pr.Message != "" {
-		return pr.Message, nil, nil
+		return pr.Message, nil, pr.RelevantTools, nil
 	}
-	return toolResult.Content, nil, nil
+	return toolResult.Content, nil, pr.RelevantTools, nil
 }
 
 // formatResponse runs all configured response formatters on result.Response.
@@ -549,8 +591,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 
 	content := userMessage
 	// Run content preparers before the first LLM call (config-driven).
+	var relevantTools []string
 	for _, prep := range o.preparers {
-		guardedContent, blocked, err := o.runSinglePreparer(ctx, prep, content, "preparer", true)
+		guardedContent, blocked, tools, err := o.runSinglePreparer(ctx, prep, content, "preparer", true)
 		if err != nil {
 			return nil, err
 		}
@@ -558,6 +601,14 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			return blocked, nil
 		}
 		content = guardedContent
+		// Last preparer that returns relevant_tools wins.
+		if len(tools) > 0 {
+			relevantTools = tools
+		}
+	}
+	// Store relevant tools in context so buildSystemPrompt can filter.
+	if len(relevantTools) > 0 {
+		ctx = withRelevantTools(ctx, relevantTools)
 	}
 
 	// Block B: Run planner to check if this requires a multi-step pipeline.
@@ -784,7 +835,7 @@ func (o *Orchestrator) runGuardPlugins(ctx context.Context, messages []provider.
 	original := messages[lastIdx].Content
 	content := original
 	for _, g := range o.guards {
-		nextContent, blocked, err := o.runSinglePreparer(ctx, g, content, "guard", false)
+		nextContent, blocked, _, err := o.runSinglePreparer(ctx, g, content, "guard", false)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -986,6 +1037,15 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 	// Resolve the set of plugins allowed for the current profile group (if any).
 	allowedPlugins := o.resolveAllowedPlugins(ctx)
 
+	// Build a set of relevant tools from the preparer (RAG) for filtering.
+	// When non-empty, only tools in this set (format "plugin.action") are shown.
+	relevantToolSet := make(map[string]bool)
+	if rt := relevantToolsFromContext(ctx); len(rt) > 0 {
+		for _, t := range rt {
+			relevantToolSet[t] = true
+		}
+	}
+
 	caps := o.registry.ListCapabilities()
 	for _, cap := range caps {
 		if !o.pluginAllowed(cap, allowedPlugins) {
@@ -998,11 +1058,25 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 			continue
 		}
 		slog.Debug("plugin included in system prompt", "plugin", cap.Name)
-		fmt.Fprintf(&sb, "## %s\n%s\n", cap.Name, cap.Description)
+
+		// When relevantToolSet is populated, filter actions to only include relevant ones.
+		var visibleActions []Action
 		for _, action := range cap.Actions {
 			if preparerAction[cap.Name+"."+action.Name] || action.UserOnly {
 				continue
 			}
+			if len(relevantToolSet) > 0 && !relevantToolSet[cap.Name+"."+action.Name] {
+				continue
+			}
+			visibleActions = append(visibleActions, action)
+		}
+		// Skip plugin header entirely if no actions are visible after filtering.
+		if len(visibleActions) == 0 && cap.SystemPromptAddition == "" {
+			continue
+		}
+
+		fmt.Fprintf(&sb, "## %s\n%s\n", cap.Name, cap.Description)
+		for _, action := range visibleActions {
 			fmt.Fprintf(&sb, "- %s.%s: %s\n", cap.Name, action.Name, action.Description)
 			for _, p := range action.Parameters {
 				req := ""
@@ -1467,6 +1541,21 @@ func formatToolResultMessage(result ToolResult) string {
 	return fmt.Sprintf("[tool_result] %s", result.Content)
 }
 
+// relevantToolsKey is the context key for tool filtering from preparer responses.
+type relevantToolsKey struct{}
+
+// withRelevantTools stores the relevant tool list from a preparer response in ctx.
+// An empty or nil slice means "no filtering" (show all tools).
+func withRelevantTools(ctx context.Context, tools []string) context.Context {
+	return context.WithValue(ctx, relevantToolsKey{}, tools)
+}
+
+// relevantToolsFromContext returns the relevant tool list, or nil if not set.
+func relevantToolsFromContext(ctx context.Context) []string {
+	tools, _ := ctx.Value(relevantToolsKey{}).([]string)
+	return tools
+}
+
 // allowedPluginsKey is the context key for the per-Run allowed-plugin cache.
 type allowedPluginsKey struct{}
 
@@ -1656,6 +1745,146 @@ func (p *permissionCheckerImpl) Allowed(ctx context.Context, actorID, plugin str
 		return false, nil // deny on error
 	}
 	return parsePermissionResult(result.Content), nil
+}
+
+// syncActionEntry mirrors the weaviate-plugin's expected JSON shape for one action.
+type syncActionEntry struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description"`
+	Parameters  []Parameter `json:"parameters"`
+}
+
+// syncActionsPayload is the JSON shape expected by the sync_actions action.
+type syncActionsPayload struct {
+	PluginName string            `json:"plugin_name"`
+	Actions    []syncActionEntry `json:"actions"`
+}
+
+// SyncActions iterates all registered plugin capabilities and calls the configured
+// sync_actions plugin to upsert them into the vector store. This enables retrieval-based
+// tool filtering by the RAG preparer. Safe to call at startup; errors are logged, not returned.
+func (o *Orchestrator) SyncActions(ctx context.Context) {
+	if o.syncActionsPlugin == "" || o.syncActionsAction == "" {
+		return
+	}
+	if !o.registry.HasAction(o.syncActionsPlugin, o.syncActionsAction) {
+		slog.Warn("sync_actions target not found", "plugin", o.syncActionsPlugin, "action", o.syncActionsAction)
+		return
+	}
+
+	caps := o.registry.ListCapabilities()
+	for _, cap := range caps {
+		// Don't sync the sync plugin itself.
+		if cap.Name == o.syncActionsPlugin {
+			continue
+		}
+		entries := make([]syncActionEntry, 0, len(cap.Actions))
+		for _, a := range cap.Actions {
+			if a.UserOnly {
+				continue
+			}
+			entries = append(entries, syncActionEntry{
+				Name:        a.Name,
+				Description: a.Description,
+				Parameters:  a.Parameters,
+			})
+		}
+		if len(entries) == 0 {
+			continue
+		}
+		payload := syncActionsPayload{PluginName: cap.Name, Actions: entries}
+		b, err := json.Marshal(payload)
+		if err != nil {
+			slog.Warn("sync_actions marshal failed", "plugin", cap.Name, "error", err)
+			continue
+		}
+		call := ToolCall{
+			ID:     fmt.Sprintf("sync-%s", cap.Name),
+			Plugin: o.syncActionsPlugin,
+			Action: o.syncActionsAction,
+			Args:   map[string]string{"payload": string(b)},
+		}
+		result := o.guard.ExecuteWithTimeout(ctx, mustGetExec(o.registry, o.syncActionsPlugin), call)
+		if result.Error != "" {
+			slog.Warn("sync_actions failed", "plugin", cap.Name, "error", result.Error)
+		} else {
+			slog.Info("sync_actions done", "plugin", cap.Name, "actions", len(entries))
+		}
+	}
+}
+
+// IngestKnowledgeDir scans the configured knowledge directory for .md files and
+// ingests each one via the configured plugin action. The directory is optional —
+// knowledge articles can also be submitted via the plugin's HTTP API. Idempotent;
+// errors are logged, not returned.
+func (o *Orchestrator) IngestKnowledgeDir(ctx context.Context) {
+	k := o.knowledge
+	if k.Plugin == "" || k.Action == "" {
+		return
+	}
+	// Dir is optional — articles may arrive exclusively via HTTP API.
+	if k.Dir == "" {
+		return
+	}
+	if !o.registry.HasAction(k.Plugin, k.Action) {
+		slog.Warn("knowledge ingest target not found", "plugin", k.Plugin, "action", k.Action)
+		return
+	}
+
+	entries, err := os.ReadDir(k.Dir)
+	if err != nil {
+		slog.Warn("knowledge dir scan failed", "dir", k.Dir, "error", err)
+		return
+	}
+
+	exec, ok := o.registry.GetExecutor(k.Plugin)
+	if !ok {
+		slog.Warn("knowledge ingest executor not found", "plugin", k.Plugin)
+		return
+	}
+
+	var count int
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := k.Dir + "/" + e.Name()
+		data, err := os.ReadFile(path)
+		if err != nil {
+			slog.Warn("knowledge file read failed", "path", path, "error", err)
+			continue
+		}
+		title := strings.TrimSuffix(e.Name(), ".md")
+		call := ToolCall{
+			ID:     fmt.Sprintf("knowledge-ingest-%s", title),
+			Plugin: k.Plugin,
+			Action: k.Action,
+			Args: map[string]string{
+				"title":   title,
+				"content": string(data),
+				"source":  "knowledge_dir",
+			},
+		}
+		result := o.guard.ExecuteWithTimeout(ctx, exec, call)
+		if result.Error != "" {
+			slog.Warn("knowledge ingest failed", "file", e.Name(), "error", result.Error)
+		} else {
+			count++
+		}
+	}
+	if count > 0 {
+		slog.Info("knowledge dir ingested", "dir", k.Dir, "files", count)
+	}
+}
+
+// mustGetExec returns the executor for a plugin or panics. Only used for
+// plugins whose existence was verified before the call.
+func mustGetExec(reg *ToolRegistry, name string) PluginExecutor {
+	exec, ok := reg.GetExecutor(name)
+	if !ok {
+		panic("executor not found for verified plugin: " + name)
+	}
+	return exec
 }
 
 // parsePermissionResult interprets permission plugin output: "true" or JSON {"allowed": true} -> true.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -1774,7 +1775,8 @@ func (o *Orchestrator) SyncActions(ctx context.Context) {
 
 	caps := o.registry.ListCapabilities()
 	for _, cap := range caps {
-		// Don't sync the sync plugin itself.
+		// Skip all actions from the sync plugin so it doesn't index its own
+		// internal actions (sync_actions, ingest, etc.) into the vector store.
 		if cap.Name == o.syncActionsPlugin {
 			continue
 		}
@@ -1804,7 +1806,12 @@ func (o *Orchestrator) SyncActions(ctx context.Context) {
 			Action: o.syncActionsAction,
 			Args:   map[string]string{"payload": string(b)},
 		}
-		result := o.guard.ExecuteWithTimeout(ctx, mustGetExec(o.registry, o.syncActionsPlugin), call)
+		exec, ok := o.registry.GetExecutor(o.syncActionsPlugin)
+		if !ok {
+			slog.Warn("sync_actions executor disappeared", "plugin", o.syncActionsPlugin)
+			return
+		}
+		result := o.guard.ExecuteWithTimeout(ctx, exec, call)
 		if result.Error != "" {
 			slog.Warn("sync_actions failed", "plugin", cap.Name, "error", result.Error)
 		} else {
@@ -1813,10 +1820,11 @@ func (o *Orchestrator) SyncActions(ctx context.Context) {
 	}
 }
 
-// IngestKnowledgeDir scans the configured knowledge directory for .md files and
-// ingests each one via the configured plugin action. The directory is optional —
-// knowledge articles can also be submitted via the plugin's HTTP API. Idempotent;
-// errors are logged, not returned.
+// IngestKnowledgeDir recursively scans the configured knowledge directory for .md
+// files and ingests each one via the configured plugin action. The directory is
+// optional — knowledge articles can also be submitted via the plugin's HTTP API.
+// Whether re-runs produce duplicates depends on the ingest action (weaviate upserts
+// by title, so re-runs are safe). Errors are logged, not returned.
 func (o *Orchestrator) IngestKnowledgeDir(ctx context.Context) {
 	k := o.knowledge
 	if k.Plugin == "" || k.Action == "" {
@@ -1831,30 +1839,37 @@ func (o *Orchestrator) IngestKnowledgeDir(ctx context.Context) {
 		return
 	}
 
-	entries, err := os.ReadDir(k.Dir)
-	if err != nil {
-		slog.Warn("knowledge dir scan failed", "dir", k.Dir, "error", err)
-		return
-	}
-
 	exec, ok := o.registry.GetExecutor(k.Plugin)
 	if !ok {
 		slog.Warn("knowledge ingest executor not found", "plugin", k.Plugin)
 		return
 	}
 
+	const maxFileSize int64 = 10 << 20 // 10 MB
+
 	var count int
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
-			continue
+	err := filepath.WalkDir(k.Dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		path := k.Dir + "/" + e.Name()
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			slog.Warn("knowledge file stat failed", "path", path, "error", err)
+			return nil
+		}
+		if info.Size() > maxFileSize {
+			slog.Warn("knowledge file too large, skipping", "path", path, "size_bytes", info.Size(), "max_bytes", maxFileSize)
+			return nil
+		}
 		data, err := os.ReadFile(path)
 		if err != nil {
 			slog.Warn("knowledge file read failed", "path", path, "error", err)
-			continue
+			return nil
 		}
-		title := strings.TrimSuffix(e.Name(), ".md")
+		title := strings.TrimSuffix(d.Name(), ".md")
 		call := ToolCall{
 			ID:     fmt.Sprintf("knowledge-ingest-%s", title),
 			Plugin: k.Plugin,
@@ -1867,24 +1882,18 @@ func (o *Orchestrator) IngestKnowledgeDir(ctx context.Context) {
 		}
 		result := o.guard.ExecuteWithTimeout(ctx, exec, call)
 		if result.Error != "" {
-			slog.Warn("knowledge ingest failed", "file", e.Name(), "error", result.Error)
+			slog.Warn("knowledge ingest failed", "file", d.Name(), "error", result.Error)
 		} else {
 			count++
 		}
+		return nil
+	})
+	if err != nil {
+		slog.Warn("knowledge dir walk failed", "dir", k.Dir, "error", err)
 	}
 	if count > 0 {
 		slog.Info("knowledge dir ingested", "dir", k.Dir, "files", count)
 	}
-}
-
-// mustGetExec returns the executor for a plugin or panics. Only used for
-// plugins whose existence was verified before the call.
-func mustGetExec(reg *ToolRegistry, name string) PluginExecutor {
-	exec, ok := reg.GetExecutor(name)
-	if !ok {
-		panic("executor not found for verified plugin: " + name)
-	}
-	return exec
 }
 
 // parsePermissionResult interprets permission plugin output: "true" or JSON {"allowed": true} -> true.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -2218,5 +2219,302 @@ func TestResponseFormatterLuaMissingScript(t *testing.T) {
 	// FailOpen=true: missing Lua script is logged and skipped
 	if result.Response != "keep me" {
 		t.Errorf("Response = %q, want %q", result.Response, "keep me")
+	}
+}
+
+// --- Knowledge-Augmented RAG tests (issue #97) ---
+
+func TestPreparerRelevantToolsFilterSystemPrompt(t *testing.T) {
+	// A preparer returns relevant_tools -> buildSystemPrompt only shows those tools.
+	ragJSON := `{"send_to_llm": true, "message": "enriched query", "relevant_tools": ["gitlab.analyze_code"]}`
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "RAG prepare", Parameters: []Parameter{{Name: "text", Description: "User message"}}}},
+	}, &fixedResultExecutor{content: ragJSON})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab integration",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code"},
+			{Name: "create_pr", Description: "Create PR"},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira integration",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	interceptLLM := &capturingLLM{responses: []string{"done"}}
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(interceptLLM, parser, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	result, err := orch.Run(context.Background(), "s1", "analyze my repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response != "done" {
+		t.Errorf("Response = %q", result.Response)
+	}
+
+	if len(interceptLLM.requests) == 0 {
+		t.Fatal("no requests captured")
+	}
+
+	systemPrompt := interceptLLM.requests[0].Messages[0].Content
+	// Should include gitlab.analyze_code (relevant)
+	if !strings.Contains(systemPrompt, "gitlab.analyze_code") {
+		t.Error("system prompt should contain gitlab.analyze_code (relevant tool)")
+	}
+	// Should NOT include gitlab.create_pr or jira.create_issue (not in relevant_tools)
+	if strings.Contains(systemPrompt, "gitlab.create_pr") {
+		t.Error("system prompt should NOT contain gitlab.create_pr (not in relevant_tools)")
+	}
+	if strings.Contains(systemPrompt, "jira.create_issue") {
+		t.Error("system prompt should NOT contain jira.create_issue (not in relevant_tools)")
+	}
+}
+
+func TestPreparerNoRelevantToolsShowsAll(t *testing.T) {
+	// When preparer returns empty relevant_tools, all tools remain visible.
+	ragJSON := `{"send_to_llm": true, "message": "unchanged", "relevant_tools": []}`
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "RAG prepare", Parameters: []Parameter{{Name: "text", Description: "text"}}}},
+	}, &fixedResultExecutor{content: ragJSON})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	interceptLLM := &capturingLLM{responses: []string{"all tools"}}
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(interceptLLM, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	result, err := orch.Run(context.Background(), "s1", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Response != "all tools" {
+		t.Errorf("Response = %q", result.Response)
+	}
+	systemPrompt := interceptLLM.requests[0].Messages[0].Content
+	if !strings.Contains(systemPrompt, "gitlab.analyze_code") {
+		t.Error("system prompt should contain all tools when relevant_tools is empty")
+	}
+	if !strings.Contains(systemPrompt, "jira.create_issue") {
+		t.Error("system prompt should contain all tools when relevant_tools is empty")
+	}
+}
+
+func TestPreparerInjectsAllowedPlugins(t *testing.T) {
+	// When a profile with strict plugins is present, the preparer should receive
+	// allowed_plugins in its args.
+	var capturedArgs map[string]string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "RAG prepare", Parameters: []Parameter{
+			{Name: "text", Description: "text"},
+			{Name: "allowed_plugins", Description: "allowed plugins"},
+		}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		capturedArgs = call.Args
+		return ToolResult{CallID: call.ID, Content: `{"send_to_llm": true, "message": "ok"}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(&fakeLLM{responses: []string{"reply"}}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	// Set up a strict profile with allowed plugins.
+	ctx := profile.WithProfile(context.Background(), &profile.Profile{
+		EntityID: "user1",
+		Group:    "team1",
+		Plugins:  []string{"gitlab", "rag-preparer"},
+	})
+
+	_, err := orch.Run(ctx, "s1", "test message")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedArgs == nil {
+		t.Fatal("preparer was not called")
+	}
+	ap, ok := capturedArgs["allowed_plugins"]
+	if !ok || ap == "" {
+		t.Fatal("allowed_plugins not injected into preparer args")
+	}
+	// Should be a JSON array containing the allowed plugins.
+	var plugins []string
+	if err := json.Unmarshal([]byte(ap), &plugins); err != nil {
+		t.Fatalf("allowed_plugins is not valid JSON: %v", err)
+	}
+	if len(plugins) != 2 {
+		t.Errorf("expected 2 allowed plugins, got %d: %v", len(plugins), plugins)
+	}
+}
+
+func TestSyncActions(t *testing.T) {
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code"},
+			{Name: "create_pr", Description: "Create PR"},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	// Should have synced gitlab and jira (not weaviate itself).
+	if len(syncCalls) != 2 {
+		t.Fatalf("expected 2 sync calls, got %d", len(syncCalls))
+	}
+
+	// Verify payload contains expected plugin names.
+	allPayloads := strings.Join(syncCalls, " ")
+	if !strings.Contains(allPayloads, `"plugin_name":"gitlab"`) && !strings.Contains(allPayloads, `"plugin_name":"jira"`) {
+		t.Errorf("sync payloads missing expected plugin names: %s", allPayloads)
+	}
+	if strings.Contains(allPayloads, `"plugin_name":"weaviate"`) {
+		t.Error("sync should not include the sync plugin itself")
+	}
+}
+
+func TestSyncActionsNoopWhenUnconfigured(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{})
+
+	// Should not panic or error when sync is not configured.
+	orch.SyncActions(context.Background())
+}
+
+func TestIngestKnowledgeDirNoopWhenUnconfigured(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{})
+
+	// Should not panic or error when knowledge is not configured.
+	orch.IngestKnowledgeDir(context.Background())
+}
+
+func TestIngestKnowledgeDir(t *testing.T) {
+	dir := t.TempDir()
+	// Write two markdown files and one non-markdown file.
+	if err := os.WriteFile(dir+"/getting-started.md", []byte("# Getting Started\nWelcome!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/faq.md", []byte("# FAQ\nQ: What?\nA: This."), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dir+"/ignore.txt", []byte("not a markdown file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var ingestCalls []map[string]string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "ingest", Description: "Ingest article", Parameters: []Parameter{
+			{Name: "title", Description: "Title"},
+			{Name: "content", Description: "Content"},
+			{Name: "source", Description: "Source"},
+		}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		ingestCalls = append(ingestCalls, call.Args)
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		Knowledge: KnowledgeConfig{
+			Plugin: "weaviate",
+			Action: "ingest",
+			Dir:    dir,
+		},
+	})
+
+	orch.IngestKnowledgeDir(context.Background())
+
+	if len(ingestCalls) != 2 {
+		t.Fatalf("expected 2 ingest calls (only .md files), got %d", len(ingestCalls))
+	}
+
+	// Verify titles and sources.
+	for _, args := range ingestCalls {
+		if args["source"] != "knowledge_dir" {
+			t.Errorf("expected source 'knowledge_dir', got %q", args["source"])
+		}
+		if args["title"] != "getting-started" && args["title"] != "faq" {
+			t.Errorf("unexpected title: %q", args["title"])
+		}
+		if args["content"] == "" {
+			t.Error("content should not be empty")
+		}
+	}
+}
+
+func TestRelevantToolsContextRoundTrip(t *testing.T) {
+	tools := []string{"gitlab.analyze_code", "jira.create_issue"}
+	ctx := withRelevantTools(context.Background(), tools)
+	got := relevantToolsFromContext(ctx)
+	if len(got) != 2 || got[0] != tools[0] || got[1] != tools[1] {
+		t.Errorf("round-trip failed: got %v, want %v", got, tools)
+	}
+}
+
+func TestRelevantToolsContextEmpty(t *testing.T) {
+	got := relevantToolsFromContext(context.Background())
+	if got != nil {
+		t.Errorf("expected nil from empty context, got %v", got)
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -2500,6 +2501,94 @@ func TestIngestKnowledgeDir(t *testing.T) {
 		if args["content"] == "" {
 			t.Error("content should not be empty")
 		}
+	}
+}
+
+func TestPreparerRelevantToolsNoMatchSkipsAllHeaders(t *testing.T) {
+	// When relevant_tools contains names that don't match any registered action,
+	// all plugin headers are skipped from the system prompt.
+	ragJSON := `{"send_to_llm": true, "message": "query", "relevant_tools": ["nonexistent.action"]}`
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "RAG prepare", Parameters: []Parameter{{Name: "text", Description: "text"}}}},
+	}, &fixedResultExecutor{content: ragJSON})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab integration",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira integration",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	interceptLLM := &capturingLLM{responses: []string{"ok"}}
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(interceptLLM, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	_, err := orch.Run(context.Background(), "s1", "something irrelevant")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	systemPrompt := interceptLLM.requests[0].Messages[0].Content
+	// No plugin actions should appear (nonexistent.action matches nothing).
+	if strings.Contains(systemPrompt, "gitlab.analyze_code") {
+		t.Error("system prompt should NOT contain gitlab.analyze_code when relevant_tools match nothing")
+	}
+	if strings.Contains(systemPrompt, "jira.create_issue") {
+		t.Error("system prompt should NOT contain jira.create_issue when relevant_tools match nothing")
+	}
+	// Plugin headers (## gitlab, ## jira) should also be absent.
+	if strings.Contains(systemPrompt, "## gitlab") {
+		t.Error("system prompt should NOT contain ## gitlab header when no actions match")
+	}
+	if strings.Contains(systemPrompt, "## jira") {
+		t.Error("system prompt should NOT contain ## jira header when no actions match")
+	}
+}
+
+func TestIngestKnowledgeDirRecursive(t *testing.T) {
+	// Verify that subdirectories are scanned recursively.
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "faq")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "top.md"), []byte("top level"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "nested.md"), []byte("nested file"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var ingestCount int
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "ingest", Description: "Ingest", Parameters: []Parameter{
+			{Name: "title"}, {Name: "content"}, {Name: "source"},
+		}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		ingestCount++
+		return ToolResult{CallID: call.ID, Content: `{"ok":true}`}
+	}})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		Knowledge: KnowledgeConfig{Plugin: "weaviate", Action: "ingest", Dir: dir},
+	})
+
+	orch.IngestKnowledgeDir(context.Background())
+
+	if ingestCount != 2 {
+		t.Errorf("expected 2 ingest calls (top + nested), got %d", ingestCount)
 	}
 }
 


### PR DESCRIPTION
Add orchestrator-side support for the weaviate-plugin's RAG system:

- Preparer responses can now return `relevant_tools` to filter the system prompt to only the tools relevant to the user's query, reducing token usage on LLM calls.
- Built-in `allowed_plugins` context arg provider so RAG preparers and LLM-called actions (e.g. ask_knowledge) receive the profile's plugin allowlist for access-controlled filtering.
- SyncActions() syncs all registered plugin capabilities to the vector store at startup for retrieval-based tool filtering.
- IngestKnowledgeDir() optionally scans a directory of .md files and ingests them at startup; articles can also arrive via HTTP API.
- New `orchestrator.knowledge` config section for YAML-based setup.