### PR TITLE
fix: expand env vars in state.db.dsn config field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -480,6 +480,9 @@ func Parse(data []byte) (*Config, error) {
 	if cfg.Metrics.Enabled && cfg.Metrics.Addr == "" {
 		cfg.Metrics.Addr = ":2112"
 	}
+	if cfg.State.DB.DSN != "" {
+		cfg.State.DB.DSN = expandEnv(cfg.State.DB.DSN)
+	}
 	if cfg.State.DataDir == "" {
 		home, _ := os.UserHomeDir()
 		cfg.State.DataDir = filepath.Join(home, ".opentalon")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -266,6 +266,26 @@ state:
 	}
 }
 
+func TestStateDBDSNEnvSubstitution(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user:pass@host:5432/db")
+	yaml := `
+models:
+  providers: {}
+state:
+  data_dir: ""
+  db:
+    driver: postgres
+    dsn: "${DATABASE_URL}"
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.State.DB.DSN != "postgres://user:pass@host:5432/db" {
+		t.Errorf("db.dsn = %q, want expanded DSN", cfg.State.DB.DSN)
+	}
+}
+
 func TestResolveStateDataDirAbsoluteUnchanged(t *testing.T) {
 	cfg, err := Parse([]byte(testYAML))
 	if err != nil {


### PR DESCRIPTION
The ${DATABASE_URL} syntax in state.db.dsn was passed as a literal string to the Postgres driver because expandEnv was never called on this field. Other config fields (redis, providers, plugins) already had env expansion.