### PR TITLE
feat: cluster perf, narration detection, channel proto response_format

### DIFF
--- a/internal/channel/client.go
+++ b/internal/channel/client.go
@@ -153,13 +153,15 @@ func capabilitiesFromProto(pb *channelpb.ChannelCapabilities) pkg.Capabilities {
 		return pkg.Capabilities{}
 	}
 	return pkg.Capabilities{
-		ID:               pb.Id,
-		Name:             pb.Name,
-		Threads:          pb.Threads,
-		Files:            pb.Files,
-		Reactions:        pb.Reactions,
-		Edits:            pb.Edits,
-		MaxMessageLength: pb.MaxMessageLength,
+		ID:                   pb.Id,
+		Name:                 pb.Name,
+		Threads:              pb.Threads,
+		Files:                pb.Files,
+		Reactions:            pb.Reactions,
+		Edits:                pb.Edits,
+		MaxMessageLength:     pb.MaxMessageLength,
+		ResponseFormat:       pkg.ResponseFormat(pb.ResponseFormat),
+		ResponseFormatPrompt: pb.ResponseFormatPrompt,
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,11 +347,11 @@ type StateConfig struct {
 // DBConfig selects the database backend. Driver defaults to "sqlite".
 // For postgres, set driver: "postgres" and provide a DSN.
 type DBConfig struct {
-	Driver          string `yaml:"driver"`            // "sqlite" (default) or "postgres"
-	DSN             string `yaml:"dsn"`               // postgres only: e.g. "postgres://user:pass@host:5432/dbname?sslmode=require"
-	MaxOpenConns    int    `yaml:"max_open_conns"`    // max open connections (postgres only; 0 = default 25)
-	MaxIdleConns    int    `yaml:"max_idle_conns"`    // max idle connections (postgres only; 0 = default 10)
-	ConnMaxLifetime string `yaml:"conn_max_lifetime"` // max connection lifetime (postgres only; Go duration, e.g. "5m"; empty = default 5m)
+	Driver          string `yaml:"driver"`             // "sqlite" (default) or "postgres"
+	DSN             string `yaml:"dsn"`                // postgres only: e.g. "postgres://user:pass@host:5432/dbname?sslmode=require"
+	MaxOpenConns    int    `yaml:"max_open_conns"`     // max open connections (postgres only; 0 = default 25)
+	MaxIdleConns    int    `yaml:"max_idle_conns"`     // max idle connections (postgres only; 0 = default 10)
+	ConnMaxLifetime string `yaml:"conn_max_lifetime"`  // max connection lifetime (postgres only; Go duration, e.g. "5m"; empty = default 5m)
 	ConnMaxIdleTime string `yaml:"conn_max_idle_time"` // max idle time per connection (postgres only; Go duration; empty = default 5m)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -347,8 +347,12 @@ type StateConfig struct {
 // DBConfig selects the database backend. Driver defaults to "sqlite".
 // For postgres, set driver: "postgres" and provide a DSN.
 type DBConfig struct {
-	Driver string `yaml:"driver"` // "sqlite" (default) or "postgres"
-	DSN    string `yaml:"dsn"`    // postgres only: e.g. "postgres://user:pass@host:5432/dbname?sslmode=require"
+	Driver          string `yaml:"driver"`            // "sqlite" (default) or "postgres"
+	DSN             string `yaml:"dsn"`               // postgres only: e.g. "postgres://user:pass@host:5432/dbname?sslmode=require"
+	MaxOpenConns    int    `yaml:"max_open_conns"`    // max open connections (postgres only; 0 = default 25)
+	MaxIdleConns    int    `yaml:"max_idle_conns"`    // max idle connections (postgres only; 0 = default 10)
+	ConnMaxLifetime string `yaml:"conn_max_lifetime"` // max connection lifetime (postgres only; Go duration, e.g. "5m"; empty = default 5m)
+	ConnMaxIdleTime string `yaml:"conn_max_idle_time"` // max idle time per connection (postgres only; Go duration; empty = default 5m)
 }
 
 // SessionConfig limits session size and optional idle pruning.

--- a/internal/orchestrator/cached_session.go
+++ b/internal/orchestrator/cached_session.go
@@ -1,0 +1,78 @@
+package orchestrator
+
+import (
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// cachedSessionStore wraps a SessionStoreInterface with a request-scoped
+// in-memory cache. It is created at the start of Run() and garbage-collected
+// when Run() returns. The per-session lock in Run() guarantees that only one
+// goroutine accesses a given session's cache at a time, so no extra
+// synchronization is needed.
+type cachedSessionStore struct {
+	inner SessionStoreInterface
+	cache map[string]*state.Session
+}
+
+func newCachedSessionStore(inner SessionStoreInterface) *cachedSessionStore {
+	return &cachedSessionStore{inner: inner, cache: make(map[string]*state.Session)}
+}
+
+func (c *cachedSessionStore) Get(id string) (*state.Session, error) {
+	if s, ok := c.cache[id]; ok {
+		return s, nil
+	}
+	s, err := c.inner.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	// Copy so in-memory stores (which return pointers to live data) don't
+	// share the Messages slice with the cache — prevents double-append.
+	cp := *s
+	cp.Messages = make([]provider.Message, len(s.Messages))
+	copy(cp.Messages, s.Messages)
+	c.cache[id] = &cp
+	return &cp, nil
+}
+
+func (c *cachedSessionStore) Create(id, entityID, groupID string) *state.Session {
+	s := c.inner.Create(id, entityID, groupID)
+	c.cache[id] = s
+	return s
+}
+
+func (c *cachedSessionStore) AddMessage(id string, msg provider.Message) error {
+	if err := c.inner.AddMessage(id, msg); err != nil {
+		return err
+	}
+	// Update cache in-memory so subsequent Get() calls don't hit the DB.
+	if s, ok := c.cache[id]; ok {
+		s.Messages = append(s.Messages, msg)
+	}
+	return nil
+}
+
+func (c *cachedSessionStore) SetModel(id string, model provider.ModelRef) error {
+	if err := c.inner.SetModel(id, model); err != nil {
+		return err
+	}
+	if s, ok := c.cache[id]; ok {
+		s.ActiveModel = model
+	}
+	return nil
+}
+
+func (c *cachedSessionStore) SetSummary(id string, summary string, messages []provider.Message) error {
+	if err := c.inner.SetSummary(id, summary, messages); err != nil {
+		return err
+	}
+	// Invalidate — the message set changed completely.
+	delete(c.cache, id)
+	return nil
+}
+
+func (c *cachedSessionStore) Delete(id string) error {
+	delete(c.cache, id)
+	return c.inner.Delete(id)
+}

--- a/internal/orchestrator/cached_session_test.go
+++ b/internal/orchestrator/cached_session_test.go
@@ -1,0 +1,182 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// stubSessionStore is a minimal in-memory session store for testing.
+type stubSessionStore struct {
+	sessions map[string]*state.Session
+	getCalls int
+}
+
+func newStubSessionStore() *stubSessionStore {
+	return &stubSessionStore{sessions: make(map[string]*state.Session)}
+}
+
+func (s *stubSessionStore) Get(id string) (*state.Session, error) {
+	s.getCalls++
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil, &sessionNotFoundError{id}
+	}
+	// Return a copy to simulate DB behavior.
+	cp := *sess
+	cp.Messages = make([]provider.Message, len(sess.Messages))
+	copy(cp.Messages, sess.Messages)
+	return &cp, nil
+}
+
+func (s *stubSessionStore) Create(id, entityID, groupID string) *state.Session {
+	sess := &state.Session{ID: id, Messages: []provider.Message{}}
+	s.sessions[id] = sess
+	return sess
+}
+
+func (s *stubSessionStore) AddMessage(id string, msg provider.Message) error {
+	sess := s.sessions[id]
+	if sess == nil {
+		return &sessionNotFoundError{id}
+	}
+	sess.Messages = append(sess.Messages, msg)
+	return nil
+}
+
+func (s *stubSessionStore) SetModel(id string, model provider.ModelRef) error {
+	sess := s.sessions[id]
+	if sess == nil {
+		return &sessionNotFoundError{id}
+	}
+	sess.ActiveModel = model
+	return nil
+}
+
+func (s *stubSessionStore) SetSummary(id string, summary string, messages []provider.Message) error {
+	sess := s.sessions[id]
+	if sess == nil {
+		return &sessionNotFoundError{id}
+	}
+	sess.Summary = summary
+	sess.Messages = messages
+	return nil
+}
+
+func (s *stubSessionStore) Delete(id string) error {
+	delete(s.sessions, id)
+	return nil
+}
+
+type sessionNotFoundError struct{ id string }
+
+func (e *sessionNotFoundError) Error() string { return "session not found: " + e.id }
+
+func TestCachedSessionStore_GetCachesOnHit(t *testing.T) {
+	stub := newStubSessionStore()
+	stub.Create("s1", "", "")
+	cached := newCachedSessionStore(stub)
+
+	// First Get should hit the inner store.
+	s1, err := cached.Get("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s1.ID != "s1" {
+		t.Fatalf("expected s1, got %s", s1.ID)
+	}
+	if stub.getCalls != 1 {
+		t.Fatalf("expected 1 inner Get call, got %d", stub.getCalls)
+	}
+
+	// Second Get should be a cache hit — no additional inner call.
+	s2, err := cached.Get("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s2.ID != "s1" {
+		t.Fatalf("expected s1, got %s", s2.ID)
+	}
+	if stub.getCalls != 1 {
+		t.Fatalf("expected 1 inner Get call after cache hit, got %d", stub.getCalls)
+	}
+}
+
+func TestCachedSessionStore_AddMessageUpdatesCache(t *testing.T) {
+	stub := newStubSessionStore()
+	stub.Create("s1", "", "")
+	cached := newCachedSessionStore(stub)
+
+	// Populate cache.
+	if _, err := cached.Get("s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a message.
+	msg := provider.Message{Role: provider.RoleUser, Content: "hello"}
+	if err := cached.AddMessage("s1", msg); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get should return updated messages without hitting inner store again.
+	beforeCalls := stub.getCalls
+	s, err := cached.Get("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.getCalls != beforeCalls {
+		t.Fatalf("expected no additional inner Get call, got %d", stub.getCalls-beforeCalls)
+	}
+	if len(s.Messages) != 1 || s.Messages[0].Content != "hello" {
+		t.Fatalf("expected 1 message 'hello', got %v", s.Messages)
+	}
+}
+
+func TestCachedSessionStore_SetSummaryInvalidatesCache(t *testing.T) {
+	stub := newStubSessionStore()
+	stub.Create("s1", "", "")
+	cached := newCachedSessionStore(stub)
+
+	// Populate cache.
+	if _, err := cached.Get("s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// SetSummary should invalidate.
+	if err := cached.SetSummary("s1", "summary", []provider.Message{{Role: provider.RoleAssistant, Content: "kept"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Next Get should hit inner store again.
+	beforeCalls := stub.getCalls
+	s, err := cached.Get("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stub.getCalls <= beforeCalls {
+		t.Fatal("expected inner Get call after SetSummary invalidation")
+	}
+	if s.Summary != "summary" {
+		t.Fatalf("expected summary 'summary', got %q", s.Summary)
+	}
+}
+
+func TestCachedSessionStore_DeleteRemovesFromCache(t *testing.T) {
+	stub := newStubSessionStore()
+	stub.Create("s1", "", "")
+	cached := newCachedSessionStore(stub)
+
+	if _, err := cached.Get("s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cached.Delete("s1"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get after delete should fail.
+	if _, err := cached.Get("s1"); err == nil {
+		t.Fatal("expected error after delete")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -714,7 +714,12 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	sm := o.acquireSessionLock(sessionID)
 	defer o.releaseSessionLock(sessionID, sm)
 
-	if _, err := o.sessions.Get(sessionID); err != nil {
+	// Request-scoped session cache: avoids redundant DB roundtrips for
+	// sessions.Get() on every agent loop iteration. The per-session lock
+	// above guarantees single-writer access.
+	sessions := newCachedSessionStore(o.sessions)
+
+	if _, err := sessions.Get(sessionID); err != nil {
 		return nil, fmt.Errorf("session lookup: %w", err)
 	}
 	ctx = actor.WithSessionID(ctx, sessionID)
@@ -745,7 +750,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			decision = pipeline.ParseConfirmation(userMessage)
 		}
 		log.Debug("pipeline pending", "pipeline_id", p.ID, "session", sessionID, "input", userMessage, "decision", decision)
-		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
+		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
 		if decision == pipeline.Approved {
 			log.Debug("pipeline executing", "pipeline_id", p.ID, "steps", len(p.Steps))
 			res, err := o.executePipeline(ctx, sessionID, p)
@@ -758,7 +763,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			return res, err
 		}
 		resp := "Pipeline cancelled."
-		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
+		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
 		log.Debug("pipeline rejected", "pipeline_id", p.ID, "input", userMessage)
 		return &RunResult{Response: resp}, nil
 	}
@@ -822,8 +827,8 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			} else {
 				planText = narrated
 			}
-			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: content})
-			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
+			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: content})
+			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 			log.Debug("pipeline stored, awaiting confirmation", "pipeline_id", p.ID, "session", sessionID, "steps", len(p.Steps))
 			return &RunResult{Response: planText}, nil
 		}
@@ -843,7 +848,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		content = "[The user sent a file attachment.]"
 	}
 
-	if err := o.sessions.AddMessage(sessionID, provider.Message{
+	if err := sessions.AddMessage(sessionID, provider.Message{
 		Role:    provider.RoleUser,
 		Content: content,
 		Files:   files,
@@ -886,7 +891,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	var lastCallSig string // "plugin.action\x00arg1=val1\x00..." for loop detection
 	var repeatCount int
 	for i := 0; i < maxAgentLoopIterations; i++ {
-		sess, _ := o.sessions.Get(sessionID)
+		sess, _ := sessions.Get(sessionID)
 
 		// Include server instructions only on the first round — they are large
 		// (can be 10KB+) and the LLM doesn't need them again just to process
@@ -946,7 +951,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				if stripRetries >= 5 {
 					log.Debug("LLM repeatedly produced empty/unparseable response, giving up", "round", i+1)
 					result.Response = "(no response)"
-					_ = o.sessions.AddMessage(sessionID, provider.Message{
+					_ = sessions.AddMessage(sessionID, provider.Message{
 						Role:    provider.RoleAssistant,
 						Content: result.Response,
 					})
@@ -992,7 +997,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				}
 				result.InputForDisplay = strings.TrimSpace(strings.Join(parts, "\n"))
 			}
-			_ = o.sessions.AddMessage(sessionID, provider.Message{
+			_ = sessions.AddMessage(sessionID, provider.Message{
 				Role:    provider.RoleAssistant,
 				Content: resp.Content,
 			})
@@ -1054,11 +1059,11 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", perCallInput, perCallOutput)
 			}
 
-			_ = o.sessions.AddMessage(sessionID, provider.Message{
+			_ = sessions.AddMessage(sessionID, provider.Message{
 				Role:    provider.RoleAssistant,
 				Content: formatToolCallMessage(call),
 			})
-			_ = o.sessions.AddMessage(sessionID, provider.Message{
+			_ = sessions.AddMessage(sessionID, provider.Message{
 				Role:    provider.RoleUser,
 				Content: o.guard.WrapContent(toolResult),
 			})
@@ -1155,6 +1160,10 @@ type streamTagFilter struct {
 	pending    string // buffered text that might be the start of a tag
 	blockBody  string // accumulated body inside a [tool_call] block
 	showLabels bool   // when true, emit friendly "_plugin → action…_" labels
+
+	// Narration holdback: buffer outgoing text and suppress it if it
+	// turns out to be a narrated tool call like "We will call list-containers…"
+	narrationBuf string // text held back while checking for narration
 }
 
 func newStreamTagFilter(showLabels bool) *streamTagFilter {
@@ -1219,7 +1228,71 @@ func (f *streamTagFilter) Feed(text string) string {
 			f.pending = ""
 		}
 	}
+	return f.filterNarration(out.String())
+}
+
+// filterNarration buffers outgoing text and suppresses it if it matches a
+// narrated tool call pattern (e.g. "We will call list-containers…"). Text is
+// held back until a sentence boundary (period, newline) confirms or refutes
+// the narration. If the sentence is not a narration, the held-back text is
+// flushed to the caller.
+func (f *streamTagFilter) filterNarration(text string) string {
+	if text == "" {
+		return ""
+	}
+	f.narrationBuf += text
+
+	var out strings.Builder
+
+	// Process sentence by sentence. A "sentence" ends at '.' or '\n'.
+	for {
+		idx := strings.IndexAny(f.narrationBuf, ".\n")
+		if idx < 0 {
+			// No sentence boundary yet — keep buffering if the text so far
+			// could still be the start of a narration.
+			if couldBeNarration(f.narrationBuf) {
+				break
+			}
+			// Not a narration prefix — release everything.
+			out.WriteString(f.narrationBuf)
+			f.narrationBuf = ""
+			break
+		}
+
+		sentence := f.narrationBuf[:idx+1]
+		f.narrationBuf = f.narrationBuf[idx+1:]
+
+		if hasNarratedToolCall(sentence) || hasNarratedIntent(sentence) {
+			// Suppress the narrated sentence; continue processing remainder.
+			continue
+		}
+		out.WriteString(sentence)
+	}
+
 	return out.String()
+}
+
+// couldBeNarration returns true if s could be the beginning of a narrated
+// tool call sentence. Matches common LLM narration prefixes.
+func couldBeNarration(s string) bool {
+	lower := strings.ToLower(strings.TrimSpace(s))
+	prefixes := []string{
+		"we will", "we'll", "we need to", "we should",
+		"i will", "i'll", "i need to", "i'm going to",
+		"let me", "let's",
+		"now ", "next ",
+		"i'll fetch", "we'll fetch", "i'll check", "we'll check",
+		"i'll get", "we'll get", "i'll look", "we'll look",
+		"i'll search", "we'll search", "i'll query", "we'll query",
+		"i'll find", "we'll find", "i'll list", "we'll list",
+		"i'll count", "we'll count", "i'll retrieve", "we'll retrieve",
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // Flush returns any buffered text that was held back for partial tag matching.
@@ -1231,7 +1304,18 @@ func (f *streamTagFilter) Flush() string {
 	if f.inside {
 		// Unclosed block — drop the buffered content.
 		f.inside = false
-		return ""
+		s = ""
+	}
+	// Release any narration buffer — fail-open: if the stream ends
+	// mid-sentence, show the text rather than swallowing it.
+	if f.narrationBuf != "" {
+		held := f.narrationBuf
+		f.narrationBuf = ""
+		// Even on flush, suppress confirmed narrations.
+		if hasNarratedToolCall(held) || hasNarratedIntent(held) {
+			return s
+		}
+		return s + held
 	}
 	return s
 }

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -128,7 +128,7 @@ func (defaultParser) Parse(response string) []ToolCall {
 		// Fallback: detect narrated tool calls in plain text.
 		// Weak LLMs sometimes say "We need to call timly__list-items" instead
 		// of using [tool_call] format. Flag this so the orchestrator can retry.
-		if hasNarratedToolCall(response) {
+		if hasNarratedToolCall(response) || hasNarratedIntent(response) {
 			return narratedToolCallPlaceholder
 		}
 		// We found [tool_call] blocks (or Claude's native XML variants) but
@@ -411,7 +411,20 @@ func parseXMLParameters(body string) map[string]string {
 
 // narratedToolRe matches tool names in plain text narration from weak LLMs.
 // Captures patterns like "call timly.timly__list-items" or "use timly__list-container-types".
-var narratedToolRe = regexp.MustCompile(`(?i)(?:call|use|invoke|execute|run)\s+` + "`?" + `([a-zA-Z0-9_.-]+(?:\.[a-zA-Z0-9_.-]+|__[a-zA-Z0-9_-]+))` + "`?")
+var narratedToolRe = regexp.MustCompile(`(?i)(?:call|use|invoke|execute|run|fetch|query|check|search|look\s*up|retrieve)\s+` + "`?" + `([a-zA-Z0-9_.-]+(?:\.[a-zA-Z0-9_.-]+|__[a-zA-Z0-9_-]+))` + "`?")
+
+// narratedIntentRe matches broad narration patterns where the LLM announces it
+// will do something without naming a specific tool. Examples:
+//   - "We'll fetch the total count of items."
+//   - "I'll look up your inventory."
+//   - "Let me check how many items you have."
+var narratedIntentRe = regexp.MustCompile(`(?i)^(?:we'?(?:ll| will)|i'?(?:ll| will)|let me|let'?s|i'?m going to|i need to|we need to|we should)\s+(?:fetch|get|check|look|search|query|retrieve|find|list|count|pull|grab|load)`)
+
+// hasNarratedIntent returns true if the response is the LLM announcing its
+// intent to act without producing a [tool_call] block.
+func hasNarratedIntent(response string) bool {
+	return narratedIntentRe.MatchString(strings.TrimSpace(response))
+}
 
 // narratedToolCallPlaceholder is returned when the LLM narrated a tool call
 // instead of using [tool_call] format. The orchestrator detects this via

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -468,13 +468,22 @@ func TestParseBareJSONToolCall(t *testing.T) {
 }
 
 func TestParseBareJSONToolCall_WithSurroundingText(t *testing.T) {
-	// Bare JSON mixed with text should NOT be parsed (avoid false positives).
+	// "Let me look that up." matches narrated intent detection, so
+	// it correctly returns a narrated placeholder for retry.
 	response := `Let me look that up.
 {"tool": "myapp.search", "args": {"q": "test"}}`
 
 	calls := DefaultParser.Parse(response)
-	if calls != nil {
-		t.Errorf("expected nil for bare JSON with surrounding text, got %v", calls)
+	if !IsNarratedPlaceholder(calls) {
+		t.Errorf("expected narrated placeholder for bare JSON with narration prefix, got %v", calls)
+	}
+
+	// Non-narrated text with bare JSON should NOT be parsed.
+	response2 := `Here are some results:
+{"tool": "myapp.search", "args": {"q": "test"}}`
+	calls2 := DefaultParser.Parse(response2)
+	if calls2 != nil {
+		t.Errorf("expected nil for bare JSON with non-narrated text, got %v", calls2)
 	}
 }
 
@@ -528,11 +537,25 @@ func TestParseXMLFunctionCalls_NoArgs(t *testing.T) {
 func TestParseNarratedToolCall(t *testing.T) {
 	// Narrated tool calls return a placeholder — the orchestrator retries with "?".
 	matches := []string{
+		// Tool-name narration (narratedToolRe):
 		"We need to call timly.timly__list-container-types.",
 		"I'll call timly__list-items to check.",
 		"Let me use timly.timly__show-person to look that up.",
 		"We should call `timly.timly__list-items`.",
 		"Call timly.timly__list-items and also call timly.timly__list-persons.",
+		"I need to fetch timly__list-items to check.",
+		"Let me query timly.timly__list-items.",
+		// Intent narration without tool name (narratedIntentRe):
+		"We'll fetch the total count of items (including regular items, twins, and stock items).",
+		"I'll check how many items you have.",
+		"Let me look up your inventory.",
+		"I'll get the item count for you.",
+		"We'll search for all items in your account.",
+		"I'll retrieve the data now.",
+		"Let me find the matching records.",
+		"I'll list all items.",
+		"We'll count the items for you.",
+		"I'm going to fetch the list.",
 	}
 	for _, input := range matches {
 		calls := DefaultParser.Parse(input)
@@ -541,8 +564,15 @@ func TestParseNarratedToolCall(t *testing.T) {
 		}
 	}
 	// No match — should return nil.
-	calls := DefaultParser.Parse("Here are your results.")
-	if calls != nil {
-		t.Errorf("expected nil for non-narrated text, got %v", calls)
+	noMatch := []string{
+		"Here are your results.",
+		"You have 42 items in your account.",
+		"The item was successfully assigned.",
+	}
+	for _, input := range noMatch {
+		calls := DefaultParser.Parse(input)
+		if calls != nil {
+			t.Errorf("expected nil for non-narrated text %q, got %v", input, calls)
+		}
 	}
 }

--- a/internal/orchestrator/stream_filter_test.go
+++ b/internal/orchestrator/stream_filter_test.go
@@ -100,6 +100,47 @@ func TestStreamTagFilter_HiddenMode(t *testing.T) {
 	}
 }
 
+func TestStreamTagFilter_NarratedToolCallSuppressed(t *testing.T) {
+	f := newStreamTagFilter(false)
+	out := f.Feed("We will call timly__list-containers with subcategory filter.")
+	out += f.Flush()
+	if out != "" {
+		t.Errorf("narrated tool call should be suppressed, got %q", out)
+	}
+}
+
+func TestStreamTagFilter_NarratedChunked(t *testing.T) {
+	f := newStreamTagFilter(false)
+	var out string
+	out += f.Feed("We will ")
+	out += f.Feed("call timly__list-containers")
+	out += f.Feed(" with subcategory filter.")
+	out += f.Flush()
+	if out != "" {
+		t.Errorf("chunked narrated tool call should be suppressed, got %q", out)
+	}
+}
+
+func TestStreamTagFilter_NarratedFollowedByRealContent(t *testing.T) {
+	f := newStreamTagFilter(false)
+	var out string
+	out += f.Feed("Let me use timly__show-container to look that up.\nHere are the details.")
+	out += f.Flush()
+	// The narrated sentence should be suppressed, the real content kept.
+	if out != "\nHere are the details." {
+		t.Errorf("expected real content only, got %q", out)
+	}
+}
+
+func TestStreamTagFilter_NormalTextPassesThrough(t *testing.T) {
+	f := newStreamTagFilter(false)
+	out := f.Feed("The container has 5 items inside it.")
+	out += f.Flush()
+	if out != "The container has 5 items inside it." {
+		t.Errorf("normal text should pass through, got %q", out)
+	}
+}
+
 func TestToolCallFriendlyLabel(t *testing.T) {
 	tests := []struct {
 		body string

--- a/internal/state/store/db.go
+++ b/internal/state/store/db.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/opentalon/opentalon/internal/config"
@@ -72,6 +73,28 @@ func Open(cfg config.DBConfig, dataDir string) (*DB, error) {
 		if err = rawDB.Ping(); err != nil {
 			_ = rawDB.Close()
 			return nil, fmt.Errorf("state store: ping postgres: %w", err)
+		}
+		// Connection pool tuning — sensible defaults for a system doing 10-15+
+		// queries per request. Operators can override via config.
+		maxOpen := cfg.MaxOpenConns
+		if maxOpen <= 0 {
+			maxOpen = 25
+		}
+		rawDB.SetMaxOpenConns(maxOpen)
+		maxIdle := cfg.MaxIdleConns
+		if maxIdle <= 0 {
+			maxIdle = 10
+		}
+		rawDB.SetMaxIdleConns(maxIdle)
+		if lt, err := time.ParseDuration(cfg.ConnMaxLifetime); err == nil && lt > 0 {
+			rawDB.SetConnMaxLifetime(lt)
+		} else {
+			rawDB.SetConnMaxLifetime(5 * time.Minute)
+		}
+		if it, err := time.ParseDuration(cfg.ConnMaxIdleTime); err == nil && it > 0 {
+			rawDB.SetConnMaxIdleTime(it)
+		} else {
+			rawDB.SetConnMaxIdleTime(5 * time.Minute)
 		}
 
 	default:

--- a/internal/state/store/session.go
+++ b/internal/state/store/session.go
@@ -85,33 +85,39 @@ func (s *SessionStore) Create(id, entityID, groupID string) *state.Session {
 }
 
 // AddMessage inserts a message into the messages table and updates the session timestamp.
+// All statements run in a single transaction to reduce network roundtrips to PostgreSQL.
 func (s *SessionStore) AddMessage(id string, msg provider.Message) error {
 	ctx := context.Background()
 	d := s.db.Dialect()
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	tx, err := s.db.SQLDB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("add message begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
 	// Atomically assign next seq in a single statement to avoid race conditions
 	// between concurrent AddMessage calls.
-	_, err := s.db.SQLDB().ExecContext(ctx,
+	if _, err := tx.ExecContext(ctx,
 		d.Rebind(`INSERT INTO messages (session_id, seq, role, content, created_at)
 		SELECT ?, COALESCE(MAX(seq), 0) + 1, ?, ?, ? FROM messages WHERE session_id = ?`),
-		id, string(msg.Role), msg.Content, now, id)
-	if err != nil {
+		id, string(msg.Role), msg.Content, now, id); err != nil {
 		return fmt.Errorf("add message insert: %w", err)
 	}
 
 	// Trim if maxMessages is set.
 	if s.maxMessages > 0 {
-		_, _ = s.db.SQLDB().ExecContext(ctx,
+		_, _ = tx.ExecContext(ctx,
 			d.Rebind(`DELETE FROM messages WHERE session_id = ? AND seq <= (SELECT MAX(seq) - ? FROM messages WHERE session_id = ?)`),
 			id, s.maxMessages, id)
 	}
 
 	// Touch session updated_at.
-	_, _ = s.db.SQLDB().ExecContext(ctx,
+	_, _ = tx.ExecContext(ctx,
 		d.Rebind(`UPDATE sessions SET updated_at = ? WHERE id = ?`), now, id)
 
-	return nil
+	return tx.Commit()
 }
 
 // SetModel updates the active model and persists.

--- a/pkg/channel/channelpb/channel.pb.go
+++ b/pkg/channel/channelpb/channel.pb.go
@@ -613,16 +613,18 @@ func (x *FileAttachment) GetSize() int64 {
 }
 
 type ChannelCapabilities struct {
-	state            protoimpl.MessageState `protogen:"open.v1"`
-	Id               string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Name             string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
-	Threads          bool                   `protobuf:"varint,3,opt,name=threads,proto3" json:"threads,omitempty"`
-	Files            bool                   `protobuf:"varint,4,opt,name=files,proto3" json:"files,omitempty"`
-	Reactions        bool                   `protobuf:"varint,5,opt,name=reactions,proto3" json:"reactions,omitempty"`
-	Edits            bool                   `protobuf:"varint,6,opt,name=edits,proto3" json:"edits,omitempty"`
-	MaxMessageLength int64                  `protobuf:"varint,7,opt,name=max_message_length,json=maxMessageLength,proto3" json:"max_message_length,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Id                   string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name                 string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Threads              bool                   `protobuf:"varint,3,opt,name=threads,proto3" json:"threads,omitempty"`
+	Files                bool                   `protobuf:"varint,4,opt,name=files,proto3" json:"files,omitempty"`
+	Reactions            bool                   `protobuf:"varint,5,opt,name=reactions,proto3" json:"reactions,omitempty"`
+	Edits                bool                   `protobuf:"varint,6,opt,name=edits,proto3" json:"edits,omitempty"`
+	MaxMessageLength     int64                  `protobuf:"varint,7,opt,name=max_message_length,json=maxMessageLength,proto3" json:"max_message_length,omitempty"`
+	ResponseFormat       string                 `protobuf:"bytes,8,opt,name=response_format,json=responseFormat,proto3" json:"response_format,omitempty"`
+	ResponseFormatPrompt string                 `protobuf:"bytes,9,opt,name=response_format_prompt,json=responseFormatPrompt,proto3" json:"response_format_prompt,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ChannelCapabilities) Reset() {
@@ -704,6 +706,20 @@ func (x *ChannelCapabilities) GetMaxMessageLength() int64 {
 	return 0
 }
 
+func (x *ChannelCapabilities) GetResponseFormat() string {
+	if x != nil {
+		return x.ResponseFormat
+	}
+	return ""
+}
+
+func (x *ChannelCapabilities) GetResponseFormatPrompt() string {
+	if x != nil {
+		return x.ResponseFormatPrompt
+	}
+	return ""
+}
+
 var File_channel_proto protoreflect.FileDescriptor
 
 const file_channel_proto_rawDesc = "" +
@@ -764,7 +780,7 @@ const file_channel_proto_rawDesc = "" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1b\n" +
 	"\tmime_type\x18\x02 \x01(\tR\bmimeType\x12\x12\n" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x12\x12\n" +
-	"\x04size\x18\x04 \x01(\x03R\x04size\"\xcb\x01\n" +
+	"\x04size\x18\x04 \x01(\x03R\x04size\"\xaa\x02\n" +
 	"\x13ChannelCapabilities\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x18\n" +
@@ -772,7 +788,9 @@ const file_channel_proto_rawDesc = "" +
 	"\x05files\x18\x04 \x01(\bR\x05files\x12\x1c\n" +
 	"\treactions\x18\x05 \x01(\bR\treactions\x12\x14\n" +
 	"\x05edits\x18\x06 \x01(\bR\x05edits\x12,\n" +
-	"\x12max_message_length\x18\a \x01(\x03R\x10maxMessageLength2\xa3\x03\n" +
+	"\x12max_message_length\x18\a \x01(\x03R\x10maxMessageLength\x12'\n" +
+	"\x0fresponse_format\x18\b \x01(\tR\x0eresponseFormat\x124\n" +
+	"\x16response_format_prompt\x18\t \x01(\tR\x14responseFormatPrompt2\xa3\x03\n" +
 	"\x0eChannelService\x12Q\n" +
 	"\fCapabilities\x12\x16.google.protobuf.Empty\x1a).opentalon.channel.v1.ChannelCapabilities\x12\\\n" +
 	"\tConfigure\x12&.opentalon.channel.v1.ConfigureRequest\x1a'.opentalon.channel.v1.ConfigureResponse\x12D\n" +

--- a/pkg/channel/convert.go
+++ b/pkg/channel/convert.go
@@ -10,13 +10,15 @@ import (
 
 func capabilitiesToProto(c Capabilities) *channelpb.ChannelCapabilities {
 	return &channelpb.ChannelCapabilities{
-		Id:               c.ID,
-		Name:             c.Name,
-		Threads:          c.Threads,
-		Files:            c.Files,
-		Reactions:        c.Reactions,
-		Edits:            c.Edits,
-		MaxMessageLength: c.MaxMessageLength,
+		Id:                   c.ID,
+		Name:                 c.Name,
+		Threads:              c.Threads,
+		Files:                c.Files,
+		Reactions:            c.Reactions,
+		Edits:                c.Edits,
+		MaxMessageLength:     c.MaxMessageLength,
+		ResponseFormat:       string(c.ResponseFormat),
+		ResponseFormatPrompt: c.ResponseFormatPrompt,
 	}
 }
 

--- a/proto/channel.proto
+++ b/proto/channel.proto
@@ -82,4 +82,6 @@ message ChannelCapabilities {
   bool reactions = 5;
   bool edits = 6;
   int64 max_message_length = 7;
+  string response_format = 8;
+  string response_format_prompt = 9;
 }


### PR DESCRIPTION
- Session cache in Run() to avoid redundant DB roundtrips
- PostgreSQL connection pool tuning with sensible defaults
- AddMessage wrapped in single transaction
- Broader narrated tool call detection (intent without tool name)
- Stream filter suppresses narrated text before it reaches user
- Add response_format/response_format_prompt to channel gRPC proto