### PR TITLE
fix: qualify ambiguous column reference in group_plugins upsert

### DIFF
--- a/internal/state/store/group_plugins.go
+++ b/internal/state/store/group_plugins.go
@@ -55,7 +55,7 @@ ON CONFLICT (group_id, plugin_id) DO UPDATE SET
     source     = excluded.source,
     updated_at = excluded.updated_at
 WHERE CASE excluded.source WHEN 'bootstrap' THEN 0 WHEN 'config' THEN 1 WHEN 'whoami' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END
-   >= CASE source           WHEN 'bootstrap' THEN 0 WHEN 'config' THEN 1 WHEN 'whoami' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END`)
+   >= CASE group_plugins.source WHEN 'bootstrap' THEN 0 WHEN 'config' THEN 1 WHEN 'whoami' THEN 2 WHEN 'admin' THEN 3 ELSE 0 END`)
 
 	tx, err := s.db.SQLDB().BeginTx(ctx, nil)
 	if err != nil {


### PR DESCRIPTION
Postgres requires explicit table qualification for column references in ON CONFLICT DO UPDATE WHERE clauses. The bare `source` was ambiguous between the existing row and the `excluded` pseudo-table, causing "column reference is ambiguous" errors on Postgres (worked on SQLite).