### PR TITLE
feat: add tool call debug formatting to Lua response formatter

### DIFF
--- a/internal/lua/runner_test.go
+++ b/internal/lua/runner_test.go
@@ -3,6 +3,7 @@ package lua
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -231,5 +232,106 @@ end
 	}
 	if result != "keep me" {
 		t.Errorf("expected no-op for empty format, got %q", result)
+	}
+}
+
+// formatResponseScriptPath returns the path to the bundled format-response.lua script.
+func formatResponseScriptPath(t *testing.T) string {
+	t.Helper()
+	// Resolve relative to this test file's package: internal/lua -> ../../scripts
+	path := filepath.Join("..", "..", "scripts", "format-response.lua")
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("resolve format-response.lua path: %v", err)
+	}
+	if _, err := os.Stat(abs); err != nil {
+		t.Skipf("format-response.lua not found at %s, skipping", abs)
+	}
+	return abs
+}
+
+func TestFormatResponseSlackToolDebug(t *testing.T) {
+	path := formatResponseScriptPath(t)
+
+	input := "[tool_call] timly.list-containers(page=1, per_page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
+	result, err := RunFormat(path, input, "slack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Debug section should use Slack blockquote format
+	if !strings.Contains(result, "> :wrench:") {
+		t.Errorf("expected Slack wrench emoji in blockquote, got:\n%s", result)
+	}
+	if !strings.Contains(result, "`timly.list-containers(page=1, per_page=1)`") {
+		t.Errorf("expected tool call in code block, got:\n%s", result)
+	}
+	// Response should be Slack-formatted (bold: *text* not **text**)
+	if !strings.Contains(result, "*7*") {
+		t.Errorf("expected Slack bold formatting, got:\n%s", result)
+	}
+	// Should not contain raw [tool_call] tags
+	if strings.Contains(result, "[tool_call]") {
+		t.Errorf("raw [tool_call] tag should be removed, got:\n%s", result)
+	}
+}
+
+func TestFormatResponseSlackToolDebugError(t *testing.T) {
+	path := formatResponseScriptPath(t)
+
+	input := "[tool_call] jira.get-issue(id=123)\n[tool_result] error: not found\n\n---\n\nI could not find that issue."
+	result, err := RunFormat(path, input, "slack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "> :x:") {
+		t.Errorf("expected error indicator in debug, got:\n%s", result)
+	}
+}
+
+func TestFormatResponseMarkdownToolDebug(t *testing.T) {
+	path := formatResponseScriptPath(t)
+
+	input := "[tool_call] timly.list-containers(page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
+	result, err := RunFormat(path, input, "markdown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "> **Tool:**") {
+		t.Errorf("expected markdown blockquote with bold, got:\n%s", result)
+	}
+	// Response body should pass through unchanged for markdown
+	if !strings.Contains(result, "**7**") {
+		t.Errorf("expected markdown bold preserved, got:\n%s", result)
+	}
+}
+
+func TestFormatResponseHTMLToolDebug(t *testing.T) {
+	path := formatResponseScriptPath(t)
+
+	input := "[tool_call] timly.list-containers(page=1)\n[tool_result] ok\n\n---\n\nDone."
+	result, err := RunFormat(path, input, "html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "<blockquote>") {
+		t.Errorf("expected HTML blockquote, got:\n%s", result)
+	}
+	if !strings.Contains(result, "<code>timly.list-containers(page=1)</code>") {
+		t.Errorf("expected HTML code tag, got:\n%s", result)
+	}
+}
+
+func TestFormatResponseNoDebugUnchanged(t *testing.T) {
+	path := formatResponseScriptPath(t)
+
+	// Normal response without tool debug blocks
+	input := "You have **7** containers."
+	result, err := RunFormat(path, input, "slack")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should just do normal Slack formatting
+	if !strings.Contains(result, "*7*") {
+		t.Errorf("expected normal Slack formatting, got:\n%s", result)
 	}
 }

--- a/scripts/format-response.lua
+++ b/scripts/format-response.lua
@@ -197,6 +197,133 @@ local function format_telegram(s)
   return format_html(s)
 end
 
+-- Format [tool_call] and [tool_result] debug blocks that appear when
+-- orchestrator.show_tool_calls is enabled. Returns (formatted_debug, rest)
+-- where rest is the response body after the "---" separator.
+-- If no debug blocks are found, returns (nil, text).
+local function split_tool_debug(text)
+  -- The orchestrator prepends: tool_call/result lines + "\n\n---\n\n" + response
+  local sep = text:find("\n\n%-%-%-%s*\n\n")
+  if not sep then return nil, text end
+
+  local debug_part = text:sub(1, sep - 1)
+  local rest = text:sub(text:find("\n", sep + 3) or sep + 5)
+  rest = rest:gsub("^%s+", "")
+
+  -- Only treat as debug if it actually contains [tool_call] lines
+  if not debug_part:find("%[tool_call%]") then
+    return nil, text
+  end
+  return debug_part, rest
+end
+
+local function format_tool_debug_slack(debug_part)
+  local lines = {}
+  for line in debug_part:gmatch("[^\n]+") do
+    -- [tool_call] plugin.action(args) -> blockquote with code
+    local tool = line:match("^%[tool_call%]%s*(.+)$")
+    if tool then
+      table.insert(lines, "> :wrench:  `" .. tool .. "`")
+    else
+      -- [tool_result] content or [tool_result] error: msg
+      local err = line:match("^%[tool_result%] error:%s*(.+)$")
+      if err then
+        table.insert(lines, "> :x:  " .. err)
+      else
+        local result = line:match("^%[tool_result%]%s*(.+)$")
+        if result then
+          -- Truncate long results for readability
+          if #result > 200 then
+            result = result:sub(1, 200) .. "..."
+          end
+          table.insert(lines, "> :white_check_mark:  `" .. result .. "`")
+        else
+          table.insert(lines, "> " .. line)
+        end
+      end
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local function format_tool_debug_html(debug_part)
+  local lines = {}
+  for line in debug_part:gmatch("[^\n]+") do
+    local tool = line:match("^%[tool_call%]%s*(.+)$")
+    if tool then
+      table.insert(lines, "<b>Tool:</b> <code>" .. tool .. "</code>")
+    else
+      local err = line:match("^%[tool_result%] error:%s*(.+)$")
+      if err then
+        table.insert(lines, "<b>Error:</b> " .. err)
+      else
+        local result = line:match("^%[tool_result%]%s*(.+)$")
+        if result then
+          if #result > 200 then
+            result = result:sub(1, 200) .. "..."
+          end
+          table.insert(lines, "<b>Result:</b> <code>" .. result .. "</code>")
+        else
+          table.insert(lines, line)
+        end
+      end
+    end
+  end
+  return "<blockquote>" .. table.concat(lines, "\n") .. "</blockquote>"
+end
+
+local function format_tool_debug_text(debug_part)
+  local lines = {}
+  for line in debug_part:gmatch("[^\n]+") do
+    local tool = line:match("^%[tool_call%]%s*(.+)$")
+    if tool then
+      table.insert(lines, "  Tool: " .. tool)
+    else
+      local err = line:match("^%[tool_result%] error:%s*(.+)$")
+      if err then
+        table.insert(lines, "  Error: " .. err)
+      else
+        local result = line:match("^%[tool_result%]%s*(.+)$")
+        if result then
+          if #result > 200 then
+            result = result:sub(1, 200) .. "..."
+          end
+          table.insert(lines, "  Result: " .. result)
+        else
+          table.insert(lines, "  " .. line)
+        end
+      end
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
+local function format_tool_debug_markdown(debug_part)
+  local lines = {}
+  for line in debug_part:gmatch("[^\n]+") do
+    local tool = line:match("^%[tool_call%]%s*(.+)$")
+    if tool then
+      table.insert(lines, "> **Tool:** `" .. tool .. "`")
+    else
+      local err = line:match("^%[tool_result%] error:%s*(.+)$")
+      if err then
+        table.insert(lines, "> **Error:** " .. err)
+      else
+        local result = line:match("^%[tool_result%]%s*(.+)$")
+        if result then
+          if #result > 200 then
+            result = result:sub(1, 200) .. "..."
+          end
+          table.insert(lines, "> **Result:** `" .. result .. "`")
+        else
+          table.insert(lines, "> " .. line)
+        end
+      end
+    end
+  end
+  return table.concat(lines, "\n")
+end
+
 -- Main entry point called by OpenTalon's response formatter pipeline.
 -- text: the LLM response
 -- response_format: channel format string ("slack", "teams", "text", etc.)
@@ -205,19 +332,22 @@ function format(text, response_format)
     return text
   end
 
+  -- Split off debug tool_call blocks (from show_tool_calls) before formatting.
+  local debug_part, rest = split_tool_debug(text)
+
+  local formatted
   if response_format == "slack" then
-    return apply_transform(text, format_slack)
+    formatted = apply_transform(rest, format_slack)
   elseif response_format == "teams" then
-    return apply_transform(text, format_teams)
+    formatted = apply_transform(rest, format_teams)
   elseif response_format == "whatsapp" then
-    return apply_transform(text, format_whatsapp)
+    formatted = apply_transform(rest, format_whatsapp)
   elseif response_format == "text" then
     -- For plain text, also strip code delimiters from protected segments
-    local segments = split_segments(text)
+    local segments = split_segments(rest)
     local parts = {}
     for _, seg in ipairs(segments) do
       if seg.protected then
-        -- Strip fences and backticks but keep content
         local inner = seg.text
         inner = inner:gsub("^```[^\n]*\n?", "")
         inner = inner:gsub("\n?```$", "")
@@ -228,13 +358,33 @@ function format(text, response_format)
         table.insert(parts, format_text(seg.text))
       end
     end
-    return table.concat(parts)
+    formatted = table.concat(parts)
   elseif response_format == "html" then
-    return apply_transform(text, format_html)
+    formatted = apply_transform(rest, format_html)
   elseif response_format == "telegram" then
-    return apply_transform(text, format_telegram)
+    formatted = apply_transform(rest, format_telegram)
   else
-    -- markdown, discord, empty: no-op
-    return text
+    -- markdown, discord, empty: no-op on response body
+    formatted = rest
   end
+
+  -- If no debug blocks, return the formatted response as-is.
+  if not debug_part then
+    return formatted
+  end
+
+  -- Format the debug blocks for the target channel.
+  local debug_formatted
+  if response_format == "slack" then
+    debug_formatted = format_tool_debug_slack(debug_part)
+  elseif response_format == "html" or response_format == "telegram" then
+    debug_formatted = format_tool_debug_html(debug_part)
+  elseif response_format == "text" then
+    debug_formatted = format_tool_debug_text(debug_part)
+  else
+    -- markdown, discord, teams, whatsapp: use markdown blockquotes
+    debug_formatted = format_tool_debug_markdown(debug_part)
+  end
+
+  return debug_formatted .. "\n\n" .. formatted
 end


### PR DESCRIPTION
When show_tool_calls is enabled, the format-response.lua script now formats [tool_call] and [tool_result] blocks per channel:

- Slack: blockquote with emoji indicators (:wrench:, :white_check_mark:, :x:)
- HTML/Telegram: <blockquote> with <code> tags
- Markdown/Discord/Teams: > blockquote with bold labels
- Plain text: indented lines

Long tool results are truncated at 200 chars for readability.