### PR TITLE
fix: use reasoning_effort param for OpenAI-compatible reasoning models

### DIFF
--- a/cmd/opentalon/default_model_client_test.go
+++ b/cmd/opentalon/default_model_client_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/provider"
+)
+
+// fakeProvider implements provider.Provider for testing.
+type fakeProvider struct {
+	models    []provider.ModelInfo
+	lastReq   *provider.CompletionRequest
+	streamReq *provider.CompletionRequest
+}
+
+func (f *fakeProvider) ID() string                   { return "fake" }
+func (f *fakeProvider) Models() []provider.ModelInfo { return f.models }
+func (f *fakeProvider) SupportsFeature(feat provider.Feature) bool {
+	for _, m := range f.models {
+		if m.SupportsFeature(feat) {
+			return true
+		}
+	}
+	return false
+}
+func (f *fakeProvider) Complete(_ context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	f.lastReq = req
+	return &provider.CompletionResponse{Content: "ok"}, nil
+}
+func (f *fakeProvider) Stream(_ context.Context, req *provider.CompletionRequest) (provider.ResponseStream, error) {
+	f.streamReq = req
+	return nil, nil
+}
+
+func TestDefaultModelClient_SupportsFeature_Reasoning(t *testing.T) {
+	fp := &fakeProvider{
+		models: []provider.ModelInfo{
+			{ID: "gpt-oss-120b", Features: []provider.Feature{provider.FeatureStreaming, provider.FeatureReasoning}},
+		},
+	}
+	c := &defaultModelClient{provider: fp, model: "gpt-oss-120b"}
+
+	if !c.SupportsFeature(provider.FeatureReasoning) {
+		t.Error("expected SupportsFeature(FeatureReasoning) = true")
+	}
+	if !c.SupportsFeature(provider.FeatureStreaming) {
+		t.Error("expected SupportsFeature(FeatureStreaming) = true")
+	}
+	if c.SupportsFeature(provider.FeatureImages) {
+		t.Error("expected SupportsFeature(FeatureImages) = false")
+	}
+}
+
+func TestDefaultModelClient_SupportsFeature_NoReasoning(t *testing.T) {
+	fp := &fakeProvider{
+		models: []provider.ModelInfo{
+			{ID: "some-model", Features: []provider.Feature{provider.FeatureStreaming}},
+		},
+	}
+	c := &defaultModelClient{provider: fp, model: "some-model"}
+
+	if c.SupportsFeature(provider.FeatureReasoning) {
+		t.Error("expected SupportsFeature(FeatureReasoning) = false")
+	}
+}
+
+func TestDefaultModelClient_Complete_PreservesReasoningFields(t *testing.T) {
+	fp := &fakeProvider{
+		models: []provider.ModelInfo{{ID: "gpt-oss-120b"}},
+	}
+	c := &defaultModelClient{provider: fp, model: "gpt-oss-120b"}
+
+	req := &provider.CompletionRequest{
+		Messages:        []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Reasoning:       true,
+		ReasoningEffort: "high",
+		BudgetTokens:    5000,
+	}
+	_, _ = c.Complete(context.Background(), req)
+
+	if fp.lastReq == nil {
+		t.Fatal("expected provider to receive request")
+	}
+	if fp.lastReq.Model != "gpt-oss-120b" {
+		t.Errorf("expected model gpt-oss-120b, got %s", fp.lastReq.Model)
+	}
+	if !fp.lastReq.Reasoning {
+		t.Error("expected Reasoning=true to be preserved")
+	}
+	if fp.lastReq.ReasoningEffort != "high" {
+		t.Errorf("expected ReasoningEffort=high, got %s", fp.lastReq.ReasoningEffort)
+	}
+	if fp.lastReq.BudgetTokens != 5000 {
+		t.Errorf("expected BudgetTokens=5000, got %d", fp.lastReq.BudgetTokens)
+	}
+}
+
+func TestDefaultModelClient_Stream_PreservesReasoningFields(t *testing.T) {
+	fp := &fakeProvider{
+		models: []provider.ModelInfo{{ID: "gpt-oss-120b"}},
+	}
+	c := &defaultModelClient{provider: fp, model: "gpt-oss-120b"}
+
+	req := &provider.CompletionRequest{
+		Messages:        []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Reasoning:       true,
+		ReasoningEffort: "medium",
+	}
+	_, _ = c.Stream(context.Background(), req)
+
+	if fp.streamReq == nil {
+		t.Fatal("expected provider to receive stream request")
+	}
+	if !fp.streamReq.Reasoning {
+		t.Error("expected Reasoning=true to be preserved in stream")
+	}
+	if fp.streamReq.ReasoningEffort != "medium" {
+		t.Errorf("expected ReasoningEffort=medium, got %s", fp.streamReq.ReasoningEffort)
+	}
+}

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -866,13 +866,9 @@ type defaultModelClient struct {
 
 func (c *defaultModelClient) Complete(ctx context.Context, req *provider.CompletionRequest) (*provider.CompletionResponse, error) {
 	if req.Model == "" {
-		req = &provider.CompletionRequest{
-			Model:       c.model,
-			Messages:    req.Messages,
-			MaxTokens:   req.MaxTokens,
-			Temperature: req.Temperature,
-			Stream:      req.Stream,
-		}
+		cp := *req
+		cp.Model = c.model
+		req = &cp
 	}
 	return c.provider.Complete(ctx, req)
 }
@@ -881,15 +877,18 @@ func (c *defaultModelClient) Complete(ctx context.Context, req *provider.Complet
 // underlying provider's Stream method, filling in the default model if needed.
 func (c *defaultModelClient) Stream(ctx context.Context, req *provider.CompletionRequest) (provider.ResponseStream, error) {
 	if req.Model == "" {
-		req = &provider.CompletionRequest{
-			Model:       c.model,
-			Messages:    req.Messages,
-			MaxTokens:   req.MaxTokens,
-			Temperature: req.Temperature,
-			Stream:      true,
-		}
+		cp := *req
+		cp.Model = c.model
+		cp.Stream = true
+		req = &cp
 	}
 	return c.provider.Stream(ctx, req)
+}
+
+// SupportsFeature delegates to the underlying provider so the orchestrator
+// can detect reasoning support via type assertion.
+func (c *defaultModelClient) SupportsFeature(f provider.Feature) bool {
+	return c.provider.SupportsFeature(f)
 }
 
 // buildLuaScriptPaths returns a map of Lua plugin name -> path to .lua script,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -924,7 +924,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			if p := profile.FromContext(ctx); p != nil && p.BudgetTokens > 0 {
 				req.BudgetTokens = p.BudgetTokens
 			}
-			log.Debug("reasoning enabled for LLM request", "round", i+1, "budget_tokens", req.BudgetTokens)
+			log.Debug("reasoning enabled for LLM request", "round", i+1,
+				"budget_tokens", req.BudgetTokens,
+				"reasoning_effort", req.ReasoningEffort)
 		}
 
 		// Use streaming when a callback is registered and the LLM supports it.

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -77,18 +77,19 @@ type oaiStreamOptions struct {
 }
 
 type oaiRequest struct {
-	Model            string            `json:"model"`
-	Messages         []oaiMessage      `json:"messages"`
-	MaxTokens        int               `json:"max_tokens,omitempty"`
-	Temperature      *float64          `json:"temperature,omitempty"`
-	Stream           bool              `json:"stream,omitempty"`
-	StreamOptions    *oaiStreamOptions `json:"stream_options,omitempty"`
-	IncludeReasoning bool              `json:"include_reasoning,omitempty"` // OpenRouter: include reasoning in response
+	Model           string            `json:"model"`
+	Messages        []oaiMessage      `json:"messages"`
+	MaxTokens       int               `json:"max_tokens,omitempty"`
+	Temperature     *float64          `json:"temperature,omitempty"`
+	Stream          bool              `json:"stream,omitempty"`
+	StreamOptions   *oaiStreamOptions `json:"stream_options,omitempty"`
+	ReasoningEffort string            `json:"reasoning_effort,omitempty"` // "low", "medium", "high" for reasoning models (gpt-oss-120b, o1, etc.)
 }
 
 type oaiMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role             string `json:"role"`
+	Content          string `json:"content"`
+	ReasoningContent string `json:"reasoning_content,omitempty"` // reasoning models return thinking here
 }
 
 type oaiResponse struct {
@@ -150,10 +151,10 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	}
 	oaiReq.Stream = false
 
-	if oaiReq.IncludeReasoning {
+	if oaiReq.ReasoningEffort != "" {
 		slog.DebugContext(ctx, "openai reasoning enabled",
 			"model", oaiReq.Model,
-			"include_reasoning", true,
+			"reasoning_effort", oaiReq.ReasoningEffort,
 		)
 	}
 
@@ -194,7 +195,18 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 
 	content := ""
 	if len(oaiResp.Choices) > 0 {
-		content = oaiResp.Choices[0].Message.Content
+		msg := oaiResp.Choices[0].Message
+		content = msg.Content
+
+		// Log reasoning content when present.
+		if msg.ReasoningContent != "" {
+			slog.DebugContext(ctx, "openai reasoning response",
+				"model", oaiResp.Model,
+				"reasoning_len", len(msg.ReasoningContent),
+				"reasoning", msg.ReasoningContent,
+				"content_len", len(content),
+			)
+		}
 	}
 
 	return &CompletionResponse{
@@ -323,7 +335,10 @@ func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error
 		Temperature: req.Temperature,
 	}
 	if req.Reasoning {
-		oai.IncludeReasoning = true
+		oai.ReasoningEffort = req.ReasoningEffort
+		if oai.ReasoningEffort == "" {
+			oai.ReasoningEffort = "medium" // default effort
+		}
 	}
 	return oai, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,13 +24,14 @@ type Message struct {
 }
 
 type CompletionRequest struct {
-	Model        string    `json:"model"`
-	Messages     []Message `json:"messages"`
-	MaxTokens    int       `json:"max_tokens,omitempty"`
-	Temperature  *float64  `json:"temperature,omitempty"`
-	Stream       bool      `json:"stream,omitempty"`
-	Reasoning    bool      `json:"reasoning,omitempty"`     // enable extended thinking / reasoning
-	BudgetTokens int       `json:"budget_tokens,omitempty"` // max tokens for thinking (0 = provider default)
+	Model           string    `json:"model"`
+	Messages        []Message `json:"messages"`
+	MaxTokens       int       `json:"max_tokens,omitempty"`
+	Temperature     *float64  `json:"temperature,omitempty"`
+	Stream          bool      `json:"stream,omitempty"`
+	Reasoning       bool      `json:"reasoning,omitempty"`        // enable extended thinking / reasoning
+	BudgetTokens    int       `json:"budget_tokens,omitempty"`    // Anthropic: max tokens for thinking (0 = provider default)
+	ReasoningEffort string    `json:"reasoning_effort,omitempty"` // OpenAI: "low", "medium", "high" (0 = "medium")
 }
 
 type Usage struct {


### PR DESCRIPTION
- Send reasoning_effort ("low"/"medium"/"high") instead of include_reasoning
- Parse reasoning_content from response and log it
- Default effort: "medium"
- Supports gpt-oss-120b, o1, o3, and other OpenAI reasoning models