### PR TITLE
fix: planner args unmarshal fails when LLM returns int values

### DIFF
--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -60,11 +60,12 @@ type Planner struct {
 	llm LLMClient
 }
 
-// PlanResult holds the planner's decision: either "direct" (single action, use normal agent loop)
-// or "pipeline" with multiple steps.
+// PlanResult holds the planner's decision: "direct" (no steps, use normal agent loop)
+// or "pipeline" with one or more steps. Single-step pipelines are preserved so the
+// orchestrator can execute them server-side without an LLM round-trip.
 type PlanResult struct {
 	Type  string  // "direct" | "pipeline"
-	Steps []*Step // only when Type == "pipeline"
+	Steps []*Step // populated when Type == "pipeline"
 }
 
 // NewPlanner creates a planner backed by the given LLM client.
@@ -79,12 +80,12 @@ type planResponse struct {
 }
 
 type planStepJSON struct {
-	ID        string            `json:"id"`
-	Name      string            `json:"name"`
-	Plugin    string            `json:"plugin"`
-	Action    string            `json:"action"`
-	Args      map[string]string `json:"args"`
-	DependsOn []string          `json:"depends_on"`
+	ID        string                 `json:"id"`
+	Name      string                 `json:"name"`
+	Plugin    string                 `json:"plugin"`
+	Action    string                 `json:"action"`
+	Args      map[string]interface{} `json:"args"`
+	DependsOn []string               `json:"depends_on"`
 }
 
 // PlanTimeout is the maximum time the planner waits for an LLM response.
@@ -167,9 +168,9 @@ func parsePlanResponse(content string) (*PlanResult, error) {
 		if id == "" {
 			id = fmt.Sprintf("%d", i+1)
 		}
-		args := s.Args
-		if args == nil {
-			args = make(map[string]string)
+		args := make(map[string]string, len(s.Args))
+		for k, v := range s.Args {
+			args[k] = fmt.Sprintf("%v", v)
 		}
 		steps[i] = &Step{
 			ID:   id,


### PR DESCRIPTION
## Summary
- The planner LLM returns args like `{"page": 1, "per_page": 1}` with **integer values**
- `planStepJSON.Args` was `map[string]string` — `json.Unmarshal` silently fails on int→string
- Every single-step pipeline was being dropped to `type=direct, steps=0`
- This blocked the single-step server-side execution from PR #181

## Fix
- Changed `Args` to `map[string]interface{}` for JSON unmarshalling
- Convert values to strings via `fmt.Sprintf("%v", v)` when building `Step`
- Also updated `PlanResult` comment to reflect that single-step pipelines are now preserved

## Impact
This unblocks `perf/single-step-server-side` — "how many items?" should now execute the tool server-side in ~5s instead of going through 3 failed LLM rounds (~30s).

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/pipeline/... ./internal/orchestrator/...`
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)