### PR TITLE
fix: aggressive sanitizeHistory strips all tool-less assistant messages

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1526,52 +1526,32 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 }
 
 // sanitizeHistory removes poisoned assistant messages from session history.
-// These are messages where the LLM narrated tool calls or hallucinated
-// results instead of actually calling tools. Keeping them in history
-// teaches the LLM to repeat the same bad pattern.
+// An assistant message is "legitimate" only if it contains a [tool_call] block
+// OR is immediately preceded by a [plugin_output] (meaning it's a summary of
+// real tool results). Everything else is the LLM talking without acting —
+// hallucinated numbers, narrated intent, placeholder text — and teaches the
+// model to repeat the same bad pattern.
 func sanitizeHistory(msgs []provider.Message) []provider.Message {
 	out := make([]provider.Message, 0, len(msgs))
 	for i, m := range msgs {
 		if m.Role == provider.RoleAssistant {
-			// Drop assistant messages that contain hallucinated template variables.
-			if hasHallucinatedResult(m.Content) {
-				// Also drop the preceding user message if it exists and is now orphaned.
-				if len(out) > 0 && out[len(out)-1].Role == provider.RoleUser {
-					out = out[:len(out)-1]
-				}
+			// Keep assistant messages that contain tool calls — they drove real actions.
+			if strings.Contains(m.Content, "[tool_call]") {
+				out = append(out, m)
 				continue
 			}
-			// Drop assistant messages that are purely narrated intent (no tool call
-			// blocks, no [plugin_output] results) — they pollute history with
-			// "Here are the results..." without actual results.
-			if !strings.Contains(m.Content, "[tool_call]") &&
-				!strings.Contains(m.Content, "[plugin_output]") &&
-				(hasNarratedToolCall(m.Content) || hasNarratedIntent(m.Content)) {
-				if len(out) > 0 && out[len(out)-1].Role == provider.RoleUser {
-					out = out[:len(out)-1]
-				}
+			// Keep assistant messages that follow a [plugin_output] — they summarize
+			// real tool results (the normal round-2 response after a tool call).
+			if i > 0 && strings.Contains(msgs[i-1].Content, "[plugin_output]") {
+				out = append(out, m)
 				continue
 			}
-			// Drop assistant messages that claim results without evidence:
-			// short messages referencing "results" but no tool output in adjacent messages.
-			if len(m.Content) < 200 && !strings.Contains(m.Content, "[tool_call]") {
-				hasToolContext := false
-				// Check if the next message is a tool result
-				if i+1 < len(msgs) && strings.Contains(msgs[i+1].Content, "[plugin_output]") {
-					hasToolContext = true
-				}
-				// Check if previous message has tool output
-				if i > 0 && strings.Contains(msgs[i-1].Content, "[plugin_output]") {
-					hasToolContext = true
-				}
-				if !hasToolContext && (strings.Contains(strings.ToLower(m.Content), "here are the results") ||
-					strings.Contains(strings.ToLower(m.Content), "here is the result")) {
-					if len(out) > 0 && out[len(out)-1].Role == provider.RoleUser {
-						out = out[:len(out)-1]
-					}
-					continue
-				}
+			// Everything else is the LLM answering without calling a tool.
+			// Drop it and its orphaned preceding user message.
+			if len(out) > 0 && out[len(out)-1].Role == provider.RoleUser {
+				out = out[:len(out)-1]
 			}
+			continue
 		}
 		out = append(out, m)
 	}

--- a/internal/orchestrator/sanitize_history_test.go
+++ b/internal/orchestrator/sanitize_history_test.go
@@ -6,57 +6,84 @@ import (
 	"github.com/opentalon/opentalon/internal/provider"
 )
 
-func TestSanitizeHistory_RemovesHallucinatedTemplates(t *testing.T) {
+func TestSanitizeHistory_RemovesHallucinatedText(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "how many org units?"},
 		{Role: provider.RoleAssistant, Content: "You have **{{plugin_output.pagination.total}}** org-units."},
 		{Role: provider.RoleUser, Content: "that's wrong"},
 	}
 	got := sanitizeHistory(msgs)
-	// The hallucinated assistant message AND its orphaned user message should be removed.
 	if len(got) != 1 || got[0].Content != "that's wrong" {
 		t.Errorf("expected 1 message, got %d: %v", len(got), got)
 	}
 }
 
-func TestSanitizeHistory_RemovesNarratedIntent(t *testing.T) {
+func TestSanitizeHistory_RemovesNarratedAndFabricatedAnswers(t *testing.T) {
+	// Simulates a poisoned session where the LLM keeps answering without tools
 	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: "how many items?"},
-		{Role: provider.RoleAssistant, Content: "We'll fetch the total count of items."},
-		{Role: provider.RoleUser, Content: "list my items"},
-		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
+		{Role: provider.RoleUser, Content: "how many items do i have?"},
+		{Role: provider.RoleAssistant, Content: "<b>Total items:</b> 0 (the system returned no matching records)."},
+		{Role: provider.RoleUser, Content: "lies!"},
+		{Role: provider.RoleAssistant, Content: "<b>Total number of items:</b> 0 (the query returned no items)."},
+		{Role: provider.RoleUser, Content: "lies!"},
+		{Role: provider.RoleAssistant, Content: "<b>Total number of items:</b> 94 (including all item types)."},
+		{Role: provider.RoleUser, Content: "run the tools!"},
+		{Role: provider.RoleAssistant, Content: "We need to call the tool."},
+		{Role: provider.RoleUser, Content: "call please"},
+		{Role: provider.RoleAssistant, Content: "<b>Fetching the total number of items…</b>"},
+		{Role: provider.RoleUser, Content: "?"},
+		{Role: provider.RoleAssistant, Content: "<b>Retrieving item count…</b>"},
+		{Role: provider.RoleUser, Content: "?"},
 	}
 	got := sanitizeHistory(msgs)
-	// Narrated message + its user message removed; the real tool call survives.
-	if len(got) != 2 {
-		t.Errorf("expected 2 messages, got %d: %v", len(got), got)
+	// ALL assistant messages should be removed (none contain [tool_call] or follow [plugin_output]).
+	// Their preceding user messages should also be removed.
+	// Only the final "?" without a preceding assistant remains.
+	if len(got) != 1 || got[0].Content != "?" {
+		t.Errorf("expected 1 message '?', got %d: %v", len(got), got)
+	}
+}
+
+func TestSanitizeHistory_KeepsToolCallAndResults(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "how many items?"},
+		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
+		{Role: provider.RoleUser, Content: "[plugin_output]{\"pagination\":{\"total\":370}}[/plugin_output]"},
+		{Role: provider.RoleAssistant, Content: "You have 370 items."},
+	}
+	got := sanitizeHistory(msgs)
+	if len(got) != len(msgs) {
+		t.Errorf("expected all %d messages preserved, got %d", len(msgs), len(got))
+	}
+}
+
+func TestSanitizeHistory_KeepsMixedSession(t *testing.T) {
+	msgs := []provider.Message{
+		// First turn: hallucinated (should be removed)
+		{Role: provider.RoleUser, Content: "how many items?"},
+		{Role: provider.RoleAssistant, Content: "You have 0 items."},
+		// Second turn: real tool call (should be kept)
+		{Role: provider.RoleUser, Content: "list my items"},
+		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
+		{Role: provider.RoleUser, Content: "[plugin_output]Items: 370 total[/plugin_output]"},
+		{Role: provider.RoleAssistant, Content: "You have 370 items."},
+		// Third turn: hallucinated again (should be removed)
+		{Role: provider.RoleUser, Content: "how many persons?"},
+		{Role: provider.RoleAssistant, Content: "You have 15 persons."},
+	}
+	got := sanitizeHistory(msgs)
+	// Should keep: "list my items", tool_call, plugin_output, "You have 370 items."
+	if len(got) != 4 {
+		t.Errorf("expected 4 messages, got %d: %v", len(got), got)
 	}
 	if got[0].Content != "list my items" {
 		t.Errorf("expected 'list my items', got %q", got[0].Content)
 	}
 }
 
-func TestSanitizeHistory_RemovesClaimedResults(t *testing.T) {
-	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: "how many inactive items?"},
-		{Role: provider.RoleAssistant, Content: "Here are the results showing inactive items."},
-		{Role: provider.RoleUser, Content: "its no results!"},
-	}
-	got := sanitizeHistory(msgs)
-	if len(got) != 1 || got[0].Content != "its no results!" {
-		t.Errorf("expected 1 message, got %d: %v", len(got), got)
-	}
-}
-
-func TestSanitizeHistory_KeepsLegitMessages(t *testing.T) {
-	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: "how many items?"},
-		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
-		{Role: provider.RoleUser, Content: "[plugin_output]{\"pagination\":{\"total\":42}}[/plugin_output]"},
-		{Role: provider.RoleAssistant, Content: "You have 42 items."},
-	}
-	got := sanitizeHistory(msgs)
-	if len(got) != len(msgs) {
-		t.Errorf("expected all %d messages preserved, got %d", len(msgs), len(got))
+func TestSanitizeHistory_EmptyHistory(t *testing.T) {
+	got := sanitizeHistory(nil)
+	if len(got) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(got))
 	}
 }


### PR DESCRIPTION
Assistant messages are only kept if they contain [tool_call] or immediately follow a [plugin_output]. Everything else — hallucinated numbers, narrated intent, placeholder text — is stripped from session history to prevent the model from learning bad patterns.