### PR TITLE
feat: add LLM streaming support for real-time response delivery

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -783,6 +783,21 @@ func (c *defaultModelClient) Complete(ctx context.Context, req *provider.Complet
 	return c.provider.Complete(ctx, req)
 }
 
+// Stream implements orchestrator.StreamingLLMClient by delegating to the
+// underlying provider's Stream method, filling in the default model if needed.
+func (c *defaultModelClient) Stream(ctx context.Context, req *provider.CompletionRequest) (provider.ResponseStream, error) {
+	if req.Model == "" {
+		req = &provider.CompletionRequest{
+			Model:       c.model,
+			Messages:    req.Messages,
+			MaxTokens:   req.MaxTokens,
+			Temperature: req.Temperature,
+			Stream:      true,
+		}
+	}
+	return c.provider.Stream(ctx, req)
+}
+
 // buildLuaScriptPaths returns a map of Lua plugin name -> path to .lua script,
 // from local scripts_dir and from plugins downloaded from GitHub.
 func buildLuaScriptPaths(ctx context.Context, dataDir string, cfg *config.Config) map[string]string {

--- a/internal/channel/registry.go
+++ b/internal/channel/registry.go
@@ -186,11 +186,28 @@ func (r *Registry) dispatch(ch pkg.Channel, inbox <-chan pkg.InboundMessage) {
 					}
 				}
 
+				// When the channel supports edits, attach a StreamWriter so the
+				// orchestrator can progressively deliver LLM output in real-time.
+				var sw *pkg.StreamWriter
+				caps := ch.Capabilities()
+				if caps.Edits {
+					sw = pkg.NewStreamWriter(ch, m.ConversationID, m.ThreadID, safeMetadata(m.Metadata))
+					ctx = pkg.WithStreamWriter(ctx, sw)
+				}
+
 				resp, err := r.handler(ctx, sessionKey, m)
 				if err != nil {
 					logger.FromContext(ctx).Error("handling message failed", "channel", ch.ID(), "session", sessionKey, "error", err)
 					return
 				}
+
+				// If streaming already delivered the content, skip the final
+				// Send to avoid duplicating the message. The StreamWriter's
+				// last flush (done=true) already sent the complete text.
+				if sw != nil && sw.Flushed() {
+					return
+				}
+
 				if err := ch.Send(ctx, resp); err != nil {
 					logger.FromContext(ctx).Error("sending response failed", "channel", ch.ID(), "error", err)
 				}

--- a/internal/channel/registry_test.go
+++ b/internal/channel/registry_test.go
@@ -411,3 +411,99 @@ func TestRegistryDispatchInjectsCapabilities(t *testing.T) {
 		t.Error("capabilities.Threads should be true")
 	}
 }
+
+func TestRegistryDispatchStreamWriterInjected(t *testing.T) {
+	// When a channel declares edits:true, the dispatch should inject a
+	// StreamWriter into the context. The handler can verify this.
+	var gotSW bool
+	done := make(chan struct{})
+
+	handler := func(ctx context.Context, _ string, msg pkg.InboundMessage) (pkg.OutboundMessage, error) {
+		sw := pkg.StreamWriterFromContext(ctx)
+		gotSW = sw != nil
+		// Simulate streaming: call OnChunk so the StreamWriter flushes,
+		// which means the final Send should be skipped.
+		if sw != nil {
+			sw.OnChunk(ctx, "streamed!", true)
+		}
+		close(done)
+		return pkg.OutboundMessage{ConversationID: msg.ConversationID, Content: "streamed!"}, nil
+	}
+
+	reg := NewRegistry(handler)
+	defer reg.StopAll()
+
+	ch := &mockChannel{
+		id:   "slack-stream",
+		caps: pkg.Capabilities{ID: "slack-stream", Name: "Slack", Edits: true},
+	}
+	_ = reg.Register(ch)
+
+	ch.pushMessage(pkg.InboundMessage{
+		ChannelID:      "slack-stream",
+		ConversationID: "c1",
+		Content:        "hello",
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	if !gotSW {
+		t.Error("expected StreamWriter to be injected for edits:true channel")
+	}
+
+	// Give dispatch goroutine time to finish.
+	time.Sleep(50 * time.Millisecond)
+	sent := ch.sentMessages()
+
+	// The StreamWriter flushed (streaming delivered the content), so the
+	// registry dispatch should have skipped the final ch.Send. However,
+	// the StreamWriter itself called Send once for the streaming flush.
+	// So we expect exactly 1 Send (from StreamWriter), not 2.
+	if len(sent) != 1 {
+		t.Errorf("expected 1 Send call (from StreamWriter), got %d", len(sent))
+	}
+}
+
+func TestRegistryDispatchNoStreamWriterWithoutEdits(t *testing.T) {
+	// Channels without edits:true should not get a StreamWriter.
+	var gotSW bool
+	done := make(chan struct{})
+
+	handler := func(ctx context.Context, _ string, msg pkg.InboundMessage) (pkg.OutboundMessage, error) {
+		gotSW = pkg.StreamWriterFromContext(ctx) != nil
+		close(done)
+		return pkg.OutboundMessage{ConversationID: msg.ConversationID, Content: "reply"}, nil
+	}
+
+	reg := NewRegistry(handler)
+	defer reg.StopAll()
+
+	ch := newMockChannel("noedit")
+	_ = reg.Register(ch)
+
+	ch.pushMessage(pkg.InboundMessage{
+		ChannelID:      "noedit",
+		ConversationID: "c1",
+		Content:        "hello",
+	})
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	if gotSW {
+		t.Error("StreamWriter should NOT be injected when edits is false")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	sent := ch.sentMessages()
+	if len(sent) != 1 {
+		t.Errorf("expected 1 Send call, got %d", len(sent))
+	}
+}

--- a/internal/channel/yaml_channel.go
+++ b/internal/channel/yaml_channel.go
@@ -206,6 +206,58 @@ func (ch *YAMLChannel) Send(ctx context.Context, msg pkg.OutboundMessage) error 
 	return nil
 }
 
+// SendAndCapture implements pkg.UpdatableChannel. It sends a message using the
+// outbound.send spec and captures the message ID from the response (using the
+// field name configured in outbound.send_store_id, e.g. "ts" for Slack).
+func (ch *YAMLChannel) SendAndCapture(ctx context.Context, msg pkg.OutboundMessage) (string, error) {
+	storeField := ch.spec.Outbound.SendStoreID
+	if storeField == "" {
+		// No capture configured — fall back to plain Send.
+		return "", ch.Send(ctx, msg)
+	}
+
+	msgCtx := map[string]string{
+		"conversation_id": msg.ConversationID,
+		"thread_id":       msg.ThreadID,
+		"content":         msg.Content,
+	}
+	for k, v := range msg.Metadata {
+		msgCtx["metadata."+k] = v
+	}
+
+	contexts := ch.buildContexts()
+	contexts["msg"] = msgCtx
+
+	messageID, err := ch.doHTTPCallCaptureField(ctx, ch.spec.Outbound.Send, contexts, storeField)
+	if err != nil {
+		return "", fmt.Errorf("channel %s send-and-capture: %w", ch.spec.ID, err)
+	}
+	return messageID, nil
+}
+
+// SendUpdate implements pkg.UpdatableChannel. It uses the optional outbound.update
+// HTTP call spec to edit an existing message (e.g. Slack chat.update).
+func (ch *YAMLChannel) SendUpdate(ctx context.Context, messageID string, msg pkg.OutboundMessage) error {
+	if ch.spec.Outbound.Update.URL == "" {
+		return fmt.Errorf("channel %s: no update spec configured", ch.spec.ID)
+	}
+
+	msgCtx := map[string]string{
+		"conversation_id": msg.ConversationID,
+		"thread_id":       msg.ThreadID,
+		"content":         msg.Content,
+		"message_id":      messageID,
+	}
+	for k, v := range msg.Metadata {
+		msgCtx["metadata."+k] = v
+	}
+
+	contexts := ch.buildContexts()
+	contexts["msg"] = msgCtx
+
+	return ch.doHTTPCall(ctx, ch.spec.Outbound.Update, contexts)
+}
+
 // encodeFilesJSON serialises a slice of FileAttachments as a JSON array with
 // base64-encoded data fields, suitable for embedding in outbound templates.
 func encodeFilesJSON(files []pkg.FileAttachment) string {

--- a/internal/channel/yaml_spec.go
+++ b/internal/channel/yaml_spec.go
@@ -217,8 +217,10 @@ type DedupSpec struct {
 
 // OutboundSpec describes how to send messages.
 type OutboundSpec struct {
-	Chunking ChunkingSpec `yaml:"chunking"`
-	Send     HTTPCallSpec `yaml:"send"`
+	Chunking      ChunkingSpec      `yaml:"chunking"`
+	Send          HTTPCallSpec      `yaml:"send"`
+	Update        HTTPCallSpec      `yaml:"update"`         // optional: edit an existing message (for streaming); template has {{msg.message_id}}
+	SendStoreID   string            `yaml:"send_store_id"`  // optional: JSON field in send response to capture as message ID (e.g. "ts" for Slack)
 }
 
 // ChunkingSpec configures message chunking.

--- a/internal/channel/yaml_spec.go
+++ b/internal/channel/yaml_spec.go
@@ -217,10 +217,10 @@ type DedupSpec struct {
 
 // OutboundSpec describes how to send messages.
 type OutboundSpec struct {
-	Chunking      ChunkingSpec      `yaml:"chunking"`
-	Send          HTTPCallSpec      `yaml:"send"`
-	Update        HTTPCallSpec      `yaml:"update"`         // optional: edit an existing message (for streaming); template has {{msg.message_id}}
-	SendStoreID   string            `yaml:"send_store_id"`  // optional: JSON field in send response to capture as message ID (e.g. "ts" for Slack)
+	Chunking    ChunkingSpec `yaml:"chunking"`
+	Send        HTTPCallSpec `yaml:"send"`
+	Update      HTTPCallSpec `yaml:"update"`        // optional: edit an existing message (for streaming); template has {{msg.message_id}}
+	SendStoreID string       `yaml:"send_store_id"` // optional: JSON field in send response to capture as message ID (e.g. "ts" for Slack)
 }
 
 // ChunkingSpec configures message chunking.

--- a/internal/channel/yaml_ws.go
+++ b/internal/channel/yaml_ws.go
@@ -557,6 +557,65 @@ func (ch *YAMLChannel) doHTTPCall(ctx context.Context, call HTTPCallSpec, contex
 	return nil
 }
 
+// doHTTPCallCaptureField executes a templated HTTP call and extracts a single
+// top-level string field from the JSON response. Returns "" if the field is
+// absent or the response isn't JSON. Used to capture message IDs (e.g. Slack's
+// "ts") from send responses for streaming updates.
+func (ch *YAMLChannel) doHTTPCallCaptureField(ctx context.Context, call HTTPCallSpec, contexts map[string]map[string]string, field string) (string, error) {
+	url := substituteTemplate(call.URL, contexts)
+	if url == "" {
+		return "", fmt.Errorf("empty URL after template substitution")
+	}
+
+	var bodyReader io.Reader
+	if call.Body != "" {
+		isJSON := false
+		for _, v := range call.Headers {
+			if strings.EqualFold(v, "application/json") {
+				isJSON = true
+				break
+			}
+		}
+		var resolved string
+		if isJSON {
+			resolved = substituteTemplateJSON(call.Body, contexts)
+			resolved = stripEmptyJSONValues(resolved)
+		} else {
+			resolved = substituteTemplate(call.Body, contexts)
+		}
+		bodyReader = strings.NewReader(resolved)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, strings.ToUpper(call.Method), url, bodyReader)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	for k, v := range call.Headers {
+		req.Header.Set(k, substituteTemplate(v, contexts))
+	}
+
+	resp, err := ch.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request: %w", err)
+	}
+	respBody, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, bytes.TrimSpace(respBody))
+	}
+
+	if field == "" {
+		return "", nil
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", nil // not JSON, silently ignore
+	}
+	return getStringField(parsed, field), nil
+}
+
 // navigatePath walks a dot-separated path into a nested map.
 // Returns nil if the path doesn't lead to a map.
 func navigatePath(obj map[string]interface{}, path string) map[string]interface{} {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -50,6 +50,20 @@ type LLMClient interface {
 	Complete(ctx context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error)
 }
 
+// StreamingLLMClient is an optional extension of LLMClient that supports
+// streaming responses. When the orchestrator's LLM implements this interface
+// and an OnStreamChunk callback is provided, the final-answer LLM round
+// streams tokens to the caller in real-time.
+type StreamingLLMClient interface {
+	LLMClient
+	Stream(ctx context.Context, req *provider.CompletionRequest) (provider.ResponseStream, error)
+}
+
+// StreamChunkCallback is called for each text chunk during a streaming LLM
+// response. The ctx carries the same trace/actor information as the Run call.
+// done is true on the last invocation (content may be empty).
+type StreamChunkCallback func(ctx context.Context, content string, done bool)
+
 // ToolCallParser extracts tool calls from LLM response text.
 // Returns nil if the response is a final answer (no tool calls).
 type ToolCallParser interface {
@@ -121,6 +135,7 @@ type OrchestratorOpts struct {
 	SyncActionsAction       string             // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
 	Knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
 	Subprocess              SubprocessConfig   // optional; subprocess (sub-agent) support
+	OnStreamChunk           StreamChunkCallback // optional; when set and LLM supports streaming, final answers are streamed
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -180,6 +195,7 @@ type Orchestrator struct {
 	syncActionsAction       string             // optional; action name for action sync
 	knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
 	subprocessConfig        SubprocessConfig   // optional; subprocess (sub-agent) support
+	onStreamChunk           StreamChunkCallback // optional; when set, final answers stream to caller
 }
 
 const (
@@ -301,6 +317,7 @@ func NewWithRules(
 		syncActionsPlugin:       opts.SyncActionsPlugin,
 		syncActionsAction:       opts.SyncActionsAction,
 		knowledge:               opts.Knowledge,
+		onStreamChunk:           opts.OnStreamChunk,
 	}
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)
@@ -747,7 +764,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		if profileModel != "" {
 			req.Model = profileModel
 		}
-		resp, err := o.llm.Complete(ctx, req)
+
+		// Use streaming when a callback is registered and the LLM supports it.
+		// Streaming delivers tokens to the channel in real-time while still
+		// collecting the full response for tool-call parsing.
+		// A per-request callback (from context) takes priority over the global one.
+		var resp *provider.CompletionResponse
+		streamCB := o.resolveStreamCallback(ctx)
+		if streamCB != nil {
+			resp, err = o.streamComplete(ctx, req)
+		} else {
+			resp, err = o.llm.Complete(ctx, req)
+		}
 		if err != nil {
 			return nil, fmt.Errorf("LLM completion: %w", err)
 		}
@@ -851,6 +879,61 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	}
 
 	return nil, fmt.Errorf("agent loop exceeded %d iterations", maxAgentLoopIterations)
+}
+
+// resolveStreamCallback returns the streaming callback for the current request.
+// A per-request callback (from context, set by the channel handler) takes
+// priority over the global one configured in OrchestratorOpts.
+func (o *Orchestrator) resolveStreamCallback(ctx context.Context) StreamChunkCallback {
+	if sw := pkgchannel.StreamWriterFromContext(ctx); sw != nil {
+		return sw.OnChunk
+	}
+	return o.onStreamChunk
+}
+
+// streamComplete attempts a streaming LLM call, forwarding chunks via the
+// resolved callback and returning the fully assembled response. If the LLM
+// does not support streaming it falls back to a regular Complete call.
+func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	sllm, ok := o.llm.(StreamingLLMClient)
+	if !ok {
+		return o.llm.Complete(ctx, req)
+	}
+
+	cb := o.resolveStreamCallback(ctx)
+
+	stream, err := sllm.Stream(ctx, req)
+	if err != nil {
+		// If streaming fails, fall back to non-streaming.
+		logger.FromContext(ctx).Debug("streaming unavailable, falling back to complete", "error", err)
+		return o.llm.Complete(ctx, req)
+	}
+	defer stream.Close()
+
+	var buf strings.Builder
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			return nil, fmt.Errorf("stream recv: %w", err)
+		}
+		if chunk.Content != "" {
+			buf.WriteString(chunk.Content)
+			if cb != nil {
+				cb(ctx, chunk.Content, false)
+			}
+		}
+		if chunk.Done {
+			if cb != nil {
+				cb(ctx, "", true)
+			}
+			break
+		}
+	}
+
+	return &provider.CompletionResponse{
+		Content: buf.String(),
+		// Usage is not available in streaming mode for most providers.
+	}, nil
 }
 
 // runGuardPlugins runs all guard plugins on the last non-system message before an LLM call.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -126,15 +126,15 @@ type OrchestratorOpts struct {
 	SummarizeUpdatePrompt   string                        // empty = default English
 	PipelineEnabled         bool                          // when true, create Planner from llm
 	PipelineConfig          pipeline.PipelineConfig
-	ContextWindow           int                // model context window in tokens; 0 = no trimming
-	MaxConcurrentSessions   int                // max sessions running in parallel; default 1 (sequential)
-	GroupPluginLookup       GroupPluginLookup  // optional; when set, filters tool list by profile group
-	UsageRecorder           UsageRecorder      // optional; when set, records LLM usage after each run
-	PluginCallObserver      PluginCallObserver // optional; when set, notified after each plugin/tool call
-	SyncActionsPlugin       string             // optional; plugin name for action sync (e.g. "weaviate")
-	SyncActionsAction       string             // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
-	Knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
-	Subprocess              SubprocessConfig   // optional; subprocess (sub-agent) support
+	ContextWindow           int                 // model context window in tokens; 0 = no trimming
+	MaxConcurrentSessions   int                 // max sessions running in parallel; default 1 (sequential)
+	GroupPluginLookup       GroupPluginLookup   // optional; when set, filters tool list by profile group
+	UsageRecorder           UsageRecorder       // optional; when set, records LLM usage after each run
+	PluginCallObserver      PluginCallObserver  // optional; when set, notified after each plugin/tool call
+	SyncActionsPlugin       string              // optional; plugin name for action sync (e.g. "weaviate")
+	SyncActionsAction       string              // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
+	Knowledge               KnowledgeConfig     // optional; knowledge directory ingestion
+	Subprocess              SubprocessConfig    // optional; subprocess (sub-agent) support
 	OnStreamChunk           StreamChunkCallback // optional; when set and LLM supports streaming, final answers are streamed
 }
 
@@ -187,14 +187,14 @@ type Orchestrator struct {
 	pendingMu               sync.Mutex                    // guards pendingPipelines map
 	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline (access via pendingMu)
 	pipelineConfig          pipeline.PipelineConfig
-	contextWindow           int                // model context window in tokens; 0 = no trimming
-	groupPluginLookup       GroupPluginLookup  // optional; nil = no group-based filtering
-	usageRecorder           UsageRecorder      // optional; nil = no usage tracking
-	pluginCallObserver      PluginCallObserver // optional; nil = no plugin call observation
-	syncActionsPlugin       string             // optional; plugin name for action sync
-	syncActionsAction       string             // optional; action name for action sync
-	knowledge               KnowledgeConfig    // optional; knowledge directory ingestion
-	subprocessConfig        SubprocessConfig   // optional; subprocess (sub-agent) support
+	contextWindow           int                 // model context window in tokens; 0 = no trimming
+	groupPluginLookup       GroupPluginLookup   // optional; nil = no group-based filtering
+	usageRecorder           UsageRecorder       // optional; nil = no usage tracking
+	pluginCallObserver      PluginCallObserver  // optional; nil = no plugin call observation
+	syncActionsPlugin       string              // optional; plugin name for action sync
+	syncActionsAction       string              // optional; action name for action sync
+	knowledge               KnowledgeConfig     // optional; knowledge directory ingestion
+	subprocessConfig        SubprocessConfig    // optional; subprocess (sub-agent) support
 	onStreamChunk           StreamChunkCallback // optional; when set, final answers stream to caller
 }
 
@@ -908,7 +908,7 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 		logger.FromContext(ctx).Debug("streaming unavailable, falling back to complete", "error", err)
 		return o.llm.Complete(ctx, req)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	var buf strings.Builder
 	for {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2825,8 +2825,8 @@ func TestRelevantToolsContextExplicitEmpty(t *testing.T) {
 
 // fakeStreamingLLM implements StreamingLLMClient for tests.
 type fakeStreamingLLM struct {
-	chunks    []string // each string becomes one StreamChunk
-	completeResp string // fallback for Complete
+	chunks       []string // each string becomes one StreamChunk
+	completeResp string   // fallback for Complete
 }
 
 func (f *fakeStreamingLLM) Complete(_ context.Context, _ *provider.CompletionRequest) (*provider.CompletionResponse, error) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2822,3 +2822,111 @@ func TestRelevantToolsContextExplicitEmpty(t *testing.T) {
 		t.Errorf("expected empty slice, got %v", got)
 	}
 }
+
+// fakeStreamingLLM implements StreamingLLMClient for tests.
+type fakeStreamingLLM struct {
+	chunks    []string // each string becomes one StreamChunk
+	completeResp string // fallback for Complete
+}
+
+func (f *fakeStreamingLLM) Complete(_ context.Context, _ *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	return &provider.CompletionResponse{Content: f.completeResp}, nil
+}
+
+func (f *fakeStreamingLLM) Stream(_ context.Context, _ *provider.CompletionRequest) (provider.ResponseStream, error) {
+	return &fakeResponseStream{chunks: f.chunks}, nil
+}
+
+type fakeResponseStream struct {
+	chunks []string
+	index  int
+}
+
+func (s *fakeResponseStream) Recv() (provider.StreamChunk, error) {
+	if s.index >= len(s.chunks) {
+		return provider.StreamChunk{Done: true}, nil
+	}
+	c := s.chunks[s.index]
+	s.index++
+	return provider.StreamChunk{Content: c}, nil
+}
+
+func (s *fakeResponseStream) Close() error { return nil }
+
+func TestStreamingFinalAnswer(t *testing.T) {
+	sllm := &fakeStreamingLLM{
+		chunks: []string{"Hello", " ", "world", "!"},
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	var mu sync.Mutex
+	var receivedChunks []string
+	var doneSeen bool
+
+	orch := NewWithRules(sllm, parser, registry, memory, sessions, OrchestratorOpts{
+		OnStreamChunk: func(_ context.Context, content string, done bool) {
+			mu.Lock()
+			defer mu.Unlock()
+			if done {
+				doneSeen = true
+			} else {
+				receivedChunks = append(receivedChunks, content)
+			}
+		},
+	})
+
+	result, err := orch.Run(context.Background(), "s1", "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Response != "Hello world!" {
+		t.Errorf("response = %q, want %q", result.Response, "Hello world!")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !doneSeen {
+		t.Error("expected done=true callback")
+	}
+	joined := strings.Join(receivedChunks, "")
+	if joined != "Hello world!" {
+		t.Errorf("streamed chunks = %q, want %q", joined, "Hello world!")
+	}
+}
+
+func TestStreamingFallbackToComplete(t *testing.T) {
+	// When LLM does not implement StreamingLLMClient, should fall back to Complete.
+	llm := &fakeLLM{responses: []string{"plain response"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1")
+
+	callbackCalled := false
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		OnStreamChunk: func(_ context.Context, _ string, _ bool) {
+			callbackCalled = true
+		},
+	})
+
+	result, err := orch.Run(context.Background(), "s1", "Hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Response != "plain response" {
+		t.Errorf("response = %q, want %q", result.Response, "plain response")
+	}
+	// Callback should NOT be called when falling back to Complete.
+	if callbackCalled {
+		t.Error("callback should not be called when LLM doesn't support streaming")
+	}
+}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -107,6 +108,33 @@ type oaiError struct {
 	Code    string `json:"code"`
 }
 
+// -- OpenAI streaming wire types --
+
+type oaiStreamChunk struct {
+	ID      string             `json:"id"`
+	Model   string             `json:"model"`
+	Choices []oaiStreamChoice  `json:"choices"`
+	Usage   *oaiUsage          `json:"usage,omitempty"`
+	Error   *oaiError          `json:"error,omitempty"`
+}
+
+type oaiStreamChoice struct {
+	Index        int            `json:"index"`
+	Delta        oaiStreamDelta `json:"delta"`
+	FinishReason *string        `json:"finish_reason"`
+}
+
+type oaiStreamDelta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+// oaiResponseStream implements ResponseStream over an SSE connection.
+type oaiResponseStream struct {
+	body    io.ReadCloser
+	scanner *bufio.Scanner
+}
+
 // Complete sends a non-streaming completion request.
 func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (*CompletionResponse, error) {
 	oaiReq, err := p.toOAIRequest(req)
@@ -166,9 +194,84 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	}, nil
 }
 
-// Stream is not yet implemented; returns an error.
-func (p *OpenAIProvider) Stream(_ context.Context, _ *CompletionRequest) (ResponseStream, error) {
-	return nil, fmt.Errorf("streaming not yet implemented for provider %s", p.id)
+// Stream sends a streaming completion request and returns a ResponseStream
+// that yields chunks as they arrive via SSE.
+func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (ResponseStream, error) {
+	oaiReq, err := p.toOAIRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	oaiReq.Stream = true
+
+	body, err := json.Marshal(oaiReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		p.baseURL+openAICompletionsPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	p.setHeaders(httpReq)
+
+	// Use a client without timeout for streaming; context handles cancellation.
+	streamClient := &http.Client{}
+	httpResp, err := streamClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http request: %w", err)
+	}
+
+	if httpResp.StatusCode != http.StatusOK {
+		defer func() { _ = httpResp.Body.Close() }()
+		respBody, _ := io.ReadAll(httpResp.Body)
+		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
+	}
+
+	return &oaiResponseStream{
+		body:    httpResp.Body,
+		scanner: bufio.NewScanner(httpResp.Body),
+	}, nil
+}
+
+func (s *oaiResponseStream) Recv() (StreamChunk, error) {
+	for s.scanner.Scan() {
+		line := s.scanner.Text()
+
+		// SSE format: lines prefixed with "data: "
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+
+		// OpenAI signals end-of-stream with "data: [DONE]"
+		if data == "[DONE]" {
+			return StreamChunk{Done: true}, nil
+		}
+
+		var chunk oaiStreamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue // skip malformed chunks
+		}
+		if chunk.Error != nil {
+			return StreamChunk{}, fmt.Errorf("openai stream error [%s]: %s", chunk.Error.Type, chunk.Error.Message)
+		}
+
+		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
+			return StreamChunk{Content: chunk.Choices[0].Delta.Content}, nil
+		}
+		// Empty delta (e.g. role-only chunk) — skip and read next line.
+	}
+
+	if err := s.scanner.Err(); err != nil {
+		return StreamChunk{}, fmt.Errorf("read stream: %w", err)
+	}
+	// Scanner exhausted without [DONE] — treat as done.
+	return StreamChunk{Done: true}, nil
+}
+
+func (s *oaiResponseStream) Close() error {
+	return s.body.Close()
 }
 
 func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error) {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -111,11 +111,11 @@ type oaiError struct {
 // -- OpenAI streaming wire types --
 
 type oaiStreamChunk struct {
-	ID      string             `json:"id"`
-	Model   string             `json:"model"`
-	Choices []oaiStreamChoice  `json:"choices"`
-	Usage   *oaiUsage          `json:"usage,omitempty"`
-	Error   *oaiError          `json:"error,omitempty"`
+	ID      string            `json:"id"`
+	Model   string            `json:"model"`
+	Choices []oaiStreamChoice `json:"choices"`
+	Usage   *oaiUsage         `json:"usage,omitempty"`
+	Error   *oaiError         `json:"error,omitempty"`
 }
 
 type oaiStreamChoice struct {

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -263,7 +263,7 @@ func TestOpenAIStreamHTTPError(t *testing.T) {
 func TestOpenAIStreamError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
-		fmt.Fprintf(w, "data: %s\n\n", `{"error":{"type":"server_error","message":"internal error"}}`)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", `{"error":{"type":"server_error","message":"internal error"}}`)
 	}))
 	defer server.Close()
 

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -204,10 +204,10 @@ func TestOpenAIStream(t *testing.T) {
 			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
 		}
 		for _, c := range chunks {
-			fmt.Fprintf(w, "data: %s\n\n", c)
+			_, _ = fmt.Fprintf(w, "data: %s\n\n", c)
 			flusher.Flush()
 		}
-		fmt.Fprintf(w, "data: [DONE]\n\n")
+		_, _ = fmt.Fprintf(w, "data: [DONE]\n\n")
 		flusher.Flush()
 	}))
 	defer server.Close()
@@ -223,7 +223,7 @@ func TestOpenAIStream(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	var got strings.Builder
 	for {
@@ -276,7 +276,7 @@ func TestOpenAIStreamError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	_, err = stream.Recv()
 	if err == nil {

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -175,6 +177,110 @@ func TestOpenAITrailingSlash(t *testing.T) {
 	p := NewOpenAIProvider("openai", "https://api.example.com/v1/", "key", nil)
 	if p.baseURL != "https://api.example.com/v1" {
 		t.Errorf("baseURL = %q, should strip trailing slash", p.baseURL)
+	}
+}
+
+func TestOpenAIStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req oaiRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatal(err)
+		}
+		if !req.Stream {
+			t.Error("expected stream=true")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("server does not support flushing")
+		}
+
+		chunks := []string{
+			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
+			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+			`{"id":"c1","model":"gpt-4o","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		}
+		for _, c := range chunks {
+			fmt.Fprintf(w, "data: %s\n\n", c)
+			flusher.Flush()
+		}
+		fmt.Fprintf(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil)
+
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o",
+		Messages: []Message{
+			{Role: RoleUser, Content: "Hi"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	var got strings.Builder
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if chunk.Done {
+			break
+		}
+		got.WriteString(chunk.Content)
+	}
+
+	if got.String() != "Hello world" {
+		t.Errorf("streamed content = %q, want %q", got.String(), "Hello world")
+	}
+}
+
+func TestOpenAIStreamHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "key", nil)
+
+	_, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestOpenAIStreamError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintf(w, "data: %s\n\n", `{"error":{"type":"server_error","message":"internal error"}}`)
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "key", nil)
+
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stream.Close()
+
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error from stream chunk")
 	}
 }
 

--- a/pkg/channel/stream.go
+++ b/pkg/channel/stream.go
@@ -1,0 +1,197 @@
+package channel
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// streamWriterKey is the context key for a per-request StreamWriter.
+type streamWriterKey struct{}
+
+// WithStreamWriter stores a StreamWriter in the context.
+func WithStreamWriter(ctx context.Context, sw *StreamWriter) context.Context {
+	return context.WithValue(ctx, streamWriterKey{}, sw)
+}
+
+// StreamWriterFromContext retrieves the StreamWriter from ctx, or nil if none.
+func StreamWriterFromContext(ctx context.Context) *StreamWriter {
+	sw, _ := ctx.Value(streamWriterKey{}).(*StreamWriter)
+	return sw
+}
+
+// UpdatableChannel is an optional interface that channels can implement to
+// support editing a previously sent message. This enables progressive
+// streaming updates (send a partial message, then update it as tokens arrive).
+type UpdatableChannel interface {
+	Channel
+	// SendAndCapture sends a message and returns a channel-specific message ID
+	// (e.g. Slack's "ts") that can be used for subsequent updates.
+	// Returns "" if the channel doesn't support ID capture.
+	SendAndCapture(ctx context.Context, msg OutboundMessage) (messageID string, err error)
+	// SendUpdate replaces the content of a previously sent message.
+	// messageID is the identifier returned by SendAndCapture.
+	SendUpdate(ctx context.Context, messageID string, msg OutboundMessage) error
+}
+
+// StreamWriter buffers streaming LLM chunks and progressively delivers them
+// to a channel. It debounces updates to avoid flooding the channel API.
+//
+// Usage: the handler creates a StreamWriter before calling Run(), stores it
+// in the context, and the orchestrator's streaming callback invokes OnChunk.
+type StreamWriter struct {
+	ch         Channel
+	convID     string
+	threadID   string
+	metadata   map[string]string
+
+	mu         sync.Mutex
+	buf        strings.Builder
+	lastSent   string
+	messageID  string // populated after first send, used for updates
+	done       bool
+	flushed    bool   // true if at least one flush happened
+
+	// flushInterval controls how often partial updates are sent.
+	flushInterval time.Duration
+	lastFlush     time.Time
+	// minChunkSize is the minimum new bytes before we flush (avoids tiny updates).
+	minChunkSize int
+}
+
+// NewStreamWriter creates a StreamWriter for the given channel and message routing info.
+func NewStreamWriter(ch Channel, convID, threadID string, metadata map[string]string) *StreamWriter {
+	return &StreamWriter{
+		ch:            ch,
+		convID:        convID,
+		threadID:      threadID,
+		metadata:      metadata,
+		flushInterval: 800 * time.Millisecond,
+		minChunkSize:  50,
+	}
+}
+
+// SetFlushParams overrides the flush interval and minimum chunk size.
+// Primarily useful for testing.
+func (sw *StreamWriter) SetFlushParams(interval time.Duration, minBytes int) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	sw.flushInterval = interval
+	sw.minChunkSize = minBytes
+}
+
+// OnChunk is the callback compatible with orchestrator.StreamChunkCallback.
+// It accumulates text and debounces channel sends.
+func (sw *StreamWriter) OnChunk(ctx context.Context, content string, done bool) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	if content != "" {
+		sw.buf.WriteString(content)
+	}
+
+	if done {
+		sw.done = true
+		sw.flush(ctx)
+		return
+	}
+
+	// Debounce: flush if enough time has passed AND enough new content accumulated.
+	now := time.Now()
+	newBytes := sw.buf.Len() - len(sw.lastSent)
+	if newBytes >= sw.minChunkSize && now.Sub(sw.lastFlush) >= sw.flushInterval {
+		sw.flush(ctx)
+	}
+}
+
+// Flushed returns true if the StreamWriter sent at least one message.
+func (sw *StreamWriter) Flushed() bool {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.flushed
+}
+
+// FullContent returns the complete accumulated content.
+func (sw *StreamWriter) FullContent() string {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.buf.String()
+}
+
+// flush sends or updates the message on the channel. Must be called with mu held.
+func (sw *StreamWriter) flush(ctx context.Context) {
+	current := sw.buf.String()
+	if current == sw.lastSent {
+		return
+	}
+
+	indicator := ""
+	if !sw.done {
+		indicator = " \u25CD" // typing cursor for partial messages
+	}
+
+	msg := OutboundMessage{
+		ConversationID: sw.convID,
+		ThreadID:       sw.threadID,
+		Content:        current + indicator,
+		Metadata:       sw.cloneMetadata(),
+	}
+
+	// After the first send, try to update the existing message in place.
+	if sw.flushed && sw.messageID != "" {
+		if uch, ok := sw.ch.(UpdatableChannel); ok {
+			if err := uch.SendUpdate(ctx, sw.messageID, msg); err != nil {
+				slog.Debug("stream update failed", "error", err)
+			} else {
+				sw.lastSent = current
+				sw.lastFlush = time.Now()
+				return
+			}
+		}
+	}
+
+	// First message: try SendAndCapture to get a message ID for future updates.
+	if !sw.flushed {
+		if uch, ok := sw.ch.(UpdatableChannel); ok {
+			msgID, err := uch.SendAndCapture(ctx, msg)
+			if err != nil {
+				slog.Debug("stream send-and-capture failed", "error", err)
+				return
+			}
+			sw.messageID = msgID
+		} else {
+			if err := sw.ch.Send(ctx, msg); err != nil {
+				slog.Debug("stream send failed", "error", err)
+				return
+			}
+		}
+		sw.flushed = true
+		sw.lastSent = current
+		sw.lastFlush = time.Now()
+		return
+	}
+
+	// Channel doesn't support updates and we already sent — skip intermediate
+	// flushes to avoid message spam. Only the final done=true flush goes through
+	// as a new Send so the user sees the complete text.
+	if sw.done {
+		if err := sw.ch.Send(ctx, msg); err != nil {
+			slog.Debug("stream final send failed", "error", err)
+		}
+		sw.lastSent = current
+		sw.lastFlush = time.Now()
+	}
+}
+
+func (sw *StreamWriter) cloneMetadata() map[string]string {
+	if len(sw.metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(sw.metadata))
+	for k, v := range sw.metadata {
+		out[k] = v
+	}
+	return out
+}

--- a/pkg/channel/stream.go
+++ b/pkg/channel/stream.go
@@ -42,17 +42,17 @@ type UpdatableChannel interface {
 // Usage: the handler creates a StreamWriter before calling Run(), stores it
 // in the context, and the orchestrator's streaming callback invokes OnChunk.
 type StreamWriter struct {
-	ch         Channel
-	convID     string
-	threadID   string
-	metadata   map[string]string
+	ch       Channel
+	convID   string
+	threadID string
+	metadata map[string]string
 
-	mu         sync.Mutex
-	buf        strings.Builder
-	lastSent   string
-	messageID  string // populated after first send, used for updates
-	done       bool
-	flushed    bool   // true if at least one flush happened
+	mu        sync.Mutex
+	buf       strings.Builder
+	lastSent  string
+	messageID string // populated after first send, used for updates
+	done      bool
+	flushed   bool // true if at least one flush happened
 
 	// flushInterval controls how often partial updates are sent.
 	flushInterval time.Duration

--- a/pkg/channel/stream_test.go
+++ b/pkg/channel/stream_test.go
@@ -13,10 +13,10 @@ type fakeChannel struct {
 	messages []OutboundMessage
 }
 
-func (f *fakeChannel) ID() string                  { return f.caps.ID }
-func (f *fakeChannel) Capabilities() Capabilities   { return f.caps }
+func (f *fakeChannel) ID() string                                         { return f.caps.ID }
+func (f *fakeChannel) Capabilities() Capabilities                         { return f.caps }
 func (f *fakeChannel) Start(context.Context, chan<- InboundMessage) error { return nil }
-func (f *fakeChannel) Stop() error                  { return nil }
+func (f *fakeChannel) Stop() error                                        { return nil }
 
 func (f *fakeChannel) Send(_ context.Context, msg OutboundMessage) error {
 	f.mu.Lock()

--- a/pkg/channel/stream_test.go
+++ b/pkg/channel/stream_test.go
@@ -1,0 +1,177 @@
+package channel
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// fakeChannel implements Channel for testing.
+type fakeChannel struct {
+	mu       sync.Mutex
+	caps     Capabilities
+	messages []OutboundMessage
+}
+
+func (f *fakeChannel) ID() string                  { return f.caps.ID }
+func (f *fakeChannel) Capabilities() Capabilities   { return f.caps }
+func (f *fakeChannel) Start(context.Context, chan<- InboundMessage) error { return nil }
+func (f *fakeChannel) Stop() error                  { return nil }
+
+func (f *fakeChannel) Send(_ context.Context, msg OutboundMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.messages = append(f.messages, msg)
+	return nil
+}
+
+func (f *fakeChannel) sentCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.messages)
+}
+
+func (f *fakeChannel) lastContent() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.messages) == 0 {
+		return ""
+	}
+	return f.messages[len(f.messages)-1].Content
+}
+
+// fakeUpdatableChannel implements UpdatableChannel.
+type fakeUpdatableChannel struct {
+	fakeChannel
+	updates   []OutboundMessage
+	captureID string // returned by SendAndCapture
+}
+
+func (f *fakeUpdatableChannel) SendAndCapture(_ context.Context, msg OutboundMessage) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.messages = append(f.messages, msg)
+	return f.captureID, nil
+}
+
+func (f *fakeUpdatableChannel) SendUpdate(_ context.Context, _ string, msg OutboundMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.updates = append(f.updates, msg)
+	return nil
+}
+
+func (f *fakeUpdatableChannel) updateCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.updates)
+}
+
+func TestStreamWriterContext(t *testing.T) {
+	sw := NewStreamWriter(&fakeChannel{}, "conv1", "thread1", nil)
+
+	ctx := context.Background()
+	if StreamWriterFromContext(ctx) != nil {
+		t.Error("expected nil StreamWriter from empty context")
+	}
+
+	ctx = WithStreamWriter(ctx, sw)
+	got := StreamWriterFromContext(ctx)
+	if got != sw {
+		t.Error("expected same StreamWriter from context")
+	}
+}
+
+func TestStreamWriterDoneFlush(t *testing.T) {
+	ch := &fakeChannel{caps: Capabilities{ID: "test", Edits: true}}
+	sw := NewStreamWriter(ch, "conv1", "", nil)
+
+	ctx := context.Background()
+
+	// Send a bunch of chunks then done.
+	sw.OnChunk(ctx, "Hello", false)
+	sw.OnChunk(ctx, " world", false)
+	sw.OnChunk(ctx, "!", true) // done
+
+	if !sw.Flushed() {
+		t.Error("expected Flushed()=true after done")
+	}
+	if sw.FullContent() != "Hello world!" {
+		t.Errorf("FullContent = %q, want %q", sw.FullContent(), "Hello world!")
+	}
+	// At least one Send should have happened.
+	if ch.sentCount() == 0 {
+		t.Error("expected at least one Send call")
+	}
+}
+
+func TestStreamWriterNonEditableChannel(t *testing.T) {
+	// For non-updatable channels, first flush sends, then done sends final.
+	ch := &fakeChannel{caps: Capabilities{ID: "test"}}
+	sw := NewStreamWriter(ch, "conv1", "", nil)
+	sw.SetFlushParams(0, 0)
+
+	ctx := context.Background()
+
+	sw.OnChunk(ctx, "Hello", false)
+	sw.OnChunk(ctx, " world", false)
+	sw.OnChunk(ctx, "!", true)
+
+	// Non-updatable: first send + final done send = 2 max.
+	if ch.sentCount() > 3 {
+		t.Errorf("expected at most 3 Send calls for non-updatable channel, got %d", ch.sentCount())
+	}
+	// Final message should have the complete text without cursor.
+	last := ch.lastContent()
+	if last != "Hello world!" {
+		t.Errorf("final content = %q, want %q", last, "Hello world!")
+	}
+}
+
+func TestStreamWriterWithUpdatableChannel(t *testing.T) {
+	ch := &fakeUpdatableChannel{
+		fakeChannel: fakeChannel{caps: Capabilities{ID: "test", Edits: true}},
+		captureID:   "1234567890.123456", // simulated Slack ts
+	}
+	sw := NewStreamWriter(ch, "conv1", "", nil)
+	sw.SetFlushParams(0, 1)
+
+	ctx := context.Background()
+
+	sw.OnChunk(ctx, "Hello", false)
+	sw.OnChunk(ctx, " world", false)
+	sw.OnChunk(ctx, "!", true)
+
+	// First chunk creates via SendAndCapture.
+	if ch.sentCount() < 1 {
+		t.Error("expected at least one SendAndCapture for initial message")
+	}
+	// Subsequent chunks go through SendUpdate.
+	if ch.updateCount() < 1 {
+		t.Error("expected at least one SendUpdate call")
+	}
+}
+
+func TestStreamWriterCapturesMessageID(t *testing.T) {
+	ch := &fakeUpdatableChannel{
+		fakeChannel: fakeChannel{caps: Capabilities{ID: "test", Edits: true}},
+		captureID:   "msg-ts-123",
+	}
+	sw := NewStreamWriter(ch, "conv1", "", nil)
+	sw.SetFlushParams(0, 1)
+
+	ctx := context.Background()
+
+	// First chunk triggers SendAndCapture.
+	sw.OnChunk(ctx, "partial", false)
+	// Second chunk should use SendUpdate with the captured ID.
+	sw.OnChunk(ctx, " text", false)
+	sw.OnChunk(ctx, "", true)
+
+	if ch.sentCount() != 1 {
+		t.Errorf("expected exactly 1 SendAndCapture, got %d sends", ch.sentCount())
+	}
+	if ch.updateCount() < 1 {
+		t.Errorf("expected at least 1 update, got %d", ch.updateCount())
+	}
+}


### PR DESCRIPTION
Implement end-to-end streaming from the OpenAI-compatible provider through the orchestrator to channel adapters. This dramatically reduces perceived latency — users see tokens appear in real-time instead of waiting for the full response.

- OpenAI provider: SSE streaming via Stream() method
- Orchestrator: StreamingLLMClient interface, per-request StreamWriter via context, automatic fallback to Complete() when streaming unavailable
- Channels: StreamWriter with debounced progressive updates, UpdatableChannel interface for edit-in-place (Slack chat.update), send_store_id for capturing message IDs from API responses
- Registry: auto-injects StreamWriter for channels with edits:true, skips redundant final Send when streaming already delivered