### PR TITLE
fix: reduce planner context by stripping knowledge_context and trunca…

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -783,7 +783,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		log.Debug("planner running", "session", sessionID, "message", content)
 		rtTools, rtSet := relevantToolsFromContext(ctx)
 		plannerCaps := filterCapabilitiesByRelevantTools(o.registry.ListCapabilities(), rtTools, rtSet)
-		planResult, err := o.planner.Plan(ctx, content, capabilitiesToPlannerInfo(plannerCaps))
+		planResult, err := o.planner.Plan(ctx, stripKnowledgeContext(content), capabilitiesToPlannerInfo(plannerCaps))
 		if err != nil {
 			log.Warn("planner error, falling through to agent loop", "error", err)
 		} else {
@@ -2037,6 +2037,22 @@ func (a *plannerLLMAdapter) Complete(ctx context.Context, req *pipeline.Completi
 }
 
 // capabilitiesToPlannerInfo converts orchestrator PluginCapability to pipeline CapabilityInfo.
+// stripKnowledgeContext removes [knowledge_context]...[/knowledge_context] blocks
+// from the message before passing it to the planner. The planner only needs the
+// user's request to decide direct vs pipeline — domain instructions waste tokens.
+func stripKnowledgeContext(s string) string {
+	const open, close = "[knowledge_context]", "[/knowledge_context]"
+	start := strings.Index(s, open)
+	if start < 0 {
+		return s
+	}
+	end := strings.Index(s, close)
+	if end < 0 {
+		return s
+	}
+	return strings.TrimSpace(s[:start] + s[end+len(close):])
+}
+
 func capabilitiesToPlannerInfo(caps []PluginCapability) []pipeline.CapabilityInfo {
 	result := make([]pipeline.CapabilityInfo, len(caps))
 	for i, cap := range caps {

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -122,13 +122,14 @@ Available tools:
 `)
 	for _, cap := range capabilities {
 		for _, action := range cap.Actions {
-			fmt.Fprintf(&sb, "- plugin=%s | action=%s: %s\n", cap.Name, action.Name, action.Description)
+			desc := truncatePlannerDescription(action.Description, 200)
+			fmt.Fprintf(&sb, "- plugin=%s | action=%s: %s\n", cap.Name, action.Name, desc)
 			for _, param := range action.Parameters {
 				req := ""
 				if param.Required {
 					req = " (required)"
 				}
-				fmt.Fprintf(&sb, "  - %s: %s%s\n", param.Name, param.Description, req)
+				fmt.Fprintf(&sb, "  - %s: %s%s\n", param.Name, truncatePlannerDescription(param.Description, 80), req)
 			}
 		}
 	}
@@ -178,6 +179,26 @@ func parsePlanResponse(content string) (*PlanResult, error) {
 	}
 
 	return &PlanResult{Type: "pipeline", Steps: steps}, nil
+}
+
+// truncatePlannerDescription shortens a description to maxLen characters for the planner prompt.
+// The planner only needs a brief summary to decide direct vs pipeline — full descriptions
+// (which can include output schemas and usage examples) waste tokens.
+func truncatePlannerDescription(s string, maxLen int) string {
+	// Strip output schema blocks that inflate descriptions.
+	if idx := strings.Index(s, "\n\nOutput schema"); idx >= 0 {
+		s = s[:idx]
+	}
+	s = strings.TrimSpace(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	// Cut at last space before maxLen to avoid mid-word truncation.
+	cut := strings.LastIndex(s[:maxLen], " ")
+	if cut < maxLen/2 {
+		cut = maxLen
+	}
+	return s[:cut] + "..."
 }
 
 // extractJSON tries to pull JSON from a response that may be wrapped in markdown code fences.


### PR DESCRIPTION
…ting descriptions

The planner received the full [knowledge_context] block (14KB+ of MCP instructions) in the user message and full tool descriptions with output schemas in the system prompt. The planner only needs the bare user request and brief tool summaries to decide direct vs pipeline.

- Strip [knowledge_context] blocks before passing to planner
- Truncate action descriptions to 200 chars, strip output schemas
- Truncate parameter descriptions to 80 chars