### PR TITLE
fix: mark continuation batches in sync_actions to prevent truncation

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2378,6 +2378,14 @@ type syncActionsPayload struct {
 	Actions            []syncActionEntry `json:"actions"`
 	ServerInstructions string            `json:"server_instructions,omitempty"`
 	KeepPlugins        []string          `json:"keep_plugins,omitempty"`
+	// IsContinuationBatch tells the sync plugin to skip the per-plugin
+	// pre-delete on this call. Set on batches 1..N of a chunked plugin sync
+	// so each subsequent batch only inserts and does not wipe what batch 0
+	// (and earlier continuation batches) already persisted. Older sync-plugin
+	// versions that don't recognize the field MUST ignore it — they will
+	// continue to pre-delete on every batch and exhibit the legacy
+	// last-batch-wins truncation behaviour.
+	IsContinuationBatch bool `json:"is_continuation_batch,omitempty"`
 }
 
 // SyncActions iterates all registered plugin capabilities and calls the configured
@@ -2483,8 +2491,9 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 
 	for i, batch := range batches {
 		payload := syncActionsPayload{
-			PluginName: cap.Name,
-			Actions:    batch,
+			PluginName:          cap.Name,
+			Actions:             batch,
+			IsContinuationBatch: i > 0,
 		}
 		if i == 0 {
 			// ServerInstructions intentionally omitted — they are already in the

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2553,6 +2553,66 @@ func TestSyncActions(t *testing.T) {
 	}
 }
 
+// TestSyncActionsMarksContinuationBatches verifies that for plugins whose
+// action count exceeds the batch size, the orchestrator only sends
+// is_continuation_batch=false on the FIRST batch (so the sync plugin runs the
+// per-plugin pre-delete) and is_continuation_batch=true on every subsequent
+// batch (so the sync plugin only inserts and does not wipe earlier batches).
+//
+// Without this flag, weaviate-plugin's unconditional pre-delete on every
+// sync_actions call wipes the previous batch's inserts — leaving only the
+// LAST batch persisted. See the companion fix in
+// opentalon/weaviate-plugin#23.
+func TestSyncActionsMarksContinuationBatches(t *testing.T) {
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+
+	// Build a plugin with 25 actions so it spans 3 batches at the default
+	// batchSize=10 (10 + 10 + 5).
+	actions := make([]Action, 25)
+	for i := range actions {
+		actions[i] = Action{Name: fmt.Sprintf("action_%02d", i), Description: "test"}
+	}
+	_ = registry.Register(PluginCapability{
+		Name: "bigplugin", Description: "Many actions", Actions: actions,
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	if len(syncCalls) != 3 {
+		t.Fatalf("expected 3 sync_actions calls (25 actions / batchSize 10), got %d", len(syncCalls))
+	}
+
+	// Batch 0: must NOT carry is_continuation_batch=true (omitted is fine —
+	// `omitempty` drops the false default — but it must not be true).
+	if strings.Contains(syncCalls[0], `"is_continuation_batch":true`) {
+		t.Errorf("batch 0 must not be marked as continuation batch: %s", syncCalls[0])
+	}
+
+	// Batches 1 and 2: MUST carry is_continuation_batch=true so the sync
+	// plugin skips the per-plugin pre-delete that would wipe batch 0's inserts.
+	for i := 1; i < len(syncCalls); i++ {
+		if !strings.Contains(syncCalls[i], `"is_continuation_batch":true`) {
+			t.Errorf("batch %d must be marked as continuation batch: %s", i, syncCalls[i])
+		}
+	}
+}
+
 func TestSyncActionsCarriesServerInstructions(t *testing.T) {
 	var syncCalls []string
 	registry := NewToolRegistry()


### PR DESCRIPTION
## Summary

Companion to opentalon/weaviate-plugin#23. When a plugin's action count exceeds \`batchSize\` (10), \`syncPluginCapability\` chunks the actions across multiple \`sync_actions\` calls. weaviate-plugin's unconditional per-plugin pre-delete at the start of every call wipes the previous batches' inserts, leaving only the LAST batch persisted.

Set \`is_continuation_batch: true\` on batches 1..N so the sync plugin can skip the wipe; batch 0 keeps the default \`false\` so the orphan-prune semantic still runs once per full sync.

## Live evidence at investigation time

\`\`\`
orchestrator: sync_actions done plugin=timly actions=66 batches=7
weaviate:     6 timly objects in MCPActions  (only batch 7 survived)
\`\`\`

Missing tools (\`list-persons\`, \`list-items\`, \`list-containers\`, \`assign-item\`, \`schedule-item\`, …) were never indexed → \`relevantTools\` filter never exposed them → agent loop could not call them → wrong tool selection (e.g. answering \"Welche Personen?\" with \`list-users\` because \`list-persons\` was simply absent from the catalog).

## Change

- New \`IsContinuationBatch\` field on \`syncActionsPayload\` (json: \`is_continuation_batch,omitempty\`).
- \`syncPluginCapability\` sets it to \`i > 0\` on each batch.

## Test plan

- [x] \`TestSyncActionsMarksContinuationBatches\` (new): plugin with 25 actions produces 3 batches; batch 0 has no \`is_continuation_batch:true\`, batches 1+2 do.
- [x] All existing \`TestSyncActions*\` tests pass.
- [x] Build clean.
- [ ] Deploy alongside companion weaviate-plugin PR and confirm 66 timly objects in MCPActions on pod restart.

## Backward compatibility

| Orchestrator | Sync plugin | Behaviour |
|---|---|---|
| Old | Old | pre-delete every batch (current bug) |
| Old | New (#23) | flag absent → default false → pre-delete every batch (no regression) |
| New (this PR) | Old | flag ignored → pre-delete every batch (no regression) |
| New | New | pre-delete only batch 0 → **fix** |

No regression in any transitional combination — the \`omitempty\` JSON tag means old payloads round-trip identically and old sync plugins ignore the unknown field.

## Related

- opentalon/weaviate-plugin#23 — sync-plugin side that honours the flag
- opentalon/mcp-plugin#21 — separate fix unblocking \`SystemPromptAddition\` capture (Ruby MCP gem strips \`instructions\` below protocol version 2025-03-26)