### PR TITLE
feat: LLM-driven plan narration and confirmation classification

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -623,7 +623,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	}
 	o.pendingMu.Unlock()
 	if p := pendingPipeline; p != nil {
-		decision := pipeline.ParseConfirmation(userMessage)
+		var decision pipeline.ConfirmationDecision
+		if o.planner != nil {
+			d, classErr := o.planner.ClassifyConfirmation(ctx, userMessage)
+			if classErr != nil {
+				log.Warn("confirmation classification failed, falling back to keyword match", "error", classErr)
+				decision = pipeline.ParseConfirmation(userMessage)
+			} else {
+				decision = d
+			}
+		} else {
+			decision = pipeline.ParseConfirmation(userMessage)
+		}
 		log.Debug("pipeline pending", "pipeline_id", p.ID, "session", sessionID, "input", userMessage, "decision", decision)
 		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
 		if decision == pipeline.Approved {
@@ -637,7 +648,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			return res, err
 		}
-		resp := "Pipeline cancelled (expected y/yes to confirm)."
+		resp := "Pipeline cancelled."
 		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
 		log.Debug("pipeline rejected", "pipeline_id", p.ID, "input", userMessage)
 		return &RunResult{Response: resp}, nil
@@ -688,7 +699,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			o.pendingMu.Lock()
 			o.pendingPipelines[sessionID] = p
 			o.pendingMu.Unlock()
-			planText := p.FormatForConfirmation()
+			var planText string
+			if narrated, narrateErr := o.planner.NarratePlan(ctx, planResult.Steps); narrateErr != nil {
+				log.Warn("plan narration failed, using fallback", "error", narrateErr)
+				planText = p.FormatForConfirmation()
+			} else {
+				planText = narrated
+			}
 			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: content})
 			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 			log.Debug("pipeline stored, awaiting confirmation", "pipeline_id", p.ID, "session", sessionID, "steps", len(p.Steps))

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -200,3 +200,63 @@ func extractJSON(s string) string {
 
 	return s
 }
+
+// NarratePlan asks the LLM to describe the pipeline steps in natural language
+// and invite the user to confirm or cancel.
+func (p *Planner) NarratePlan(ctx context.Context, steps []*Step) (string, error) {
+	lang := ""
+	if prof := profile.FromContext(ctx); prof != nil {
+		lang = prof.Language
+	}
+	var sb strings.Builder
+	sb.WriteString("Plan steps:\n")
+	for i, s := range steps {
+		fmt.Fprintf(&sb, "%d. %s", i+1, s.Name)
+		if s.Command != nil {
+			fmt.Fprintf(&sb, " (%s.%s)", s.Command.Plugin, s.Command.Action)
+		}
+		sb.WriteString("\n")
+	}
+	systemContent := "You are a helpful assistant. Describe the following multi-step plan to the user in 2-3 natural sentences. Name each step clearly without exposing technical details like plugin or action names. End with a short question asking if they want to proceed."
+	if lang != "" {
+		systemContent += fmt.Sprintf(" Respond in %s.", lang)
+	}
+	resp, err := p.llm.Complete(ctx, &CompletionRequest{
+		Messages: []Message{
+			{Role: "system", Content: systemContent},
+			{Role: "user", Content: sb.String()},
+		},
+	})
+	if err != nil {
+		return "", err
+	}
+	return resp.Content, nil
+}
+
+// ClassifyConfirmation asks the LLM whether the user approved or rejected the plan.
+// Returns Rejected on parse failure.
+func (p *Planner) ClassifyConfirmation(ctx context.Context, userReply string) (ConfirmationDecision, error) {
+	prompt := fmt.Sprintf(
+		"The user was shown a multi-step task plan and asked to confirm. They replied: %q\nDid they approve? Respond ONLY with valid JSON: {\"approved\": true} or {\"approved\": false}",
+		userReply,
+	)
+	resp, err := p.llm.Complete(ctx, &CompletionRequest{
+		Messages: []Message{
+			{Role: "user", Content: prompt},
+		},
+	})
+	if err != nil {
+		return Rejected, err
+	}
+	jsonStr := extractJSON(resp.Content)
+	var result struct {
+		Approved bool `json:"approved"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		return Rejected, fmt.Errorf("classify confirmation parse: %w", err)
+	}
+	if result.Approved {
+		return Approved, nil
+	}
+	return Rejected, nil
+}

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -11,6 +12,16 @@ type fakePlannerLLM struct {
 
 func (f *fakePlannerLLM) Complete(_ context.Context, _ *CompletionRequest) (*CompletionResponse, error) {
 	return &CompletionResponse{Content: f.response}, nil
+}
+
+type capturingPlannerLLM struct {
+	response string
+	captured *CompletionRequest
+}
+
+func (c *capturingPlannerLLM) Complete(_ context.Context, req *CompletionRequest) (*CompletionResponse, error) {
+	c.captured = req
+	return &CompletionResponse{Content: c.response}, nil
 }
 
 func TestPlannerReturnsDirect(t *testing.T) {
@@ -212,6 +223,92 @@ func TestBuildPlannerPromptWithLanguage(t *testing.T) {
 	promptNoLang := buildPlannerPrompt(caps, "")
 	if containsStr(promptNoLang, "must be written in") {
 		t.Error("prompt without language should not contain language instruction")
+	}
+}
+
+func TestNarratePlanReturnsLLMResponse(t *testing.T) {
+	want := "I'll fetch error details from AppSignal, then create a Jira ticket. Want me to proceed?"
+	llm := &fakePlannerLLM{response: want}
+	planner := NewPlanner(llm)
+	steps := []*Step{
+		{ID: "1", Name: "Get error details", Command: &PluginCommand{Plugin: "appsignal", Action: "get_error"}},
+		{ID: "2", Name: "Create Jira issue", Command: &PluginCommand{Plugin: "jira", Action: "create_issue"}},
+	}
+	got, err := planner.NarratePlan(context.Background(), steps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("NarratePlan = %q, want %q", got, want)
+	}
+}
+
+func TestNarratePlanIncludesStepNamesInPrompt(t *testing.T) {
+	c := &capturingPlannerLLM{response: "ok"}
+	planner := NewPlanner(c)
+	steps := []*Step{
+		{ID: "1", Name: "Fetch metrics", Command: &PluginCommand{Plugin: "p", Action: "a"}},
+	}
+	if _, err := planner.NarratePlan(context.Background(), steps); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, msg := range c.captured.Messages {
+		if strings.Contains(msg.Content, "Fetch metrics") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("NarratePlan prompt should include step names")
+	}
+}
+
+func TestClassifyConfirmationApproved(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{"approved": true}`}
+	planner := NewPlanner(llm)
+	d, err := planner.ClassifyConfirmation(context.Background(), "yes please go ahead")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != Approved {
+		t.Errorf("ClassifyConfirmation = %d, want Approved", d)
+	}
+}
+
+func TestClassifyConfirmationRejected(t *testing.T) {
+	llm := &fakePlannerLLM{response: `{"approved": false}`}
+	planner := NewPlanner(llm)
+	d, err := planner.ClassifyConfirmation(context.Background(), "no thanks cancel it")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != Rejected {
+		t.Errorf("ClassifyConfirmation = %d, want Rejected", d)
+	}
+}
+
+func TestClassifyConfirmationMarkdownWrapped(t *testing.T) {
+	llm := &fakePlannerLLM{response: "```json\n{\"approved\": true}\n```"}
+	planner := NewPlanner(llm)
+	d, err := planner.ClassifyConfirmation(context.Background(), "sure go for it")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d != Approved {
+		t.Errorf("ClassifyConfirmation = %d, want Approved", d)
+	}
+}
+
+func TestClassifyConfirmationMalformedJSON(t *testing.T) {
+	llm := &fakePlannerLLM{response: "I cannot determine that"}
+	planner := NewPlanner(llm)
+	d, err := planner.ClassifyConfirmation(context.Background(), "sure")
+	if err == nil {
+		t.Error("expected error on malformed JSON")
+	}
+	if d != Rejected {
+		t.Errorf("ClassifyConfirmation = %d, want Rejected on error", d)
 	}
 }
 


### PR DESCRIPTION
Closes #93

## Summary
- `NarratePlan`: LLM describes the plan in natural conversational language instead of the rigid `plugin.action` format; respects profile language
- `ClassifyConfirmation`: LLM classifies free-form user reply (approve/reject) — accepts "sure", "go ahead", "nope", etc.
- Both fall back to the old keyword/template path on error

## Test plan
- [ ] `TestNarratePlanReturnsLLMResponse` — narration returns LLM content
- [ ] `TestNarratePlanIncludesStepNamesInPrompt` — step names forwarded to LLM
- [ ] `TestClassifyConfirmationApproved/Rejected/MarkdownWrapped/MalformedJSON` — classification covers happy path, markdown-wrapped JSON, and error fallback