### PR TITLE
fix: skip SystemPromptAddition when RAG preparer already injected it

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1371,7 +1371,10 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 				fmt.Fprintf(&sb, "  - %s: %s%s\n", p.Name, p.Description, req)
 			}
 		}
-		if cap.SystemPromptAddition != "" {
+		// When a RAG preparer ran (relevantToolsActive), server instructions are
+		// already injected in the user message via [knowledge_context]. Skip them
+		// here to avoid sending the same ~14KB block twice per request.
+		if cap.SystemPromptAddition != "" && !relevantToolsActive {
 			fmt.Fprintf(&sb, "--- plugin: %s ---\n%s\n--- end plugin: %s ---", cap.Name, cap.SystemPromptAddition, cap.Name)
 			sb.WriteString("\n")
 		}


### PR DESCRIPTION
When the weaviate preparer runs, it injects MCP server instructions into [knowledge_context] in the user message. The same instructions were also included in the system prompt via SystemPromptAddition, duplicating ~14KB per request.

Skip SystemPromptAddition from the system prompt when a RAG preparer ran (relevantToolsActive=true), since the instructions are already in the user message's knowledge context.