### PR TITLE
feat: add user language support from WhoAmI to LLM and planner prompts

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -411,6 +411,7 @@ func main() {
 			ChannelTypeHeader: cfg.Profiles.WhoAmI.ChannelTypeHeader,
 			LimitField:        cfg.Profiles.WhoAmI.LimitField,
 			LimitTimeField:    cfg.Profiles.WhoAmI.LimitTimeField,
+			LanguageField:     cfg.Profiles.WhoAmI.LanguageField,
 			ExtraHeaders:      cfg.Profiles.WhoAmI.ExtraHeaders,
 		}
 		if d, err := time.ParseDuration(cfg.Profiles.WhoAmI.Timeout); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -107,6 +107,7 @@ type WhoAmIConfig struct {
 	LimitField        string            `yaml:"limit_field"`             // optional JSON field for token spend limit; default "limit"
 	LimitTimeField    string            `yaml:"limit_time_field"`        // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
 	CredentialsField  string            `yaml:"credentials_field"`       // optional JSON field for per-MCP-server tokens map; default "credentials"
+	LanguageField     string            `yaml:"language_field"`          // optional JSON field for user language; default "language"
 	ExtraHeaders      map[string]string `yaml:"extra_headers,omitempty"` // static headers added to every WhoAmI call; values support ${ENV_VAR}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1286,6 +1286,11 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 		sb.WriteString("\n")
 	}
 
+	if p := profile.FromContext(ctx); p != nil && p.Language != "" {
+		sb.WriteString("## Language\n")
+		fmt.Fprintf(&sb, "IMPORTANT: You MUST respond in %s. All your replies, explanations, and summaries must be written in %s.\n\n", p.Language, p.Language)
+	}
+
 	return sb.String()
 }
 

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/opentalon/opentalon/internal/profile"
 )
 
 // LLMClient is the interface the planner uses for LLM calls, matching orchestrator.LLMClient.
@@ -84,7 +86,11 @@ type planStepJSON struct {
 
 // Plan asks the LLM whether the user's message requires a multi-step pipeline or a direct action.
 func (p *Planner) Plan(ctx context.Context, message string, capabilities []CapabilityInfo) (*PlanResult, error) {
-	systemPrompt := buildPlannerPrompt(capabilities)
+	lang := ""
+	if prof := profile.FromContext(ctx); prof != nil {
+		lang = prof.Language
+	}
+	systemPrompt := buildPlannerPrompt(capabilities, lang)
 	slog.Debug("planner system prompt", "prompt", systemPrompt)
 	slog.Debug("planner user message", "message", message)
 
@@ -103,7 +109,7 @@ func (p *Planner) Plan(ctx context.Context, message string, capabilities []Capab
 	return parsePlanResponse(resp.Content)
 }
 
-func buildPlannerPrompt(capabilities []CapabilityInfo) string {
+func buildPlannerPrompt(capabilities []CapabilityInfo, language string) string {
 	var sb strings.Builder
 	sb.WriteString(`You are a task planner. Given the user's request and available tools, decide:
 1. If this is a simple single-action request, return: {"type": "direct"}
@@ -125,6 +131,9 @@ Available tools:
 				fmt.Fprintf(&sb, "  - %s: %s%s\n", param.Name, param.Description, req)
 			}
 		}
+	}
+	if language != "" {
+		fmt.Fprintf(&sb, "\nThe step names and descriptions must be written in %s.\n", language)
 	}
 	sb.WriteString("\nRespond ONLY with valid JSON, no other text.")
 	return sb.String()

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -154,7 +154,7 @@ func TestBuildPlannerPrompt(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildPlannerPrompt(caps)
+	prompt := buildPlannerPrompt(caps, "")
 	if prompt == "" {
 		t.Error("expected non-empty prompt")
 	}
@@ -182,7 +182,7 @@ func TestBuildPlannerPromptMCPDotActions(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildPlannerPrompt(caps)
+	prompt := buildPlannerPrompt(caps, "")
 
 	// The explicit format must appear so the LLM knows plugin="mcp", not "mcp.appsignal".
 	if !containsStr(prompt, "plugin=mcp | action=appsignal.get_applications") {
@@ -194,6 +194,24 @@ func TestBuildPlannerPromptMCPDotActions(t *testing.T) {
 	// The old ambiguous dot-joined form must not appear.
 	if containsStr(prompt, "mcp.appsignal.get_applications") {
 		t.Error("prompt must not contain ambiguous 'mcp.appsignal.get_applications'")
+	}
+}
+
+func TestBuildPlannerPromptWithLanguage(t *testing.T) {
+	caps := []CapabilityInfo{
+		{Name: "jira", Description: "Jira", Actions: []ActionInfo{
+			{Name: "create_issue", Description: "Create issue"},
+		}},
+	}
+	prompt := buildPlannerPrompt(caps, "English")
+	if !containsStr(prompt, "English") {
+		t.Error("prompt should contain language instruction for English")
+	}
+
+	// Without language, no language instruction should appear.
+	promptNoLang := buildPlannerPrompt(caps, "")
+	if containsStr(promptNoLang, "must be written in") {
+		t.Error("prompt without language should not contain language instruction")
 	}
 }
 

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -24,6 +24,7 @@ type Profile struct {
 	ChannelID   string                      // set by the handler; used for usage statistics
 	Model       string                      // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
 	ChannelType string                      // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
+	Language    string                      // optional response language from WhoAmI (e.g. "German", "English")
 	Limit       int                         // token spend limit per LimitWindow (0 = unlimited)
 	LimitWindow time.Duration               // rolling window for Limit (0 = unlimited)
 	Credentials map[string]CredentialHeader // per-MCP-server credentials from WhoAmI, keyed by server name

--- a/internal/profile/verifier.go
+++ b/internal/profile/verifier.go
@@ -46,6 +46,7 @@ type VerifierConfig struct {
 	LimitField        string            // optional JSON field for token spend limit; default "limit"
 	LimitTimeField    string            // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
 	CredentialsField  string            // optional JSON field for per-MCP-server credential headers; default "credentials"
+	LanguageField     string            // optional JSON field for user language; default "language"
 	ExtraHeaders      map[string]string // static headers sent on every WhoAmI call; ${ENV_VAR} expanded once at construction
 }
 
@@ -93,6 +94,9 @@ func (c *VerifierConfig) setDefaults() {
 	}
 	if c.CredentialsField == "" {
 		c.CredentialsField = "credentials"
+	}
+	if c.LanguageField == "" {
+		c.LanguageField = "language"
 	}
 	// Expand env vars in ExtraHeaders once at construction time so values are
 	// immutable for the verifier's lifetime and can't drift mid-run. Also guard
@@ -321,6 +325,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 
 	model := jsonString(raw[v.cfg.ModelField])
 	channelTypeResp := jsonString(raw[v.cfg.ChannelTypeField])
+	language := jsonString(raw[v.cfg.LanguageField])
 
 	var limit int
 	if lraw, ok := raw[v.cfg.LimitField]; ok {
@@ -354,6 +359,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 		Plugins:     plugins,
 		Model:       model,
 		ChannelType: channelTypeResp,
+		Language:    language,
 		Limit:       limit,
 		LimitWindow: limitWindow,
 		Credentials: credentials,
@@ -364,6 +370,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 		"plugins", p.Plugins,
 		"model", p.Model,
 		"channel_type", p.ChannelType,
+		"language", p.Language,
 	)
 	return p, nil
 }

--- a/internal/profile/verifier_test.go
+++ b/internal/profile/verifier_test.go
@@ -497,6 +497,77 @@ func TestVerifier_CredentialHeaders_Malformed(t *testing.T) {
 	}
 }
 
+// TestVerifier_Language verifies that the language field from the WhoAmI
+// response is stored on the profile.
+func TestVerifier_Language(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"entity_id": "u1",
+			"group":     "g1",
+			"language":  "English",
+		})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
+	defer v.Close()
+
+	p, err := v.Verify(context.Background(), "tok", "")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if p.Language != "English" {
+		t.Errorf("Language = %q, want English", p.Language)
+	}
+}
+
+// TestVerifier_Language_Missing verifies that an absent language field
+// results in an empty string (no language override).
+func TestVerifier_Language_Missing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"entity_id": "u1",
+			"group":     "g1",
+		})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
+	defer v.Close()
+
+	p, err := v.Verify(context.Background(), "tok", "")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if p.Language != "" {
+		t.Errorf("Language = %q, want empty when not provided", p.Language)
+	}
+}
+
+// TestVerifier_Language_CustomField verifies that language_field can be
+// overridden to read from a different JSON key.
+func TestVerifier_Language_CustomField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"entity_id": "u1",
+			"group":     "g1",
+			"locale":    "English",
+		})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{URL: srv.URL, LanguageField: "locale"}, nil, nil)
+	defer v.Close()
+
+	p, err := v.Verify(context.Background(), "tok", "")
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if p.Language != "English" {
+		t.Errorf("Language = %q, want English", p.Language)
+	}
+}
+
 // stubGroupSaver records calls to UpsertGroupPlugins for test assertions.
 type stubGroupSaver struct {
 	saved map[string][]string


### PR DESCRIPTION
The WhoAmI endpoint can now return a language field (e.g. "German", "English") which flows into the Profile struct and is injected into both the LLM system prompt and the pipeline planner prompt, so the assistant responds in the user's preferred language.