### PR TITLE
feat: show status labels in Slack during processing

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -898,6 +898,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		// Streaming delivers tokens to the channel in real-time while still
 		// collecting the full response for tool-call parsing.
 		// A per-request callback (from context) takes priority over the global one.
+		if i == 0 {
+			sendStatus(ctx, "Thinking\u2026")
+		}
 		var resp *provider.CompletionResponse
 		llmStart := time.Now()
 		streamCB := o.resolveStreamCallback(ctx)
@@ -987,6 +990,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 
 		for i := range calls {
 			calls[i].FromLLM = true
+			sendStatus(ctx, fmt.Sprintf("Calling %s.%s\u2026", calls[i].Plugin, calls[i].Action))
 			pluginStart := time.Now()
 			toolResult := o.executeCall(ctx, calls[i])
 			pluginDuration := time.Since(pluginStart)
@@ -1025,6 +1029,13 @@ func (o *Orchestrator) resolveStreamCallback(ctx context.Context) StreamChunkCal
 		return sw.OnChunk
 	}
 	return o.onStreamChunk
+}
+
+// sendStatus sends a transient status label to the channel if a StreamWriter is available.
+func sendStatus(ctx context.Context, label string) {
+	if sw := pkgchannel.StreamWriterFromContext(ctx); sw != nil {
+		sw.SendStatus(ctx, label)
+	}
 }
 
 // streamComplete attempts a streaming LLM call, forwarding chunks via the

--- a/pkg/channel/stream.go
+++ b/pkg/channel/stream.go
@@ -185,6 +185,43 @@ func (sw *StreamWriter) flush(ctx context.Context) {
 	}
 }
 
+// SendStatus shows a transient status label (e.g. "Thinking...", "Calling timly.list-items...")
+// on the channel. The status is displayed as a standalone message that will be replaced
+// by the first real content chunk or the next status update. Only works on updatable channels.
+func (sw *StreamWriter) SendStatus(ctx context.Context, label string) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+
+	msg := OutboundMessage{
+		ConversationID: sw.convID,
+		ThreadID:       sw.threadID,
+		Content:        "_" + label + "_",
+		Metadata:       sw.cloneMetadata(),
+	}
+
+	if sw.flushed && sw.messageID != "" {
+		if uch, ok := sw.ch.(UpdatableChannel); ok {
+			if err := uch.SendUpdate(ctx, sw.messageID, msg); err != nil {
+				slog.Debug("status update failed", "error", err)
+			}
+			return
+		}
+	}
+
+	if !sw.flushed {
+		if uch, ok := sw.ch.(UpdatableChannel); ok {
+			msgID, err := uch.SendAndCapture(ctx, msg)
+			if err != nil {
+				slog.Debug("status send failed", "error", err)
+				return
+			}
+			sw.messageID = msgID
+			sw.flushed = true
+			return
+		}
+	}
+}
+
 // FinalUpdate replaces the streamed message content with the final processed
 // response. Called by the registry after the handler returns, so the user sees
 // the clean formatted text (tool-call blocks stripped, Lua formatting applied)

--- a/pkg/channel/stream_test.go
+++ b/pkg/channel/stream_test.go
@@ -152,6 +152,41 @@ func TestStreamWriterWithUpdatableChannel(t *testing.T) {
 	}
 }
 
+func TestStreamWriterSendStatus(t *testing.T) {
+	ch := &fakeUpdatableChannel{
+		fakeChannel: fakeChannel{caps: Capabilities{ID: "test", Edits: true}},
+		captureID:   "msg-status-1",
+	}
+	sw := NewStreamWriter(ch, "conv1", "", nil)
+	ctx := context.Background()
+
+	// First status creates the message via SendAndCapture.
+	sw.SendStatus(ctx, "Thinking\u2026")
+	if ch.sentCount() != 1 {
+		t.Errorf("expected 1 send for initial status, got %d", ch.sentCount())
+	}
+	if ch.lastContent() != "_Thinking\u2026_" {
+		t.Errorf("status content = %q, want italic label", ch.lastContent())
+	}
+
+	// Second status updates the existing message.
+	sw.SendStatus(ctx, "Calling timly.list-items\u2026")
+	if ch.updateCount() < 1 {
+		t.Error("expected SendUpdate for second status")
+	}
+	last := ch.updates[len(ch.updates)-1]
+	if last.Content != "_Calling timly.list-items\u2026_" {
+		t.Errorf("updated status = %q, want italic label", last.Content)
+	}
+
+	// Real content replaces the status.
+	sw.OnChunk(ctx, "The answer is 42.", true)
+	lastUpdate := ch.updates[len(ch.updates)-1]
+	if lastUpdate.Content != "The answer is 42." {
+		t.Errorf("final content = %q, want real answer", lastUpdate.Content)
+	}
+}
+
 func TestStreamWriterFinalUpdate(t *testing.T) {
 	ch := &fakeUpdatableChannel{
 		fakeChannel: fakeChannel{caps: Capabilities{ID: "test", Edits: true}},


### PR DESCRIPTION
Add transient status indicators ("Thinking...", "Calling plugin.action...") that appear in the Slack message while the bot is working. The status is displayed as italic text and gets replaced by the first real content chunk or the next status update.

- Add SendStatus method to StreamWriter
- Send "Thinking..." before first LLM call
- Send "Calling plugin.action..." before each tool execution