### PR TITLE
feat(orchestrator): add subprocess (sub-agent) forking support (#105)

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -452,6 +452,19 @@ func main() {
 			Action: cfg.Orchestrator.Knowledge.Action,
 			Dir:    cfg.Orchestrator.Knowledge.Dir,
 		},
+		Subprocess: orchestrator.SubprocessConfig{
+			Enabled:       cfg.Orchestrator.Subprocess.Enabled,
+			MaxDepth:      cfg.Orchestrator.Subprocess.MaxDepth,
+			MaxIterations: cfg.Orchestrator.Subprocess.MaxIterations,
+			DefaultTimeout: func() time.Duration {
+				if cfg.Orchestrator.Subprocess.DefaultTimeout != "" {
+					if d, err := time.ParseDuration(cfg.Orchestrator.Subprocess.DefaultTimeout); err == nil {
+						return d
+					}
+				}
+				return 60 * time.Second
+			}(),
+		},
 	})
 
 	// Sync plugin capabilities to the vector store and ingest knowledge articles

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -301,13 +301,14 @@ type KnowledgeConfig struct {
 }
 
 type OrchestratorConfig struct {
-	Rules                 []string                   `yaml:"rules"`
-	ContentPreparers      []ContentPreparerEntry     `yaml:"content_preparers,omitempty"`
-	ResponseFormatters    []ResponseFormatterEntry   `yaml:"response_formatters,omitempty"`
-	PermissionPlugin      string                     `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
-	MaxConcurrentSessions int                        `yaml:"max_concurrent_sessions,omitempty"` // max sessions running in parallel (default 1 = sequential)
-	Pipeline              PipelineOrchestratorConfig `yaml:"pipeline,omitempty"`
-	Knowledge             KnowledgeConfig            `yaml:"knowledge,omitempty"` // knowledge-augmented RAG configuration
+	Rules                 []string                     `yaml:"rules"`
+	ContentPreparers      []ContentPreparerEntry       `yaml:"content_preparers,omitempty"`
+	ResponseFormatters    []ResponseFormatterEntry     `yaml:"response_formatters,omitempty"`
+	PermissionPlugin      string                       `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
+	MaxConcurrentSessions int                          `yaml:"max_concurrent_sessions,omitempty"` // max sessions running in parallel (default 1 = sequential)
+	Pipeline              PipelineOrchestratorConfig   `yaml:"pipeline,omitempty"`
+	Knowledge             KnowledgeConfig              `yaml:"knowledge,omitempty"`  // knowledge-augmented RAG configuration
+	Subprocess            SubprocessOrchestratorConfig `yaml:"subprocess,omitempty"` // subprocess (sub-agent) support
 }
 
 // PipelineOrchestratorConfig enables structured multi-step pipeline execution.
@@ -315,6 +316,14 @@ type PipelineOrchestratorConfig struct {
 	Enabled        bool   `yaml:"enabled"`          // default false
 	MaxStepRetries int    `yaml:"max_step_retries"` // default 3
 	StepTimeout    string `yaml:"step_timeout"`     // Go duration, default "60s"
+}
+
+// SubprocessOrchestratorConfig enables subprocess (sub-agent) forking from the main agent loop.
+type SubprocessOrchestratorConfig struct {
+	Enabled        bool   `yaml:"enabled"`                   // default false
+	MaxDepth       int    `yaml:"max_depth,omitempty"`       // max nesting depth; default 2, hard cap 3
+	MaxIterations  int    `yaml:"max_iterations,omitempty"`  // default iterations per child; default 5, hard cap 10
+	DefaultTimeout string `yaml:"default_timeout,omitempty"` // Go duration; default "60s"
 }
 
 type StateConfig struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -120,6 +120,7 @@ type OrchestratorOpts struct {
 	SyncActionsPlugin       string             // optional; plugin name for action sync (e.g. "weaviate")
 	SyncActionsAction       string             // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
 	Knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
+	Subprocess              SubprocessConfig   // optional; subprocess (sub-agent) support
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -178,6 +179,7 @@ type Orchestrator struct {
 	syncActionsPlugin       string             // optional; plugin name for action sync
 	syncActionsAction       string             // optional; action name for action sync
 	knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
+	subprocessConfig        SubprocessConfig   // optional; subprocess (sub-agent) support
 }
 
 const (
@@ -302,6 +304,26 @@ func NewWithRules(
 	}
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)
+
+	// Register the built-in _subprocess plugin when enabled.
+	o.subprocessConfig = opts.Subprocess
+	if opts.Subprocess.Enabled {
+		subCap := PluginCapability{
+			Name:        "_subprocess",
+			Description: "Fork a focused sub-agent process to handle a sub-task",
+			Actions: []Action{{
+				Name:        "run",
+				Description: "Fork a subprocess that runs its own agent loop. Use for sub-tasks like research, multi-step tool usage, or focused questions that benefit from independent reasoning.",
+				Parameters: []Parameter{
+					{Name: "task", Description: "Clear description of what the subprocess should accomplish", Required: true},
+					{Name: "tools", Description: "Comma-separated plugin.action allowlist (empty = all available tools)", Required: false},
+					{Name: "max_iterations", Description: "Max agent loop iterations 1-10 (default 5)", Required: false},
+				},
+			}},
+		}
+		_ = o.registry.Register(subCap, &subprocessExecutor{orch: o})
+	}
+
 	return o
 }
 
@@ -1144,6 +1166,19 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 			}
 		}
 		sb.WriteString("\n")
+	}
+
+	if o.subprocessConfig.Enabled {
+		sb.WriteString("## Subprocess (sub-agent)\n")
+		sb.WriteString("You can fork a focused sub-process using `_subprocess.run` to handle sub-tasks independently.\n")
+		sb.WriteString("The subprocess runs its own agent loop with its own context — it can call tools, reason through multiple steps, and return a final answer to you.\n\n")
+		sb.WriteString("USE subprocess when:\n")
+		sb.WriteString("- A sub-task requires multiple tool calls that don't need your main conversation context\n")
+		sb.WriteString("- You need to search or research something before continuing your main reasoning\n")
+		sb.WriteString("- The task is self-contained with a clear question and answer\n\n")
+		sb.WriteString("DO NOT use subprocess for:\n")
+		sb.WriteString("- Simple single tool calls — just call the tool directly\n")
+		sb.WriteString("- Tasks that need the full conversation history\n\n")
 	}
 
 	workflowMemories, _ := o.memory.MemoriesForContext(ctx, "workflow")

--- a/internal/orchestrator/subprocess.go
+++ b/internal/orchestrator/subprocess.go
@@ -1,0 +1,294 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/provider"
+)
+
+// SubprocessConfig configures the subprocess (sub-agent) system.
+type SubprocessConfig struct {
+	Enabled        bool          // master switch
+	MaxDepth       int           // max nesting depth (default 2, hard cap 3)
+	MaxIterations  int           // default iterations per child (default 5, hard cap 10)
+	DefaultTimeout time.Duration // per-subprocess timeout (default 60s)
+}
+
+// subprocessRequest is parsed from the LLM's _subprocess.run tool call args.
+type subprocessRequest struct {
+	Task          string
+	AllowedTools  []string
+	MaxIterations int
+}
+
+// subprocessDepthKey is the context key for tracking subprocess nesting depth.
+type subprocessDepthKey struct{}
+
+func withSubprocessDepth(ctx context.Context, depth int) context.Context {
+	return context.WithValue(ctx, subprocessDepthKey{}, depth)
+}
+
+func subprocessDepth(ctx context.Context) int {
+	v, _ := ctx.Value(subprocessDepthKey{}).(int)
+	return v
+}
+
+// subprocessExecutor implements PluginExecutor for the built-in _subprocess plugin.
+type subprocessExecutor struct {
+	orch *Orchestrator
+}
+
+func (s *subprocessExecutor) Execute(ctx context.Context, call ToolCall) ToolResult {
+	req, err := parseSubprocessRequest(call.Args)
+	if err != nil {
+		return ToolResult{CallID: call.ID, Error: err.Error()}
+	}
+
+	currentDepth := subprocessDepth(ctx)
+	maxDepth := s.orch.subprocessConfig.MaxDepth
+	if maxDepth <= 0 {
+		maxDepth = 2
+	}
+	if maxDepth > 3 {
+		maxDepth = 3
+	}
+	if currentDepth >= maxDepth {
+		return ToolResult{
+			CallID: call.ID,
+			Error:  fmt.Sprintf("subprocess depth limit reached (%d)", maxDepth),
+		}
+	}
+
+	result, err := s.orch.runSubprocess(ctx, req, currentDepth+1)
+	if err != nil {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("subprocess failed: %v", err)}
+	}
+
+	return ToolResult{CallID: call.ID, Content: result.Response}
+}
+
+// subprocessResult is the outcome of a subprocess execution.
+type subprocessResult struct {
+	Response   string
+	Iterations int
+}
+
+// runSubprocess runs a mini agent loop for a focused sub-task.
+func (o *Orchestrator) runSubprocess(ctx context.Context, req subprocessRequest, depth int) (*subprocessResult, error) {
+	timeout := o.subprocessConfig.DefaultTimeout
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	ctx = withSubprocessDepth(ctx, depth)
+
+	maxIter := req.MaxIterations
+	if maxIter <= 0 {
+		defaultIter := o.subprocessConfig.MaxIterations
+		if defaultIter <= 0 {
+			defaultIter = 5
+		}
+		maxIter = defaultIter
+	}
+	if maxIter > 10 {
+		maxIter = 10
+	}
+
+	log := slog.With("component", "subprocess", "depth", depth)
+	taskPreview := req.Task
+	if len(taskPreview) > 100 {
+		taskPreview = taskPreview[:100] + "..."
+	}
+	log.Info("subprocess started", "task", taskPreview, "max_iterations", maxIter, "allowed_tools", len(req.AllowedTools))
+
+	systemPrompt := o.buildSubprocessSystemPrompt(ctx, req)
+
+	messages := []provider.Message{
+		{Role: provider.RoleSystem, Content: systemPrompt},
+		{Role: provider.RoleUser, Content: req.Task},
+	}
+
+	result := &subprocessResult{}
+	for i := 0; i < maxIter; i++ {
+		guardedMessages, blocked, err := o.runGuardPlugins(ctx, messages)
+		if err != nil {
+			return nil, fmt.Errorf("subprocess guard: %w", err)
+		}
+		if blocked != nil {
+			result.Response = blocked.Response
+			result.Iterations = i + 1
+			log.Info("subprocess blocked by guard", "iterations", result.Iterations)
+			return result, nil
+		}
+
+		resp, err := o.llm.Complete(ctx, &provider.CompletionRequest{Messages: guardedMessages})
+		if err != nil {
+			return nil, fmt.Errorf("subprocess LLM: %w", err)
+		}
+
+		calls := o.parser.Parse(resp.Content)
+		if calls == nil {
+			result.Response = StripInternalBlocks(resp.Content)
+			result.Iterations = i + 1
+			log.Info("subprocess completed", "iterations", result.Iterations)
+			return result, nil
+		}
+
+		for _, call := range calls {
+			call.FromLLM = true
+
+			if !isSubprocessToolAllowed(call, req.AllowedTools) {
+				tr := ToolResult{
+					CallID: call.ID,
+					Error:  fmt.Sprintf("tool %s.%s not allowed in this subprocess", call.Plugin, call.Action),
+				}
+				messages = append(messages,
+					provider.Message{Role: provider.RoleAssistant, Content: formatToolCallMessage(call)},
+					provider.Message{Role: provider.RoleUser, Content: o.guard.WrapContent(tr)},
+				)
+				continue
+			}
+
+			toolResult := o.executeCall(ctx, call)
+
+			if o.pluginCallObserver != nil {
+				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", 0, 0)
+			}
+
+			messages = append(messages,
+				provider.Message{Role: provider.RoleAssistant, Content: formatToolCallMessage(call)},
+				provider.Message{Role: provider.RoleUser, Content: o.guard.WrapContent(toolResult)},
+			)
+		}
+	}
+
+	result.Response = "(subprocess reached iteration limit without a final answer)"
+	result.Iterations = maxIter
+	log.Warn("subprocess hit iteration limit", "iterations", maxIter)
+	return result, nil
+}
+
+// buildSubprocessSystemPrompt builds a focused system prompt for a subprocess
+// with only the allowed tools listed. It excludes _subprocess itself to prevent fork bombs.
+func (o *Orchestrator) buildSubprocessSystemPrompt(ctx context.Context, req subprocessRequest) string {
+	var sb strings.Builder
+	sb.WriteString("You are a focused sub-agent. Complete the following task using the available tools.\n")
+	sb.WriteString("When you have the answer, respond in plain text without any tool calls.\n\n")
+	sb.WriteString("To call a tool, use EXACTLY this format:\n\n")
+	sb.WriteString("[tool_call]\n{\"tool\": \"plugin.action\", \"args\": {\"key\": \"value\"}}\n[/tool_call]\n\n")
+
+	// Build allowlist set for fast lookup.
+	allowSet := make(map[string]bool, len(req.AllowedTools))
+	for _, t := range req.AllowedTools {
+		allowSet[t] = true
+	}
+	hasAllowlist := len(allowSet) > 0
+
+	// Don't list preparer/guard actions.
+	preparerAction := make(map[string]bool)
+	for _, prep := range o.preparers {
+		preparerAction[prep.Plugin+"."+prep.Action] = true
+	}
+	for _, g := range o.guards {
+		preparerAction[g.Plugin+"."+g.Action] = true
+	}
+
+	allowedPlugins := o.resolveAllowedPlugins(ctx)
+	caps := o.registry.ListCapabilities()
+
+	for _, cap := range caps {
+		// Exclude _subprocess to prevent recursion.
+		if cap.Name == "_subprocess" {
+			continue
+		}
+
+		if !o.pluginAllowed(cap, allowedPlugins) {
+			continue
+		}
+
+		var visibleActions []Action
+		for _, action := range cap.Actions {
+			if preparerAction[cap.Name+"."+action.Name] || action.UserOnly {
+				continue
+			}
+			if hasAllowlist && !allowSet[cap.Name+"."+action.Name] {
+				continue
+			}
+			visibleActions = append(visibleActions, action)
+		}
+
+		if len(visibleActions) == 0 {
+			continue
+		}
+
+		fmt.Fprintf(&sb, "## %s\n%s\n", cap.Name, cap.Description)
+		for _, action := range visibleActions {
+			fmt.Fprintf(&sb, "- %s.%s: %s\n", cap.Name, action.Name, action.Description)
+			for _, p := range action.Parameters {
+				req := ""
+				if p.Required {
+					req = " (required)"
+				}
+				fmt.Fprintf(&sb, "  - %s: %s%s\n", p.Name, p.Description, req)
+			}
+		}
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// parseSubprocessRequest parses tool call args into a subprocessRequest.
+func parseSubprocessRequest(args map[string]string) (subprocessRequest, error) {
+	task := args["task"]
+	if task == "" {
+		return subprocessRequest{}, fmt.Errorf("subprocess requires a 'task' argument")
+	}
+
+	req := subprocessRequest{Task: task}
+
+	if tools := args["tools"]; tools != "" {
+		for _, t := range strings.Split(tools, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				req.AllowedTools = append(req.AllowedTools, t)
+			}
+		}
+	}
+
+	if maxIterStr := args["max_iterations"]; maxIterStr != "" {
+		n, err := strconv.Atoi(maxIterStr)
+		if err != nil {
+			return subprocessRequest{}, fmt.Errorf("invalid max_iterations: %s", maxIterStr)
+		}
+		req.MaxIterations = n
+	}
+
+	return req, nil
+}
+
+// isSubprocessToolAllowed checks whether a tool call is permitted in a subprocess.
+// _subprocess is always blocked (prevents fork bombs). When an allowlist is provided,
+// only listed tools are permitted; when empty, all tools except _subprocess are allowed.
+func isSubprocessToolAllowed(call ToolCall, allowedTools []string) bool {
+	if call.Plugin == "_subprocess" {
+		return false
+	}
+	if len(allowedTools) == 0 {
+		return true
+	}
+	key := call.Plugin + "." + call.Action
+	for _, t := range allowedTools {
+		if t == key {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/subprocess.go
+++ b/internal/orchestrator/subprocess.go
@@ -60,7 +60,7 @@ func (s *subprocessExecutor) Execute(ctx context.Context, call ToolCall) ToolRes
 	if currentDepth >= maxDepth {
 		return ToolResult{
 			CallID: call.ID,
-			Error:  fmt.Sprintf("subprocess depth limit reached (%d)", maxDepth),
+			Error:  fmt.Sprintf("subprocess depth limit reached (depth %d of %d)", currentDepth+1, maxDepth),
 		}
 	}
 
@@ -141,6 +141,12 @@ func (o *Orchestrator) runSubprocess(ctx context.Context, req subprocessRequest,
 			return result, nil
 		}
 
+		perCallInput, perCallOutput := 0, 0
+		if len(calls) > 0 {
+			perCallInput = resp.Usage.InputTokens / len(calls)
+			perCallOutput = resp.Usage.OutputTokens / len(calls)
+		}
+
 		for _, call := range calls {
 			call.FromLLM = true
 
@@ -159,7 +165,7 @@ func (o *Orchestrator) runSubprocess(ctx context.Context, req subprocessRequest,
 			toolResult := o.executeCall(ctx, call)
 
 			if o.pluginCallObserver != nil {
-				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", 0, 0)
+				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", perCallInput, perCallOutput)
 			}
 
 			messages = append(messages,
@@ -192,12 +198,12 @@ func (o *Orchestrator) buildSubprocessSystemPrompt(ctx context.Context, req subp
 	hasAllowlist := len(allowSet) > 0
 
 	// Don't list preparer/guard actions.
-	preparerAction := make(map[string]bool)
+	internalActions := make(map[string]bool)
 	for _, prep := range o.preparers {
-		preparerAction[prep.Plugin+"."+prep.Action] = true
+		internalActions[prep.Plugin+"."+prep.Action] = true
 	}
 	for _, g := range o.guards {
-		preparerAction[g.Plugin+"."+g.Action] = true
+		internalActions[g.Plugin+"."+g.Action] = true
 	}
 
 	allowedPlugins := o.resolveAllowedPlugins(ctx)
@@ -215,7 +221,7 @@ func (o *Orchestrator) buildSubprocessSystemPrompt(ctx context.Context, req subp
 
 		var visibleActions []Action
 		for _, action := range cap.Actions {
-			if preparerAction[cap.Name+"."+action.Name] || action.UserOnly {
+			if internalActions[cap.Name+"."+action.Name] || action.UserOnly {
 				continue
 			}
 			if hasAllowlist && !allowSet[cap.Name+"."+action.Name] {
@@ -232,11 +238,11 @@ func (o *Orchestrator) buildSubprocessSystemPrompt(ctx context.Context, req subp
 		for _, action := range visibleActions {
 			fmt.Fprintf(&sb, "- %s.%s: %s\n", cap.Name, action.Name, action.Description)
 			for _, p := range action.Parameters {
-				req := ""
+				reqMark := ""
 				if p.Required {
-					req = " (required)"
+					reqMark = " (required)"
 				}
-				fmt.Fprintf(&sb, "  - %s: %s%s\n", p.Name, p.Description, req)
+				fmt.Fprintf(&sb, "  - %s: %s%s\n", p.Name, p.Description, reqMark)
 			}
 		}
 		sb.WriteString("\n")

--- a/internal/orchestrator/subprocess_test.go
+++ b/internal/orchestrator/subprocess_test.go
@@ -107,17 +107,9 @@ func TestSubprocessDepthLimit(t *testing.T) {
 	// Subprocess executor checks depth. At depth >= MaxDepth, it returns an error.
 	orch := setupSubprocessOrchestrator(&fakeLLM{})
 
-	req := subprocessRequest{Task: "test task"}
-	ctx := withSubprocessDepth(context.Background(), 2) // already at max depth
-
-	result, err := orch.runSubprocess(ctx, req, 3) // depth 3 > MaxDepth 2
-	// The depth check is in the executor, not runSubprocess. Let's test via executor.
-	_ = result
-	_ = err
-
 	exec := &subprocessExecutor{orch: orch}
-	ctx2 := withSubprocessDepth(context.Background(), 2)
-	tr := exec.Execute(ctx2, ToolCall{ID: "1", Args: map[string]string{"task": "nested task"}})
+	ctx := withSubprocessDepth(context.Background(), 2)
+	tr := exec.Execute(ctx, ToolCall{ID: "1", Args: map[string]string{"task": "nested task"}})
 	if tr.Error == "" {
 		t.Fatal("expected depth limit error")
 	}
@@ -128,7 +120,6 @@ func TestSubprocessDepthLimit(t *testing.T) {
 
 func TestSubprocessIterationLimit(t *testing.T) {
 	// Subprocess LLM always returns tool calls, never a final answer.
-	callCount := 0
 	llm := &fakeLLM{responses: make([]string, 20)}
 	for i := range llm.responses {
 		llm.responses[i] = fmt.Sprintf(`[tool_call]
@@ -150,7 +141,6 @@ func TestSubprocessIterationLimit(t *testing.T) {
 	if result.Iterations != 3 {
 		t.Errorf("expected 3 iterations, got: %d", result.Iterations)
 	}
-	_ = callCount
 }
 
 func TestSubprocessToolAllowlist(t *testing.T) {
@@ -198,7 +188,10 @@ func TestSubprocessBlocksRecursion(t *testing.T) {
 	// The subprocess should have gotten an error for the _subprocess call
 	// and then returned a final answer.
 	if result.Response == "" {
-		t.Error("expected a response")
+		t.Fatal("expected a non-empty response")
+	}
+	if result.Iterations < 1 {
+		t.Errorf("expected at least 1 iteration, got %d", result.Iterations)
 	}
 }
 

--- a/internal/orchestrator/subprocess_test.go
+++ b/internal/orchestrator/subprocess_test.go
@@ -1,0 +1,410 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+func setupSubprocessOrchestrator(llm LLMClient) *Orchestrator {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:        "search",
+		Description: "Search tools",
+		Actions: []Action{
+			{Name: "query", Description: "Search for something", Parameters: []Parameter{
+				{Name: "q", Description: "Search query", Required: true},
+			}},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "math",
+		Description: "Math tools",
+		Actions: []Action{
+			{Name: "calculate", Description: "Calculate expression", Parameters: []Parameter{
+				{Name: "expr", Description: "Expression", Required: true},
+			}},
+		},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	return NewWithRules(llm, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		Subprocess: SubprocessConfig{
+			Enabled:        true,
+			MaxDepth:       2,
+			MaxIterations:  5,
+			DefaultTimeout: 30 * time.Second,
+		},
+	})
+}
+
+func TestSubprocessBasicFork(t *testing.T) {
+	// LLM response sequence:
+	// 1. Parent calls _subprocess.run
+	// 2. Subprocess LLM returns direct answer (no tool calls)
+	llm := &fakeLLM{responses: []string{
+		`[tool_call]
+{"tool": "_subprocess.run", "args": {"task": "What is the capital of France?"}}
+[/tool_call]`,
+		// Subprocess LLM - direct answer
+		"The capital of France is Paris.",
+		// Parent LLM - final answer incorporating subprocess result
+		"Based on my research: Paris is the capital of France.",
+	}}
+
+	orch := setupSubprocessOrchestrator(llm)
+	sess := orch.sessions.Create("test-basic")
+
+	result, err := orch.Run(context.Background(), sess.ID, "What is the capital of France?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Response, "Paris") {
+		t.Errorf("expected response to contain 'Paris', got: %s", result.Response)
+	}
+}
+
+func TestSubprocessWithToolCalls(t *testing.T) {
+	// LLM sequence:
+	// 1. Parent calls _subprocess.run with tools restriction
+	// 2. Subprocess LLM calls search.query
+	// 3. Subprocess LLM returns answer
+	// 4. Parent LLM returns final answer
+	llm := &fakeLLM{responses: []string{
+		`[tool_call]
+{"tool": "_subprocess.run", "args": {"task": "Search for refund policy", "tools": "search.query"}}
+[/tool_call]`,
+		// Subprocess LLM calls a tool
+		`[tool_call]
+{"tool": "search.query", "args": {"q": "refund policy"}}
+[/tool_call]`,
+		// Subprocess LLM returns answer after getting tool result
+		"The refund policy allows returns within 30 days.",
+		// Parent LLM final answer
+		"Our refund policy allows returns within 30 days.",
+	}}
+
+	orch := setupSubprocessOrchestrator(llm)
+	sess := orch.sessions.Create("test-tools")
+
+	result, err := orch.Run(context.Background(), sess.ID, "What is our refund policy?")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Response, "30 days") {
+		t.Errorf("expected response about refund policy, got: %s", result.Response)
+	}
+}
+
+func TestSubprocessDepthLimit(t *testing.T) {
+	// Subprocess executor checks depth. At depth >= MaxDepth, it returns an error.
+	orch := setupSubprocessOrchestrator(&fakeLLM{})
+
+	req := subprocessRequest{Task: "test task"}
+	ctx := withSubprocessDepth(context.Background(), 2) // already at max depth
+
+	result, err := orch.runSubprocess(ctx, req, 3) // depth 3 > MaxDepth 2
+	// The depth check is in the executor, not runSubprocess. Let's test via executor.
+	_ = result
+	_ = err
+
+	exec := &subprocessExecutor{orch: orch}
+	ctx2 := withSubprocessDepth(context.Background(), 2)
+	tr := exec.Execute(ctx2, ToolCall{ID: "1", Args: map[string]string{"task": "nested task"}})
+	if tr.Error == "" {
+		t.Fatal("expected depth limit error")
+	}
+	if !strings.Contains(tr.Error, "depth limit") {
+		t.Errorf("expected depth limit error, got: %s", tr.Error)
+	}
+}
+
+func TestSubprocessIterationLimit(t *testing.T) {
+	// Subprocess LLM always returns tool calls, never a final answer.
+	callCount := 0
+	llm := &fakeLLM{responses: make([]string, 20)}
+	for i := range llm.responses {
+		llm.responses[i] = fmt.Sprintf(`[tool_call]
+{"tool": "search.query", "args": {"q": "attempt %d"}}
+[/tool_call]`, i)
+	}
+
+	orch := setupSubprocessOrchestrator(llm)
+	orch.subprocessConfig.MaxIterations = 3
+
+	req := subprocessRequest{Task: "keep searching", MaxIterations: 3}
+	result, err := orch.runSubprocess(context.Background(), req, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Response, "iteration limit") {
+		t.Errorf("expected iteration limit message, got: %s", result.Response)
+	}
+	if result.Iterations != 3 {
+		t.Errorf("expected 3 iterations, got: %d", result.Iterations)
+	}
+	_ = callCount
+}
+
+func TestSubprocessToolAllowlist(t *testing.T) {
+	// Subprocess tries to call math.calculate but only search.query is allowed.
+	llm := &fakeLLM{responses: []string{
+		// Subprocess calls disallowed tool
+		`[tool_call]
+{"tool": "math.calculate", "args": {"expr": "2+2"}}
+[/tool_call]`,
+		// Then gives up
+		"I couldn't calculate that — the math tool is not available.",
+	}}
+
+	orch := setupSubprocessOrchestrator(llm)
+
+	req := subprocessRequest{
+		Task:         "calculate 2+2",
+		AllowedTools: []string{"search.query"},
+	}
+	result, err := orch.runSubprocess(context.Background(), req, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Response == "" {
+		t.Error("expected a response")
+	}
+}
+
+func TestSubprocessBlocksRecursion(t *testing.T) {
+	// Subprocess tries to call _subprocess.run — should be blocked.
+	llm := &fakeLLM{responses: []string{
+		`[tool_call]
+{"tool": "_subprocess.run", "args": {"task": "recursive task"}}
+[/tool_call]`,
+		"I can't spawn subprocesses from here.",
+	}}
+
+	orch := setupSubprocessOrchestrator(llm)
+
+	req := subprocessRequest{Task: "try to recurse"}
+	result, err := orch.runSubprocess(context.Background(), req, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The subprocess should have gotten an error for the _subprocess call
+	// and then returned a final answer.
+	if result.Response == "" {
+		t.Error("expected a response")
+	}
+}
+
+func TestSubprocessTimeout(t *testing.T) {
+	// Use a very short timeout and a slow LLM.
+	llm := &slowLLM{delay: 2 * time.Second}
+
+	orch := setupSubprocessOrchestrator(llm)
+	orch.subprocessConfig.DefaultTimeout = 50 * time.Millisecond
+
+	req := subprocessRequest{Task: "slow task"}
+	_, err := orch.runSubprocess(context.Background(), req, 1)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "context deadline exceeded") && !strings.Contains(err.Error(), "subprocess LLM") {
+		t.Errorf("expected context deadline error, got: %v", err)
+	}
+}
+
+type slowLLM struct {
+	delay time.Duration
+}
+
+func (s *slowLLM) Complete(ctx context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(s.delay):
+		return &provider.CompletionResponse{Content: "done"}, nil
+	}
+}
+
+func TestSubprocessDisabled(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	orch := NewWithRules(&fakeLLM{}, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		Subprocess: SubprocessConfig{Enabled: false},
+	})
+
+	if _, ok := orch.registry.GetExecutor("_subprocess"); ok {
+		t.Error("expected _subprocess to not be registered when disabled")
+	}
+}
+
+func TestSubprocessEnabled(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	orch := NewWithRules(&fakeLLM{}, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		Subprocess: SubprocessConfig{Enabled: true},
+	})
+
+	if _, ok := orch.registry.GetExecutor("_subprocess"); !ok {
+		t.Error("expected _subprocess to be registered when enabled")
+	}
+}
+
+func TestParseSubprocessRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]string
+		wantErr bool
+		check   func(t *testing.T, req subprocessRequest)
+	}{
+		{
+			name:    "missing task",
+			args:    map[string]string{},
+			wantErr: true,
+		},
+		{
+			name: "task only",
+			args: map[string]string{"task": "do something"},
+			check: func(t *testing.T, req subprocessRequest) {
+				if req.Task != "do something" {
+					t.Errorf("wrong task: %s", req.Task)
+				}
+				if len(req.AllowedTools) != 0 {
+					t.Errorf("expected no allowed tools, got: %v", req.AllowedTools)
+				}
+			},
+		},
+		{
+			name: "with tools",
+			args: map[string]string{"task": "search", "tools": "search.query, math.calculate"},
+			check: func(t *testing.T, req subprocessRequest) {
+				if len(req.AllowedTools) != 2 {
+					t.Fatalf("expected 2 tools, got: %d", len(req.AllowedTools))
+				}
+				if req.AllowedTools[0] != "search.query" || req.AllowedTools[1] != "math.calculate" {
+					t.Errorf("wrong tools: %v", req.AllowedTools)
+				}
+			},
+		},
+		{
+			name: "with max_iterations",
+			args: map[string]string{"task": "search", "max_iterations": "3"},
+			check: func(t *testing.T, req subprocessRequest) {
+				if req.MaxIterations != 3 {
+					t.Errorf("expected max_iterations=3, got: %d", req.MaxIterations)
+				}
+			},
+		},
+		{
+			name:    "invalid max_iterations",
+			args:    map[string]string{"task": "search", "max_iterations": "abc"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := parseSubprocessRequest(tt.args)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.check != nil {
+				tt.check(t, req)
+			}
+		})
+	}
+}
+
+func TestIsSubprocessToolAllowed(t *testing.T) {
+	// _subprocess is always blocked
+	var noTools []string
+	if isSubprocessToolAllowed(ToolCall{Plugin: "_subprocess", Action: "run"}, noTools) {
+		t.Error("_subprocess should always be blocked")
+	}
+
+	// No allowlist = everything except _subprocess
+	if !isSubprocessToolAllowed(ToolCall{Plugin: "search", Action: "query"}, noTools) {
+		t.Error("search.query should be allowed with no allowlist")
+	}
+
+	// With allowlist
+	allowed := []string{"search.query"}
+	if !isSubprocessToolAllowed(ToolCall{Plugin: "search", Action: "query"}, allowed) {
+		t.Error("search.query should be in allowlist")
+	}
+	if isSubprocessToolAllowed(ToolCall{Plugin: "math", Action: "calculate"}, allowed) {
+		t.Error("math.calculate should not be in allowlist")
+	}
+}
+
+func TestSubprocessSystemPromptExcludesSubprocess(t *testing.T) {
+	orch := setupSubprocessOrchestrator(&fakeLLM{})
+
+	prompt := orch.buildSubprocessSystemPrompt(context.Background(), subprocessRequest{
+		Task: "test",
+	})
+
+	if strings.Contains(prompt, "_subprocess") {
+		t.Error("subprocess system prompt should not contain _subprocess")
+	}
+	if !strings.Contains(prompt, "search.query") {
+		t.Error("subprocess system prompt should contain search.query")
+	}
+	if !strings.Contains(prompt, "math.calculate") {
+		t.Error("subprocess system prompt should contain math.calculate")
+	}
+}
+
+func TestSubprocessSystemPromptRespectsAllowlist(t *testing.T) {
+	orch := setupSubprocessOrchestrator(&fakeLLM{})
+
+	prompt := orch.buildSubprocessSystemPrompt(context.Background(), subprocessRequest{
+		Task:         "test",
+		AllowedTools: []string{"search.query"},
+	})
+
+	if !strings.Contains(prompt, "search.query") {
+		t.Error("subprocess system prompt should contain search.query")
+	}
+	if strings.Contains(prompt, "math.calculate") {
+		t.Error("subprocess system prompt should not contain math.calculate when not in allowlist")
+	}
+}
+
+func TestSubprocessMaxIterationsCapped(t *testing.T) {
+	// Request max_iterations=20, should be capped at 10
+	llm := &fakeLLM{responses: make([]string, 15)}
+	for i := range llm.responses {
+		llm.responses[i] = fmt.Sprintf(`[tool_call]
+{"tool": "search.query", "args": {"q": "attempt %d"}}
+[/tool_call]`, i)
+	}
+
+	orch := setupSubprocessOrchestrator(llm)
+
+	req := subprocessRequest{Task: "keep going", MaxIterations: 20}
+	result, err := orch.runSubprocess(context.Background(), req, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should be capped at 10
+	if result.Iterations != 10 {
+		t.Errorf("expected 10 iterations (capped), got: %d", result.Iterations)
+	}
+}


### PR DESCRIPTION
Add Unix-inspired subprocess system where the main LLM agent loop can fork focused child processes for sub-tasks (vector search, research, multi-step tool usage). Children run their own mini agent loop with ephemeral context and scoped tools, returning results to the parent.