### PR TITLE
feat: make plan_timeout configurable

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -428,6 +428,12 @@ func main() {
 			pipelineCfg.StepTimeout = d
 		}
 	}
+	var planTimeout time.Duration
+	if cfg.Orchestrator.Pipeline.PlanTimeout != "" {
+		if d, err := time.ParseDuration(cfg.Orchestrator.Pipeline.PlanTimeout); err == nil {
+			planTimeout = d
+		}
+	}
 	// Build profile verifier (nil when profiles.who_am_i.url is not configured).
 	var profileVerifier channel.ProfileVerifier
 	if cfg.Profiles.WhoAmI.URL != "" {
@@ -481,6 +487,7 @@ func main() {
 		SummarizePrompt:         cfg.State.Session.SummarizePrompt,
 		SummarizeUpdatePrompt:   cfg.State.Session.SummarizeUpdatePrompt,
 		PipelineEnabled:         cfg.Orchestrator.Pipeline.Enabled,
+		PlanTimeout:             planTimeout,
 		PipelineConfig:          pipelineCfg,
 		ContextWindow:           contextWindow,
 		MaxConcurrentSessions:   cfg.Orchestrator.MaxConcurrentSessions,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,6 +70,7 @@ orchestrator:
   #   enabled: true
   #   max_step_retries: 3    # retries per step before giving up (default 3)
   #   step_timeout: "60s"    # per-step timeout as Go duration (default "60s")
+  #   plan_timeout: "15s"    # max time for planner LLM call (default "15s"); increase for slower models
   # Knowledge-augmented RAG: sync plugin actions to vector store on startup and
   # optionally ingest markdown files from a directory. Articles can also arrive
   # via the weaviate plugin's HTTP API (POST /api/v1/articles).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -328,6 +328,7 @@ type PipelineOrchestratorConfig struct {
 	Enabled        bool   `yaml:"enabled"`          // default false
 	MaxStepRetries int    `yaml:"max_step_retries"` // default 3
 	StepTimeout    string `yaml:"step_timeout"`     // Go duration, default "60s"
+	PlanTimeout    string `yaml:"plan_timeout"`     // Go duration, default "15s"; max time for planner LLM call
 }
 
 // SubprocessOrchestratorConfig enables subprocess (sub-agent) forking from the main agent loop.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -131,6 +131,7 @@ type OrchestratorOpts struct {
 	SummarizePrompt         string                        // empty = default English
 	SummarizeUpdatePrompt   string                        // empty = default English
 	PipelineEnabled         bool                          // when true, create Planner from llm
+	PlanTimeout             time.Duration                 // max time for planner LLM call; 0 = default 15s
 	PipelineConfig          pipeline.PipelineConfig
 	ContextWindow           int                 // model context window in tokens; 0 = no trimming
 	MaxConcurrentSessions   int                 // max sessions running in parallel; default 1 (sequential)
@@ -270,7 +271,7 @@ func NewWithRules(
 	}
 	var planner *pipeline.Planner
 	if opts.PipelineEnabled {
-		planner = pipeline.NewPlanner(&plannerLLMAdapter{llm: llm})
+		planner = pipeline.NewPlanner(&plannerLLMAdapter{llm: llm}, opts.PlanTimeout)
 	}
 	pipelineCfg := opts.PipelineConfig
 	if pipelineCfg.MaxStepRetries == 0 && pipelineCfg.StepTimeout == 0 {

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -57,7 +57,8 @@ type ParamInfo struct {
 
 // Planner uses an LLM to decompose user requests into pipeline steps.
 type Planner struct {
-	llm LLMClient
+	llm     LLMClient
+	timeout time.Duration
 }
 
 // PlanResult holds the planner's decision: "direct" (no steps, use normal agent loop)
@@ -69,8 +70,12 @@ type PlanResult struct {
 }
 
 // NewPlanner creates a planner backed by the given LLM client.
-func NewPlanner(llm LLMClient) *Planner {
-	return &Planner{llm: llm}
+// timeout controls how long the planner waits for an LLM response (0 = default 15s).
+func NewPlanner(llm LLMClient, timeout time.Duration) *Planner {
+	if timeout <= 0 {
+		timeout = DefaultPlanTimeout
+	}
+	return &Planner{llm: llm, timeout: timeout}
 }
 
 // planResponse is the JSON shape we expect from the LLM.
@@ -88,10 +93,9 @@ type planStepJSON struct {
 	DependsOn []string               `json:"depends_on"`
 }
 
-// PlanTimeout is the maximum time the planner waits for an LLM response.
-// The planner is a lightweight classifier (direct vs pipeline); if it takes
-// longer than this the agent loop handles the request instead.
-const PlanTimeout = 15 * time.Second
+// DefaultPlanTimeout is the maximum time the planner waits for an LLM response
+// when no custom timeout is configured.
+const DefaultPlanTimeout = 15 * time.Second
 
 // Plan asks the LLM whether the user's message requires a multi-step pipeline or a direct action.
 func (p *Planner) Plan(ctx context.Context, message string, capabilities []CapabilityInfo) (*PlanResult, error) {
@@ -103,7 +107,7 @@ func (p *Planner) Plan(ctx context.Context, message string, capabilities []Capab
 	slog.Debug("planner system prompt", "prompt", systemPrompt)
 	slog.Debug("planner user message", "message", message)
 
-	planCtx, cancel := context.WithTimeout(ctx, PlanTimeout)
+	planCtx, cancel := context.WithTimeout(ctx, p.timeout)
 	defer cancel()
 
 	resp, err := p.llm.Complete(planCtx, &CompletionRequest{

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -26,7 +26,7 @@ func (c *capturingPlannerLLM) Complete(_ context.Context, req *CompletionRequest
 
 func TestPlannerReturnsDirect(t *testing.T) {
 	llm := &fakePlannerLLM{response: `{"type": "direct"}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "hello", nil)
 	if err != nil {
@@ -48,7 +48,7 @@ func TestPlannerReturnsPipeline(t *testing.T) {
 			{"id": "2", "name": "Create Jira issue", "plugin": "jira", "action": "create_issue", "args": {"title": "Fix error"}, "depends_on": ["1"]}
 		]
 	}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "investigate error 123 and create a ticket", nil)
 	if err != nil {
@@ -79,7 +79,7 @@ func TestPlannerReturnsPipeline(t *testing.T) {
 
 func TestPlannerHandlesMarkdownCodeFence(t *testing.T) {
 	llm := &fakePlannerLLM{response: "```json\n{\"type\": \"pipeline\", \"steps\": [{\"id\": \"1\", \"name\": \"Step one\", \"plugin\": \"p\", \"action\": \"a\"}]}\n```"}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "do things", nil)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestPlannerHandlesMarkdownCodeFence(t *testing.T) {
 
 func TestPlannerFallsBackOnInvalidJSON(t *testing.T) {
 	llm := &fakePlannerLLM{response: "I'm not sure what you mean, here's some text"}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "something", nil)
 	if err != nil {
@@ -108,7 +108,7 @@ func TestPlannerFallsBackOnInvalidJSON(t *testing.T) {
 
 func TestPlannerFallsBackOnEmptySteps(t *testing.T) {
 	llm := &fakePlannerLLM{response: `{"type": "pipeline", "steps": []}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "something", nil)
 	if err != nil {
@@ -121,7 +121,7 @@ func TestPlannerFallsBackOnEmptySteps(t *testing.T) {
 
 func TestPlannerAssignsDefaultIDs(t *testing.T) {
 	llm := &fakePlannerLLM{response: `{"type": "pipeline", "steps": [{"name": "Step A", "plugin": "p", "action": "a"}, {"name": "Step B", "plugin": "p", "action": "b"}]}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 
 	result, err := planner.Plan(context.Background(), "do things", nil)
 	if err != nil {
@@ -254,7 +254,7 @@ func TestBuildPlannerPromptWithLanguage(t *testing.T) {
 func TestNarratePlanReturnsLLMResponse(t *testing.T) {
 	want := "I'll fetch error details from AppSignal, then create a Jira ticket. Want me to proceed?"
 	llm := &fakePlannerLLM{response: want}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 	steps := []*Step{
 		{ID: "1", Name: "Get error details", Command: &PluginCommand{Plugin: "appsignal", Action: "get_error"}},
 		{ID: "2", Name: "Create Jira issue", Command: &PluginCommand{Plugin: "jira", Action: "create_issue"}},
@@ -270,7 +270,7 @@ func TestNarratePlanReturnsLLMResponse(t *testing.T) {
 
 func TestNarratePlanIncludesStepNamesInPrompt(t *testing.T) {
 	c := &capturingPlannerLLM{response: "ok"}
-	planner := NewPlanner(c)
+	planner := NewPlanner(c, 0)
 	steps := []*Step{
 		{ID: "1", Name: "Fetch metrics", Command: &PluginCommand{Plugin: "p", Action: "a"}},
 	}
@@ -291,7 +291,7 @@ func TestNarratePlanIncludesStepNamesInPrompt(t *testing.T) {
 
 func TestClassifyConfirmationApproved(t *testing.T) {
 	llm := &fakePlannerLLM{response: `{"approved": true}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 	d, err := planner.ClassifyConfirmation(context.Background(), "yes please go ahead")
 	if err != nil {
 		t.Fatal(err)
@@ -303,7 +303,7 @@ func TestClassifyConfirmationApproved(t *testing.T) {
 
 func TestClassifyConfirmationRejected(t *testing.T) {
 	llm := &fakePlannerLLM{response: `{"approved": false}`}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 	d, err := planner.ClassifyConfirmation(context.Background(), "no thanks cancel it")
 	if err != nil {
 		t.Fatal(err)
@@ -315,7 +315,7 @@ func TestClassifyConfirmationRejected(t *testing.T) {
 
 func TestClassifyConfirmationMarkdownWrapped(t *testing.T) {
 	llm := &fakePlannerLLM{response: "```json\n{\"approved\": true}\n```"}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 	d, err := planner.ClassifyConfirmation(context.Background(), "sure go for it")
 	if err != nil {
 		t.Fatal(err)
@@ -327,7 +327,7 @@ func TestClassifyConfirmationMarkdownWrapped(t *testing.T) {
 
 func TestClassifyConfirmationMalformedJSON(t *testing.T) {
 	llm := &fakePlannerLLM{response: "I cannot determine that"}
-	planner := NewPlanner(llm)
+	planner := NewPlanner(llm, 0)
 	d, err := planner.ClassifyConfirmation(context.Background(), "sure")
 	if err == nil {
 		t.Error("expected error on malformed JSON")


### PR DESCRIPTION
## Summary
The planner LLM call has a hardcoded 15s timeout. With slower models (e.g. gpt-oss-120b with `reasoning_effort: high`), the planner frequently times out, disabling server-side execution and retry hints.

Added `plan_timeout` as a config option under `orchestrator.pipeline`.

## Config example
```yaml
orchestrator:
  pipeline:
    enabled: true
    plan_timeout: "30s"   # default 15s
```

## Changes
- `internal/config/config.go` — added `PlanTimeout` to `PipelineOrchestratorConfig`
- `internal/pipeline/planner.go` — `NewPlanner` accepts timeout param, renamed const to `DefaultPlanTimeout`
- `internal/orchestrator/orchestrator.go` — passes `PlanTimeout` from opts to planner
- `cmd/opentalon/main.go` — parses duration from config, passes to orchestrator

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/pipeline/... ./internal/orchestrator/... ./cmd/opentalon/...`
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)