### PR TITLE
fix: capture token usage and model from streaming responses

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1043,6 +1043,8 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 	defer func() { _ = stream.Close() }()
 
 	var buf strings.Builder
+	var usage provider.Usage
+	var model string
 	for {
 		chunk, err := stream.Recv()
 		if err != nil {
@@ -1054,6 +1056,12 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 				cb(ctx, chunk.Content, false)
 			}
 		}
+		if chunk.Model != "" {
+			model = chunk.Model
+		}
+		if chunk.Usage.InputTokens > 0 || chunk.Usage.OutputTokens > 0 {
+			usage = chunk.Usage
+		}
 		if chunk.Done {
 			if cb != nil {
 				cb(ctx, "", true)
@@ -1064,7 +1072,8 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 
 	return &provider.CompletionResponse{
 		Content: buf.String(),
-		// Usage is not available in streaming mode for most providers.
+		Model:   model,
+		Usage:   usage,
 	}, nil
 }
 

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -71,12 +71,17 @@ func (p *OpenAIProvider) SupportsFeature(f Feature) bool {
 
 // -- OpenAI wire types --
 
+type oaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
 type oaiRequest struct {
-	Model       string       `json:"model"`
-	Messages    []oaiMessage `json:"messages"`
-	MaxTokens   int          `json:"max_tokens,omitempty"`
-	Temperature *float64     `json:"temperature,omitempty"`
-	Stream      bool         `json:"stream,omitempty"`
+	Model         string            `json:"model"`
+	Messages      []oaiMessage      `json:"messages"`
+	MaxTokens     int               `json:"max_tokens,omitempty"`
+	Temperature   *float64          `json:"temperature,omitempty"`
+	Stream        bool              `json:"stream,omitempty"`
+	StreamOptions *oaiStreamOptions `json:"stream_options,omitempty"`
 }
 
 type oaiMessage struct {
@@ -202,6 +207,7 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 		return nil, err
 	}
 	oaiReq.Stream = true
+	oaiReq.StreamOptions = &oaiStreamOptions{IncludeUsage: true}
 
 	body, err := json.Marshal(oaiReq)
 	if err != nil {
@@ -257,8 +263,27 @@ func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 			return StreamChunk{}, fmt.Errorf("openai stream error [%s]: %s", chunk.Error.Type, chunk.Error.Message)
 		}
 
+		// Usage-only chunk (sent as the final chunk when stream_options.include_usage is true).
+		// It has no choices but carries the complete usage for the request.
+		if chunk.Usage != nil && len(chunk.Choices) == 0 {
+			return StreamChunk{
+				Model: chunk.Model,
+				Usage: Usage{
+					InputTokens:  chunk.Usage.PromptTokens,
+					OutputTokens: chunk.Usage.CompletionTokens,
+				},
+			}, nil
+		}
+
 		if len(chunk.Choices) > 0 && chunk.Choices[0].Delta.Content != "" {
-			return StreamChunk{Content: chunk.Choices[0].Delta.Content}, nil
+			sc := StreamChunk{Content: chunk.Choices[0].Delta.Content, Model: chunk.Model}
+			if chunk.Usage != nil {
+				sc.Usage = Usage{
+					InputTokens:  chunk.Usage.PromptTokens,
+					OutputTokens: chunk.Usage.CompletionTokens,
+				}
+			}
+			return sc, nil
 		}
 		// Empty delta (e.g. role-only chunk) — skip and read next line.
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,6 +46,8 @@ type CompletionResponse struct {
 type StreamChunk struct {
 	Content string `json:"content"`
 	Done    bool   `json:"done"`
+	Model   string `json:"model,omitempty"`
+	Usage   Usage  `json:"usage,omitempty"`
 }
 
 type ResponseStream interface {


### PR DESCRIPTION
Streaming responses returned zero usage because the OpenAI provider didn't request stream_options.include_usage, StreamChunk had no usage fields, and streamComplete discarded any usage data.

- Add stream_options: {include_usage: true} to streaming requests
- Add Model and Usage fields to StreamChunk
- Parse usage from the final stream chunk in Recv()
- Capture usage and model in streamComplete

This fixes cost tracking for all channels with streaming (Slack, etc.) where profile_usage rows had model_id="" and 0 tokens/cost.