### PR TITLE
feat: sync plugin actions on startup with proper logging and retry ca…

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -316,9 +316,11 @@ func main() {
 	pluginManager := plugin.NewManager(toolRegistry)
 	retryCtx, retryCancel := context.WithCancel(ctx)
 	defer retryCancel()
+	slog.Info("loading plugins", "component", "startup", "count", len(pluginEntries))
 	if err := pluginManager.LoadAll(ctx, pluginEntries); err != nil {
 		slog.Warn("some plugins failed to load", "error", err)
 	}
+	slog.Info("plugin loading complete", "component", "startup", "loaded", len(pluginManager.List()))
 	pluginManager.StartRetryLoop(retryCtx, 10*time.Second)
 
 	if err := requestpkg.Register(toolRegistry, requestSets); err != nil {
@@ -453,17 +455,24 @@ func main() {
 	})
 
 	// Sync plugin capabilities to the vector store and ingest knowledge articles
-	// from the configured directory. Both are fire-and-forget at startup.
+	// from the configured directory. Runs synchronously so the orchestrator is
+	// fully ready before accepting traffic.
 	//
 	// These calls use guard.ExecuteWithTimeout directly (not executeCall) because
 	// there is no actor/session at startup. This intentionally skips permission
 	// checks, audit logging, arg validation, and plugin-allowed filtering.
 	// If the sync or ingest plugin ever declares AuditLog=true, those calls
 	// will not be logged — acceptable for host-initiated startup work.
-	go func() {
-		orch.SyncActions(ctx)
-		orch.IngestKnowledgeDir(ctx)
-	}()
+	slog.Info("startup: syncing plugin actions to vector store", "component", "startup")
+	orch.SyncActions(ctx)
+	orch.IngestKnowledgeDir(ctx)
+	slog.Info("startup: sync complete, orchestrator ready", "component", "startup")
+
+	// When a plugin comes online later (e.g. via the retry loop), sync its
+	// actions to the vector store automatically.
+	pluginManager.OnPluginLoaded(func(name string) {
+		go orch.SyncPluginActions(ctx, name)
+	})
 
 	// Scheduler: wired after orchestrator so it can route job actions through orch.
 	// Personal reminders bypass the approver policy via AddPersonalJob.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1773,51 +1773,83 @@ func (o *Orchestrator) SyncActions(ctx context.Context) {
 		return
 	}
 
+	slog.Info("sync_actions starting", "component", "orchestrator",
+		"sync_plugin", o.syncActionsPlugin, "sync_action", o.syncActionsAction)
+
 	caps := o.registry.ListCapabilities()
+	var synced, failed int
 	for _, cap := range caps {
-		// Skip all actions from the sync plugin so it doesn't index its own
-		// internal actions (sync_actions, ingest, etc.) into the vector store.
-		if cap.Name == o.syncActionsPlugin {
-			continue
-		}
-		entries := make([]syncActionEntry, 0, len(cap.Actions))
-		for _, a := range cap.Actions {
-			if a.UserOnly {
-				continue
-			}
-			entries = append(entries, syncActionEntry{
-				Name:        a.Name,
-				Description: a.Description,
-				Parameters:  a.Parameters,
-			})
-		}
-		if len(entries) == 0 {
-			continue
-		}
-		payload := syncActionsPayload{PluginName: cap.Name, Actions: entries}
-		b, err := json.Marshal(payload)
-		if err != nil {
-			slog.Warn("sync_actions marshal failed", "plugin", cap.Name, "error", err)
-			continue
-		}
-		call := ToolCall{
-			ID:     fmt.Sprintf("sync-%s", cap.Name),
-			Plugin: o.syncActionsPlugin,
-			Action: o.syncActionsAction,
-			Args:   map[string]string{"payload": string(b)},
-		}
-		exec, ok := o.registry.GetExecutor(o.syncActionsPlugin)
-		if !ok {
-			slog.Warn("sync_actions executor disappeared", "plugin", o.syncActionsPlugin)
-			return
-		}
-		result := o.guard.ExecuteWithTimeout(ctx, exec, call)
-		if result.Error != "" {
-			slog.Warn("sync_actions failed", "plugin", cap.Name, "error", result.Error)
+		if err := o.syncPluginCapability(ctx, cap); err != nil {
+			slog.Warn("sync_actions failed", "component", "orchestrator", "plugin", cap.Name, "error", err)
+			failed++
 		} else {
-			slog.Info("sync_actions done", "plugin", cap.Name, "actions", len(entries))
+			synced++
 		}
 	}
+
+	slog.Info("sync_actions completed", "component", "orchestrator",
+		"plugins_synced", synced, "plugins_failed", failed)
+}
+
+// SyncPluginActions syncs a single plugin's capabilities to the vector store.
+// Intended for use when a plugin comes online after initial startup (e.g. via retry).
+func (o *Orchestrator) SyncPluginActions(ctx context.Context, pluginName string) {
+	if o.syncActionsPlugin == "" || o.syncActionsAction == "" {
+		return
+	}
+	cap, ok := o.registry.GetCapability(pluginName)
+	if !ok {
+		slog.Warn("sync_actions: plugin not found in registry", "component", "orchestrator", "plugin", pluginName)
+		return
+	}
+	slog.Info("sync_actions: syncing late-loaded plugin", "component", "orchestrator", "plugin", pluginName)
+	if err := o.syncPluginCapability(ctx, cap); err != nil {
+		slog.Warn("sync_actions failed for late-loaded plugin", "component", "orchestrator", "plugin", pluginName, "error", err)
+	}
+}
+
+// syncPluginCapability syncs a single plugin's actions to the vector store.
+func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapability) error {
+	// Skip all actions from the sync plugin so it doesn't index its own
+	// internal actions (sync_actions, ingest, etc.) into the vector store.
+	if cap.Name == o.syncActionsPlugin {
+		return nil
+	}
+	entries := make([]syncActionEntry, 0, len(cap.Actions))
+	for _, a := range cap.Actions {
+		if a.UserOnly {
+			continue
+		}
+		entries = append(entries, syncActionEntry{
+			Name:        a.Name,
+			Description: a.Description,
+			Parameters:  a.Parameters,
+		})
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	payload := syncActionsPayload{PluginName: cap.Name, Actions: entries}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	call := ToolCall{
+		ID:     fmt.Sprintf("sync-%s", cap.Name),
+		Plugin: o.syncActionsPlugin,
+		Action: o.syncActionsAction,
+		Args:   map[string]string{"payload": string(b)},
+	}
+	exec, ok := o.registry.GetExecutor(o.syncActionsPlugin)
+	if !ok {
+		return fmt.Errorf("executor disappeared")
+	}
+	result := o.guard.ExecuteWithTimeout(ctx, exec, call)
+	if result.Error != "" {
+		return fmt.Errorf("%s", result.Error)
+	}
+	slog.Info("sync_actions done", "component", "orchestrator", "plugin", cap.Name, "actions", len(entries))
+	return nil
 }
 
 // IngestKnowledgeDir recursively scans the configured knowledge directory for .md

--- a/internal/plugin/manager.go
+++ b/internal/plugin/manager.go
@@ -56,13 +56,18 @@ type managed struct {
 	client  *Client
 }
 
+// PluginLoadedFunc is called after a plugin is successfully loaded and registered.
+// It receives the plugin name so the caller can react (e.g. sync actions).
+type PluginLoadedFunc func(name string)
+
 // Manager discovers, launches, and registers tool plugins with the
 // orchestrator's ToolRegistry.
 type Manager struct {
-	mu       sync.Mutex
-	plugins  map[string]*managed
-	known    map[string]PluginEntry // all configured entries, including those that failed to load
-	registry *orchestrator.ToolRegistry
+	mu             sync.Mutex
+	plugins        map[string]*managed
+	known          map[string]PluginEntry // all configured entries, including those that failed to load
+	registry       *orchestrator.ToolRegistry
+	onPluginLoaded PluginLoadedFunc
 }
 
 // NewManager creates a manager that registers plugins into the given
@@ -73,6 +78,15 @@ func NewManager(registry *orchestrator.ToolRegistry) *Manager {
 		known:    make(map[string]PluginEntry),
 		registry: registry,
 	}
+}
+
+// OnPluginLoaded sets a callback invoked after each plugin is successfully
+// loaded and registered. Intended for triggering action sync when late-loaded
+// plugins come online via the retry loop.
+func (m *Manager) OnPluginLoaded(fn PluginLoadedFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onPluginLoaded = fn
 }
 
 // LoadAll launches all enabled plugins and registers them. Plugins that fail
@@ -105,11 +119,29 @@ func (m *Manager) LoadAll(ctx context.Context, entries []PluginEntry) error {
 
 // Load launches a single plugin and registers it.
 func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
+	name, err := m.loadLocked(ctx, entry)
+	if err != nil {
+		return err
+	}
+
+	// Fire callback outside the lock to avoid deadlocks if the callback
+	// calls back into the manager.
+	m.mu.Lock()
+	fn := m.onPluginLoaded
+	m.mu.Unlock()
+	if fn != nil {
+		fn(name)
+	}
+
+	return nil
+}
+
+func (m *Manager) loadLocked(ctx context.Context, entry PluginEntry) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if _, exists := m.plugins[entry.Name]; exists {
-		return fmt.Errorf("plugin %q already loaded", entry.Name)
+		return "", fmt.Errorf("plugin %q already loaded", entry.Name)
 	}
 
 	mode := detectPluginMode(entry.Plugin)
@@ -124,10 +156,10 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 	case modeRemoteGRPC:
 		client, err = m.connectRemote(entry)
 	default:
-		return fmt.Errorf("unsupported plugin mode %q for %s", mode, entry.Name)
+		return "", fmt.Errorf("unsupported plugin mode %q for %s", mode, entry.Name)
 	}
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cap := client.Capability()
@@ -140,7 +172,7 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 		if proc != nil {
 			_ = proc.Stop(defaultStopGrace)
 		}
-		return fmt.Errorf("register %s: %w", entry.Name, err)
+		return "", fmt.Errorf("register %s: %w", entry.Name, err)
 	}
 
 	// Register per-server aliases for MCP plugins so that each MCP server
@@ -194,7 +226,8 @@ func (m *Manager) Load(ctx context.Context, entry PluginEntry) error {
 	}
 
 	slog.Info("loaded plugin", "component", "plugin-manager", "plugin", entry.Name, "mode", mode, "actions", len(cap.Actions))
-	return nil
+
+	return entry.Name, nil
 }
 
 // watchProcess monitors a plugin process and cleans up if it exits unexpectedly.


### PR DESCRIPTION
…llback

- SyncActions now runs synchronously at startup (not fire-and-forget) so the orchestrator is fully ready before accepting traffic
- Add SyncPluginActions for syncing a single plugin when it comes online late via the retry loop
- Add OnPluginLoaded callback to plugin Manager for post-load hooks
- Add structured logging throughout startup: plugin count, sync progress, and completion status