### PR TITLE
feat(orchestrator): carry server_instructions and keep_plugins in syn…

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,6 +77,13 @@ orchestrator:
   # to filter the system prompt to only the tools the query needs.
   # NOTE: If multiple content_preparers return relevant_tools, the last one wins.
   # Place the RAG preparer last in the content_preparers list to control precedence.
+  # The sync_actions payload also carries each plugin's SystemPromptAddition
+  # (e.g. an MCP server's `initialize.instructions` text bridged through by
+  # mcp-plugin) as `server_instructions`, so the vector store can index it for
+  # semantic retrieval alongside per-action descriptions. Each call also ships
+  # `keep_plugins` (the authoritative live-plugin list) so the sync plugin can
+  # delete records for plugins removed since last startup. Older sync-plugin
+  # versions ignore both fields — upserts continue to work.
   # knowledge:
   #   sync_plugin: weaviate        # plugin that has sync_actions action
   #   sync_action: sync_actions    # action name for capability sync

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1883,9 +1883,24 @@ type syncActionEntry struct {
 }
 
 // syncActionsPayload is the JSON shape expected by the sync_actions action.
+//
+// ServerInstructions carries the plugin's SystemPromptAddition (e.g. an MCP
+// server's `initialize.instructions` text bridged through by mcp-plugin) so the
+// vector store can index it for semantic retrieval alongside actions.
+//
+// KeepPlugins, when populated, is the authoritative list of plugin names that
+// should remain in the vector store. Sync-plugin implementations are expected
+// to delete any indexed records whose plugin is NOT in this list (orphan prune).
+// It's set during full startup syncs (SyncActions) and omitted during late-load
+// single-plugin syncs (SyncPluginActions). The prune is idempotent across the
+// per-plugin calls of one full sync, so plugins can apply it on every call.
+// Older sync-plugin versions that don't recognize the field MUST ignore it —
+// the upsert path is unaffected.
 type syncActionsPayload struct {
-	PluginName string            `json:"plugin_name"`
-	Actions    []syncActionEntry `json:"actions"`
+	PluginName         string            `json:"plugin_name"`
+	Actions            []syncActionEntry `json:"actions"`
+	ServerInstructions string            `json:"server_instructions,omitempty"`
+	KeepPlugins        []string          `json:"keep_plugins,omitempty"`
 }
 
 // SyncActions iterates all registered plugin capabilities and calls the configured
@@ -1904,9 +1919,22 @@ func (o *Orchestrator) SyncActions(ctx context.Context) {
 		"sync_plugin", o.syncActionsPlugin, "sync_action", o.syncActionsAction)
 
 	caps := o.registry.ListCapabilities()
+	// Build the authoritative live-plugin list once, excluding the sync plugin
+	// itself. Each per-plugin sync_actions call ships this list as keep_plugins
+	// so the sync plugin can prune records for plugins that have been removed
+	// since the last startup. Older sync-plugin versions ignore the field —
+	// upserts still work, orphans just linger (the previous behavior).
+	keep := make([]string, 0, len(caps))
+	for _, cap := range caps {
+		if cap.Name == o.syncActionsPlugin {
+			continue
+		}
+		keep = append(keep, cap.Name)
+	}
+
 	var synced, failed int
 	for _, cap := range caps {
-		if err := o.syncPluginCapability(ctx, cap); err != nil {
+		if err := o.syncPluginCapability(ctx, cap, keep); err != nil {
 			slog.Warn("sync_actions failed", "component", "orchestrator", "plugin", cap.Name, "error", err)
 			failed++
 		} else {
@@ -1930,13 +1958,17 @@ func (o *Orchestrator) SyncPluginActions(ctx context.Context, pluginName string)
 		return
 	}
 	slog.Info("sync_actions: syncing late-loaded plugin", "component", "orchestrator", "plugin", pluginName)
-	if err := o.syncPluginCapability(ctx, cap); err != nil {
+	// Late-load: omit keep_plugins so the sync plugin only upserts this one
+	// capability and does not interpret the call as a full-snapshot prune.
+	if err := o.syncPluginCapability(ctx, cap, nil); err != nil {
 		slog.Warn("sync_actions failed for late-loaded plugin", "component", "orchestrator", "plugin", pluginName, "error", err)
 	}
 }
 
 // syncPluginCapability syncs a single plugin's actions to the vector store.
-func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapability) error {
+// keepPlugins is the authoritative live-plugin set during a full startup sync,
+// or nil during late-load single-plugin re-sync.
+func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapability, keepPlugins []string) error {
 	// Skip all actions from the sync plugin so it doesn't index its own
 	// internal actions (sync_actions, ingest, etc.) into the vector store.
 	if cap.Name == o.syncActionsPlugin {
@@ -1953,10 +1985,15 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 			Parameters:  a.Parameters,
 		})
 	}
-	if len(entries) == 0 {
+	if len(entries) == 0 && cap.SystemPromptAddition == "" {
 		return nil
 	}
-	payload := syncActionsPayload{PluginName: cap.Name, Actions: entries}
+	payload := syncActionsPayload{
+		PluginName:         cap.Name,
+		Actions:            entries,
+		ServerInstructions: cap.SystemPromptAddition,
+		KeepPlugins:        keepPlugins,
+	}
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("marshal: %w", err)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2476,6 +2476,153 @@ func TestSyncActions(t *testing.T) {
 	}
 }
 
+func TestSyncActionsCarriesServerInstructions(t *testing.T) {
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "timly", Description: "Timly",
+		SystemPromptAddition: "Timly MCP server.\n\n## Org-units vs Containers\nA Place is a storage unit; an Org-unit is a structural unit.",
+		Actions:              []Action{{Name: "list-items", Description: "List items"}},
+	}, &echoExecutor{})
+	// Plugin with no actions and no SystemPromptAddition: should be skipped entirely.
+	_ = registry.Register(PluginCapability{
+		Name: "empty", Description: "Empty plugin",
+	}, &echoExecutor{})
+	// Plugin with no actions but with SystemPromptAddition: should still be synced
+	// so the vector store has the prose.
+	_ = registry.Register(PluginCapability{
+		Name:                 "prose-only",
+		Description:          "Prose only",
+		SystemPromptAddition: "Some orientation prose without any callable actions.",
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	if len(syncCalls) != 2 {
+		t.Fatalf("expected 2 sync calls (timly + prose-only), got %d: %v", len(syncCalls), syncCalls)
+	}
+
+	all := strings.Join(syncCalls, " ")
+	if !strings.Contains(all, `"server_instructions":"Timly MCP server.`) {
+		t.Errorf("timly server_instructions missing from payload: %s", all)
+	}
+	if !strings.Contains(all, `"server_instructions":"Some orientation prose without any callable actions."`) {
+		t.Errorf("prose-only server_instructions missing from payload: %s", all)
+	}
+	if strings.Contains(all, `"plugin_name":"empty"`) {
+		t.Error("empty plugin (no actions, no prose) should not be synced")
+	}
+}
+
+func TestSyncActionsOmitsServerInstructionsWhenAbsent(t *testing.T) {
+	// Pre-existing weaviate-plugin versions parse the payload without
+	// `server_instructions` — verify the JSON shape is unchanged for plugins
+	// that don't set SystemPromptAddition.
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	if len(syncCalls) != 1 {
+		t.Fatalf("expected 1 sync call, got %d", len(syncCalls))
+	}
+	if strings.Contains(syncCalls[0], "server_instructions") {
+		t.Errorf("server_instructions key should be omitted when SystemPromptAddition is empty: %s", syncCalls[0])
+	}
+}
+
+func TestSyncActionsCarriesKeepPlugins(t *testing.T) {
+	// During a full startup sync, every sync_actions call should ship the live
+	// plugin list as keep_plugins so the sync plugin can prune orphans. The
+	// late-load path (SyncPluginActions) must NOT include keep_plugins, since
+	// it represents only one capability re-syncing, not a full snapshot.
+	var fullSyncCalls []string
+	var lateLoadCalls []string
+	mode := "full"
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		if mode == "full" {
+			fullSyncCalls = append(fullSyncCalls, call.Args["payload"])
+		} else {
+			lateLoadCalls = append(lateLoadCalls, call.Args["payload"])
+		}
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "timly", Description: "Timly",
+		Actions: []Action{{Name: "list-items", Description: "List items"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+	if len(fullSyncCalls) != 2 {
+		t.Fatalf("expected 2 full-sync calls, got %d", len(fullSyncCalls))
+	}
+	for _, p := range fullSyncCalls {
+		if !strings.Contains(p, `"keep_plugins":["timly","gitlab"]`) &&
+			!strings.Contains(p, `"keep_plugins":["gitlab","timly"]`) {
+			t.Errorf("full-sync payload missing expected keep_plugins: %s", p)
+		}
+		if strings.Contains(p, `"weaviate"`) {
+			t.Errorf("keep_plugins must not include the sync plugin itself: %s", p)
+		}
+	}
+
+	mode = "late"
+	orch.SyncPluginActions(context.Background(), "timly")
+	if len(lateLoadCalls) != 1 {
+		t.Fatalf("expected 1 late-load call, got %d", len(lateLoadCalls))
+	}
+	if strings.Contains(lateLoadCalls[0], "keep_plugins") {
+		t.Errorf("late-load payload must not include keep_plugins: %s", lateLoadCalls[0])
+	}
+}
+
 func TestSyncActionsNoopWhenUnconfigured(t *testing.T) {
 	registry := NewToolRegistry()
 	memory := state.NewMemoryStore("")


### PR DESCRIPTION
…c_actions

Extend the sync_actions payload sent to the configured sync plugin (typically weaviate-plugin) with two optional fields:

- `server_instructions`: the plugin's SystemPromptAddition. For MCP-bridged plugins this is the upstream MCP server's `initialize.instructions` text (e.g. Timly's SERVER_INSTRUCTIONS). The vector store can index it as a knowledge article so semantic queries find the prose alongside per-action descriptions, instead of only seeing tool catalogs.

- `keep_plugins`: the authoritative list of live plugin names during a full startup sync. Sync-plugin implementations are expected to delete records whose plugin is NOT in this list (idempotent across the per-plugin calls of one full sync, so it's safe to apply on every call). Omitted on SyncPluginActions late-load calls — those are single-plugin upserts, not full snapshots, and must not trigger pruning.

Both fields use `omitempty`, and older sync-plugin versions ignore unknown keys, so the wire is backwards compatible — the upsert path is unchanged.

A capability with no actions but a non-empty SystemPromptAddition is now also synced, so the prose still reaches the vector store for prose-only plugins.