### PR TITLE
fix: deduplicate knowledge article outputs in session history

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2721,17 +2721,65 @@ func (a *plannerLLMAdapter) Complete(ctx context.Context, req *pipeline.Completi
 // are already in the system prompt via SystemPromptAddition, so the
 // preparer-injected knowledge_context is redundant. Stripping all turns
 // prevents both historical accumulation and current-turn duplication.
+//
+// Also deduplicates knowledge article plugin outputs: when ask_knowledge
+// returns the same MCP server instructions block repeatedly (~5KB each),
+// subsequent occurrences are replaced with a short stub to save context.
 func appendStrippingAllKC(dst []provider.Message, msgs []provider.Message) []provider.Message {
+	seenKnowledge := make(map[uint64]bool)
 	for _, m := range msgs {
 		if m.Role == provider.RoleUser {
 			stripped := stripKnowledgeContext(m.Content)
 			if stripped != m.Content {
 				m = provider.Message{Role: m.Role, Content: stripped, Files: m.Files}
 			}
+			// Deduplicate knowledge article plugin outputs.
+			m = deduplicateKnowledgeOutput(m, seenKnowledge)
 		}
 		dst = append(dst, m)
 	}
 	return dst
+}
+
+// deduplicateKnowledgeOutput replaces repeated knowledge article plugin
+// outputs with a short stub. Each unique knowledge block is kept on first
+// occurrence; subsequent identical blocks are replaced to save context.
+func deduplicateKnowledgeOutput(m provider.Message, seen map[uint64]bool) provider.Message {
+	const marker = "## Knowledge Articles"
+	const openTag = "[plugin_output]"
+	const closeTag = "[/plugin_output]"
+	if !strings.Contains(m.Content, marker) {
+		return m
+	}
+	// Extract the knowledge section between [plugin_output] tags.
+	start := strings.Index(m.Content, openTag)
+	end := strings.LastIndex(m.Content, closeTag)
+	if start < 0 || end < 0 || end <= start {
+		return m
+	}
+	body := m.Content[start+len(openTag) : end]
+	h := fnv64a(body)
+	if !seen[h] {
+		seen[h] = true
+		return m
+	}
+	// Replace duplicate knowledge output with a short stub.
+	replaced := m.Content[:start] +
+		"[plugin_output]\n(Same knowledge articles as a previous lookup — see above.)\n[/plugin_output]" +
+		m.Content[end+len(closeTag):]
+	return provider.Message{Role: m.Role, Content: strings.TrimSpace(replaced), Files: m.Files}
+}
+
+// fnv64a computes a fast FNV-1a hash for deduplication.
+func fnv64a(s string) uint64 {
+	const offset64 = 14695981039346656037
+	const prime64 = 1099511628211
+	h := uint64(offset64)
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
 }
 
 // stripKnowledgeContext removes [knowledge_context]...[/knowledge_context] blocks

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3366,3 +3366,44 @@ func TestPlannerError_RetryEnabledWithoutPanic(t *testing.T) {
 		t.Errorf("Response = %q, want agent fallback", result.Response)
 	}
 }
+
+func TestDeduplicateKnowledgeOutput(t *testing.T) {
+	knowledgeBlock := "[plugin_output]\n## Knowledge Articles\n\n### 1. timly MCP server instructions\nSource: mcp:timly\n## timly\nTimly MCP server. Read/write operations...\n\n## Available Tools\n\n### 1. timly.timly__list-items\nList items in your account.\n[/plugin_output]"
+
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "how many items?"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] weaviate.ask_knowledge(query=items)"},
+		{Role: provider.RoleUser, Content: knowledgeBlock},
+		{Role: provider.RoleAssistant, Content: "[tool_call] timly.timly__list-items"},
+		{Role: provider.RoleUser, Content: "[plugin_output]\nItems: 370 total\n[/plugin_output]"},
+		{Role: provider.RoleAssistant, Content: "You have 370 items."},
+		{Role: provider.RoleUser, Content: "show me categories"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] weaviate.ask_knowledge(query=categories)"},
+		{Role: provider.RoleUser, Content: knowledgeBlock}, // duplicate
+		{Role: provider.RoleAssistant, Content: "[tool_call] timly.timly__list-categories"},
+	}
+
+	var dst []provider.Message
+	deduped := appendStrippingAllKC(dst, msgs)
+
+	// First knowledge output should be preserved.
+	if !strings.Contains(deduped[2].Content, "## Knowledge Articles") {
+		t.Error("first knowledge output should be preserved")
+	}
+	if !strings.Contains(deduped[2].Content, "timly MCP server") {
+		t.Error("first knowledge output should contain full content")
+	}
+
+	// Second (duplicate) should be replaced with stub.
+	if strings.Contains(deduped[8].Content, "timly MCP server") {
+		t.Error("duplicate knowledge output should be replaced with stub")
+	}
+	if !strings.Contains(deduped[8].Content, "Same knowledge articles") {
+		t.Errorf("duplicate should contain stub text, got: %s", deduped[8].Content)
+	}
+
+	// Non-knowledge plugin outputs should be untouched.
+	if !strings.Contains(deduped[4].Content, "Items: 370 total") {
+		t.Error("non-knowledge plugin output should be preserved")
+	}
+}


### PR DESCRIPTION
## Summary
- `weaviate.ask_knowledge` returns the full MCP server instructions (~5KB) on every call
- Over long conversations with many knowledge lookups, this duplicated content fills the context window and pushes out actual conversation history, causing context loss
- In the log example: 6 knowledge lookups × ~5KB = ~30KB of duplicated instructions in a 94K token session

## Fix
- `appendStrippingAllKC` now tracks seen knowledge article blocks by FNV hash
- First occurrence is kept intact; subsequent identical blocks are replaced with a short stub: "(Same knowledge articles as a previous lookup — see above.)"
- Non-knowledge `[plugin_output]` blocks (tool results) are untouched

## Test plan
- [x] `TestDeduplicateKnowledgeOutput` — verifies first kept, duplicate stubbed, non-knowledge preserved
- [x] Full orchestrator test suite passes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)