### PR TITLE
fix: increase sync_actions timeout to 2 minutes

### DIFF
--- a/internal/orchestrator/guard.go
+++ b/internal/orchestrator/guard.go
@@ -78,7 +78,12 @@ func (g *Guard) WrapContent(result ToolResult) string {
 }
 
 func (g *Guard) ExecuteWithTimeout(ctx context.Context, exec PluginExecutor, call ToolCall) ToolResult {
-	callCtx, cancel := context.WithTimeout(ctx, g.Timeout)
+	return g.ExecuteWithDeadline(ctx, exec, call, g.Timeout)
+}
+
+// ExecuteWithDeadline runs a plugin call with a caller-specified timeout.
+func (g *Guard) ExecuteWithDeadline(ctx context.Context, exec PluginExecutor, call ToolCall, timeout time.Duration) ToolResult {
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	done := make(chan ToolResult, 1)
@@ -92,7 +97,7 @@ func (g *Guard) ExecuteWithTimeout(ctx context.Context, exec PluginExecutor, cal
 	case <-callCtx.Done():
 		return ToolResult{
 			CallID: call.ID,
-			Error:  fmt.Sprintf("plugin %q timed out after %s", call.Plugin, g.Timeout),
+			Error:  fmt.Sprintf("plugin %q timed out after %s", call.Plugin, timeout),
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2091,7 +2091,9 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 	if !ok {
 		return fmt.Errorf("executor disappeared")
 	}
-	result := o.guard.ExecuteWithTimeout(ctx, exec, call)
+	// Use a longer timeout for sync_actions: the payload can be large when a
+	// plugin has many actions and the vector store needs time to upsert them.
+	result := o.guard.ExecuteWithDeadline(ctx, exec, call, 2*time.Minute)
 	if result.Error != "" {
 		return fmt.Errorf("%s", result.Error)
 	}


### PR DESCRIPTION
The default 30s plugin timeout is too short for sync_actions when a plugin has many actions to upsert into the vector store. Add Guard.ExecuteWithDeadline for caller-specified timeouts and use 2min for sync_actions calls.