### PR TITLE
feat: reasoning support enabled by default

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -917,6 +917,15 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			req.Model = profileModel
 		}
 
+		// Enable reasoning when the provider supports it. Reasoning
+		// helps the model decide which tools to call instead of narrating.
+		if o.supportsReasoning() {
+			req.Reasoning = true
+			if p := profile.FromContext(ctx); p != nil && p.BudgetTokens > 0 {
+				req.BudgetTokens = p.BudgetTokens
+			}
+		}
+
 		// Use streaming when a callback is registered and the LLM supports it.
 		// Streaming delivers tokens to the channel in real-time while still
 		// collecting the full response for tool-call parsing.
@@ -1076,6 +1085,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 // resolveStreamCallback returns the streaming callback for the current request.
 // A per-request callback (from context, set by the channel handler) takes
 // priority over the global one configured in OrchestratorOpts.
+// ReasoningProvider is an optional interface that LLM providers implement
+// to indicate they support extended thinking / reasoning.
+type ReasoningProvider interface {
+	SupportsFeature(feature provider.Feature) bool
+}
+
+// supportsReasoning returns true if the underlying LLM provider supports reasoning.
+func (o *Orchestrator) supportsReasoning() bool {
+	rp, ok := o.llm.(ReasoningProvider)
+	return ok && rp.SupportsFeature(provider.FeatureReasoning)
+}
+
 func (o *Orchestrator) resolveStreamCallback(ctx context.Context) StreamChunkCallback {
 	if sw := pkgchannel.StreamWriterFromContext(ctx); sw != nil {
 		return sw.OnChunk

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -17,15 +17,16 @@ type CredentialHeader struct {
 
 // Profile is the verified identity of an inbound message's sender.
 type Profile struct {
-	EntityID    string                      // stable identifier from the WhoAmI server (used for session/memory scoping)
-	Group       string                      // group name from the WhoAmI server (used for tool-access control)
-	Token       string                      // original bearer token (may be forwarded to MCP servers)
-	Plugins     []string                    // plugin IDs returned by WhoAmI (auto-saved to group_plugins table)
-	ChannelID   string                      // set by the handler; used for usage statistics
-	Model       string                      // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
-	ChannelType string                      // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
-	Language    string                      // optional response language from WhoAmI (e.g. "German", "English")
-	Limit       int                         // token spend limit per LimitWindow (0 = unlimited)
-	LimitWindow time.Duration               // rolling window for Limit (0 = unlimited)
-	Credentials map[string]CredentialHeader // per-MCP-server credentials from WhoAmI, keyed by server name
+	EntityID     string                      // stable identifier from the WhoAmI server (used for session/memory scoping)
+	Group        string                      // group name from the WhoAmI server (used for tool-access control)
+	Token        string                      // original bearer token (may be forwarded to MCP servers)
+	Plugins      []string                    // plugin IDs returned by WhoAmI (auto-saved to group_plugins table)
+	ChannelID    string                      // set by the handler; used for usage statistics
+	Model        string                      // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
+	ChannelType  string                      // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
+	Language     string                      // optional response language from WhoAmI (e.g. "German", "English")
+	Limit        int                         // token spend limit per LimitWindow (0 = unlimited)
+	LimitWindow  time.Duration               // rolling window for Limit (0 = unlimited)
+	BudgetTokens int                         // reasoning budget tokens from WhoAmI (0 = provider default)
+	Credentials  map[string]CredentialHeader // per-MCP-server credentials from WhoAmI, keyed by server name
 }

--- a/internal/profile/verifier.go
+++ b/internal/profile/verifier.go
@@ -47,6 +47,7 @@ type VerifierConfig struct {
 	LimitTimeField    string            // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
 	CredentialsField  string            // optional JSON field for per-MCP-server credential headers; default "credentials"
 	LanguageField     string            // optional JSON field for user language; default "language"
+	BudgetTokensField string            // optional JSON field for reasoning budget tokens; default "budget_tokens"
 	ExtraHeaders      map[string]string // static headers sent on every WhoAmI call; ${ENV_VAR} expanded once at construction
 }
 
@@ -97,6 +98,9 @@ func (c *VerifierConfig) setDefaults() {
 	}
 	if c.LanguageField == "" {
 		c.LanguageField = "language"
+	}
+	if c.BudgetTokensField == "" {
+		c.BudgetTokensField = "budget_tokens"
 	}
 	// Expand env vars in ExtraHeaders once at construction time so values are
 	// immutable for the verifier's lifetime and can't drift mid-run. Also guard
@@ -344,6 +348,11 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 		}
 	}
 
+	var budgetTokens int
+	if braw, ok := raw[v.cfg.BudgetTokensField]; ok {
+		_ = json.Unmarshal(braw, &budgetTokens) // best-effort; 0 if missing or malformed
+	}
+
 	var credentials map[string]CredentialHeader
 	if craw, ok := raw[v.cfg.CredentialsField]; ok {
 		if err := json.Unmarshal(craw, &credentials); err != nil {
@@ -353,16 +362,17 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 	}
 
 	p := &Profile{
-		EntityID:    entityID,
-		Group:       group,
-		Token:       token,
-		Plugins:     plugins,
-		Model:       model,
-		ChannelType: channelTypeResp,
-		Language:    language,
-		Limit:       limit,
-		LimitWindow: limitWindow,
-		Credentials: credentials,
+		EntityID:     entityID,
+		Group:        group,
+		Token:        token,
+		Plugins:      plugins,
+		Model:        model,
+		ChannelType:  channelTypeResp,
+		Language:     language,
+		Limit:        limit,
+		LimitWindow:  limitWindow,
+		BudgetTokens: budgetTokens,
+		Credentials:  credentials,
 	}
 	slog.DebugContext(ctx, "whoami profile resolved",
 		"entity_id", p.EntityID,

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -73,6 +73,12 @@ type anthRequest struct {
 	System    string        `json:"system,omitempty"`
 	Messages  []anthMessage `json:"messages"`
 	MaxTokens int           `json:"max_tokens"`
+	Thinking  *anthThinking `json:"thinking,omitempty"`
+}
+
+type anthThinking struct {
+	Type         string `json:"type"`          // "enabled" or "disabled"
+	BudgetTokens int    `json:"budget_tokens"` // max tokens for thinking
 }
 
 type anthMessage struct {
@@ -192,12 +198,26 @@ func (p *AnthropicProvider) toAnthRequest(req *CompletionRequest) (anthRequest, 
 		maxTokens = 4096
 	}
 
-	return anthRequest{
+	ar := anthRequest{
 		Model:     req.Model,
 		System:    system,
 		Messages:  msgs,
 		MaxTokens: maxTokens,
-	}, nil
+	}
+
+	if req.Reasoning {
+		budget := req.BudgetTokens
+		if budget == 0 {
+			budget = 10000 // default thinking budget
+		}
+		ar.Thinking = &anthThinking{Type: "enabled", BudgetTokens: budget}
+		// Anthropic requires max_tokens to be at least budget_tokens + expected output.
+		if ar.MaxTokens < budget+1024 {
+			ar.MaxTokens = budget + 4096
+		}
+	}
+
+	return ar, nil
 }
 
 // toAnthMessage converts a provider.Message to an anthMessage.
@@ -264,6 +284,8 @@ func (p *AnthropicProvider) toAnthMessage(m Message) (anthMessage, error) {
 func (p *AnthropicProvider) extractContent(blocks []anthContentBlock) string {
 	var parts []string
 	for _, b := range blocks {
+		// Skip "thinking" blocks — they contain internal reasoning that
+		// should not be shown to users or parsed for tool calls.
 		if b.Type == "text" {
 			parts = append(parts, b.Text)
 		}

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -76,12 +76,13 @@ type oaiStreamOptions struct {
 }
 
 type oaiRequest struct {
-	Model         string            `json:"model"`
-	Messages      []oaiMessage      `json:"messages"`
-	MaxTokens     int               `json:"max_tokens,omitempty"`
-	Temperature   *float64          `json:"temperature,omitempty"`
-	Stream        bool              `json:"stream,omitempty"`
-	StreamOptions *oaiStreamOptions `json:"stream_options,omitempty"`
+	Model            string            `json:"model"`
+	Messages         []oaiMessage      `json:"messages"`
+	MaxTokens        int               `json:"max_tokens,omitempty"`
+	Temperature      *float64          `json:"temperature,omitempty"`
+	Stream           bool              `json:"stream,omitempty"`
+	StreamOptions    *oaiStreamOptions `json:"stream_options,omitempty"`
+	IncludeReasoning bool              `json:"include_reasoning,omitempty"` // OpenRouter: include reasoning in response
 }
 
 type oaiMessage struct {
@@ -307,12 +308,16 @@ func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error
 		}
 		msgs[i] = oaiMessage{Role: string(m.Role), Content: m.Content}
 	}
-	return oaiRequest{
+	oai := oaiRequest{
 		Model:       req.Model,
 		Messages:    msgs,
 		MaxTokens:   req.MaxTokens,
 		Temperature: req.Temperature,
-	}, nil
+	}
+	if req.Reasoning {
+		oai.IncludeReasoning = true
+	}
+	return oai, nil
 }
 
 func (p *OpenAIProvider) setHeaders(req *http.Request) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,11 +24,13 @@ type Message struct {
 }
 
 type CompletionRequest struct {
-	Model       string    `json:"model"`
-	Messages    []Message `json:"messages"`
-	MaxTokens   int       `json:"max_tokens,omitempty"`
-	Temperature *float64  `json:"temperature,omitempty"`
-	Stream      bool      `json:"stream,omitempty"`
+	Model        string    `json:"model"`
+	Messages     []Message `json:"messages"`
+	MaxTokens    int       `json:"max_tokens,omitempty"`
+	Temperature  *float64  `json:"temperature,omitempty"`
+	Stream       bool      `json:"stream,omitempty"`
+	Reasoning    bool      `json:"reasoning,omitempty"`     // enable extended thinking / reasoning
+	BudgetTokens int       `json:"budget_tokens,omitempty"` // max tokens for thinking (0 = provider default)
 }
 
 type Usage struct {


### PR DESCRIPTION
- Add Reasoning/BudgetTokens to CompletionRequest
- Anthropic: send thinking block when reasoning enabled
- OpenAI/OpenRouter: send include_reasoning flag
- Orchestrator: enable reasoning automatically when provider supports it
- WhoAmI: parse budget_tokens from profile for per-tenant control