### PR TITLE
feat: add error_code metadata to all response paths + websocket message docs

### DIFF
--- a/docs/websocket-messages.md
+++ b/docs/websocket-messages.md
@@ -1,0 +1,174 @@
+# WebSocket Message Types
+
+Every outbound WebSocket message is a JSON object with these fields:
+
+```json
+{
+  "conversation_id": "abc123",
+  "thread_id": "",
+  "content": "You have 55 items.",
+  "metadata": {
+    "type": "assistant",
+    "error_code": ""
+  }
+}
+```
+
+The `metadata.type` field tells the frontend **what kind of message this is**, so it can render it appropriately and translate the content for i18n.
+
+---
+
+## Message Types
+
+### `assistant` (default)
+
+Normal LLM response. No special `type` metadata is set (or absent). The `content` is the LLM's natural language answer.
+
+```json
+{ "type": "assistant" }
+```
+
+Frontend: render as a chat bubble from the assistant.
+
+---
+
+### `system`
+
+A server-side command or action was executed without going through the LLM. The response is a direct result from the system.
+
+```json
+{
+  "type": "system",
+  "action": "clear_session"
+}
+```
+
+| `action` value | Description |
+|---|---|
+| `clear_session` | Session was cleared (`/clear` or `/new`) |
+| `list_commands` | Available commands listed (`/commands`) |
+| `show_config` | Config displayed (`/show config`) |
+| `set_prompt` | Runtime prompt updated (`/set prompt`) |
+| `install_skill` | Skill installed (`/install skill`) |
+| `reload_mcp` | MCP plugin reloaded (`/reload mcp`) |
+| `profile_assign` | Plugin assigned to group |
+| `profile_revoke` | Plugin revoked from group |
+| `profile_list_group` | Group plugins listed |
+| `pipeline_cancelled` | User rejected a multi-step pipeline |
+
+Frontend: render as a system notification (not a chat bubble). The `action` value is stable and can be used as an i18n key.
+
+---
+
+### `confirmation`
+
+The system is asking the user to confirm a multi-step pipeline before execution. The `content` is a human-readable description of the planned steps.
+
+```json
+{
+  "type": "confirmation",
+  "prompt_type": "confirmation",
+  "pipeline_id": "abc-123",
+  "options": "approve,reject"
+}
+```
+
+| Field | Description |
+|---|---|
+| `pipeline_id` | Unique ID of the pending pipeline |
+| `options` | Comma-separated list of valid responses |
+
+Frontend: render as a confirmation dialog with approve/reject buttons. The user's next message determines the pipeline's fate.
+
+---
+
+### `error`
+
+An error occurred. The `content` is a human-readable fallback message (English). The `error_code` is a stable machine-readable code for i18n.
+
+```json
+{
+  "type": "error",
+  "error_code": "timeout"
+}
+```
+
+| `error_code` | Default English message | When |
+|---|---|---|
+| `timeout` | The request timed out. Please try again. | LLM or API call exceeded deadline |
+| `rate_limited` | I'm being rate-limited right now. Please try again in a moment. | Provider returned 429 |
+| `context_length_exceeded` | Sorry, this conversation has grown too long for the model to process. Please start a new conversation or clear the session. | Input exceeded model's context window |
+| `internal_error` | Something went wrong processing your message. Please try again or start a new conversation. | Any other unrecognized error |
+| `token_required` | profile token required | WebSocket connection missing auth token |
+| `auth_failed` | authentication failed | Token validation failed |
+| `token_limit_exceeded` | token limit reached, please try again later | User's token spend limit exceeded |
+| `empty_content` | I received your message but couldn't read its content. Could you try sending it as text? | Empty message with no file attachments |
+| `guard_blocked` | Request blocked: guard {name} failed. | Content guard rejected the message |
+
+Frontend: use `error_code` as an i18n translation key (e.g., `errors.timeout`, `errors.rate_limited`). Fall back to `content` if no translation is available.
+
+---
+
+### `_typing` (typing indicator)
+
+Sent periodically (~25s) while the system is processing a request. Keeps the WebSocket alive and signals that work is in progress.
+
+```json
+{
+  "content": "",
+  "metadata": {
+    "_typing": "true"
+  }
+}
+```
+
+No `type` field. Presence of `_typing` key is the signal.
+
+Frontend: show a typing indicator. Stop when a real message arrives.
+
+---
+
+## i18n Integration
+
+The recommended pattern for frontend i18n:
+
+```typescript
+function renderMessage(msg: OutboundMessage) {
+  const type = msg.metadata?.type;
+  const errorCode = msg.metadata?.error_code;
+  const action = msg.metadata?.action;
+
+  if (msg.metadata?._typing === "true") {
+    return showTypingIndicator();
+  }
+
+  if (type === "error" && errorCode) {
+    // Use error_code as translation key, fall back to content
+    return showError(t(`errors.${errorCode}`, msg.content));
+  }
+
+  if (type === "system" && action) {
+    // Use action as translation key for system notifications
+    return showSystemNotification(t(`system.${action}`, msg.content));
+  }
+
+  if (type === "confirmation") {
+    return showConfirmationDialog(msg.content, msg.metadata.options);
+  }
+
+  // Default: render as assistant message
+  return showAssistantMessage(msg.content);
+}
+```
+
+## Metadata Field Reference
+
+| Key | Values | Present when |
+|---|---|---|
+| `type` | `system`, `error`, `confirmation`, `assistant` | Always (absent = `assistant`) |
+| `error_code` | See error table above | `type=error` |
+| `action` | See system action table above | `type=system` |
+| `prompt_type` | `confirmation` | `type=confirmation` |
+| `pipeline_id` | UUID string | `type=confirmation` |
+| `options` | Comma-separated (e.g., `approve,reject`) | `type=confirmation` |
+| `_typing` | `true` | Typing indicator only |

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -43,12 +43,16 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 		if cfg.Verifier != nil {
 			token := msg.Metadata["profile_token"]
 			if token == "" {
-				return errorResponse(msg, "profile token required"), nil
+				return errorResponse(msg, "profile token required", map[string]string{
+					"type": "error", "error_code": "token_required",
+				}), nil
 			}
 			p, err := cfg.Verifier.Verify(ctx, token, msg.ChannelID)
 			if err != nil {
 				slog.Warn("profile verification failed", "error", err, "channel", msg.ChannelID)
-				return errorResponse(msg, "authentication failed"), nil
+				return errorResponse(msg, "authentication failed", map[string]string{
+					"type": "error", "error_code": "auth_failed",
+				}), nil
 			}
 			p.ChannelID = msg.ChannelID
 			ctx = profile.WithProfile(ctx, p)
@@ -61,7 +65,9 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 					slog.Warn("limit check failed", "error", lerr, "entity", p.EntityID)
 				} else if used >= p.Limit {
 					slog.Info("token limit exceeded", "entity", p.EntityID, "used", used, "limit", p.Limit, "window", p.LimitWindow)
-					return errorResponse(msg, "token limit reached, please try again later"), nil
+					return errorResponse(msg, "token limit reached, please try again later", map[string]string{
+						"type": "error", "error_code": "token_limit_exceeded",
+					}), nil
 				}
 			}
 
@@ -88,12 +94,10 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 		response, inputForDisplay, resultMeta, err := cfg.Runner.Run(ctx, sessionKey, content, msg.Files...)
 		if err != nil {
 			logger.FromContext(ctx).Error("handler run failed", "error", err)
-			return pkg.OutboundMessage{
-				ConversationID: msg.ConversationID,
-				ThreadID:       msg.ThreadID,
-				Content:        friendlyError(err),
-				Metadata:       safeMetadata(msg.Metadata),
-			}, nil
+			errText, errCode := friendlyError(err)
+			return errorResponse(msg, errText, map[string]string{
+				"type": "error", "error_code": errCode,
+			}), nil
 		}
 		outContent := response
 		if outContent == "" {
@@ -118,12 +122,21 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 	}
 }
 
-func errorResponse(msg pkg.InboundMessage, text string) pkg.OutboundMessage {
+func errorResponse(msg pkg.InboundMessage, text string, meta ...map[string]string) pkg.OutboundMessage {
+	outMeta := safeMetadata(msg.Metadata)
+	if len(meta) > 0 && meta[0] != nil {
+		if outMeta == nil {
+			outMeta = make(map[string]string)
+		}
+		for k, v := range meta[0] {
+			outMeta[k] = v
+		}
+	}
 	return pkg.OutboundMessage{
 		ConversationID: msg.ConversationID,
 		ThreadID:       msg.ThreadID,
 		Content:        text,
-		Metadata:       safeMetadata(msg.Metadata),
+		Metadata:       outMeta,
 	}
 }
 
@@ -140,17 +153,19 @@ func safeMetadata(m map[string]string) map[string]string {
 	return out
 }
 
-// friendlyError returns a user-facing message for known error conditions.
-func friendlyError(err error) string {
+// friendlyError returns a user-facing message and machine-readable error code
+// for known error conditions. The error_code is stable and can be used by
+// frontends for i18n translations.
+func friendlyError(err error) (message string, errorCode string) {
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "maximum context length") || strings.Contains(msg, "context_length_exceeded"):
-		return "Sorry, this conversation has grown too long for the model to process. Please start a new conversation or clear the session."
+		return "Sorry, this conversation has grown too long for the model to process. Please start a new conversation or clear the session.", "context_length_exceeded"
 	case strings.Contains(msg, "rate_limit") || strings.Contains(msg, "429"):
-		return "I'm being rate-limited right now. Please try again in a moment."
+		return "I'm being rate-limited right now. Please try again in a moment.", "rate_limited"
 	case strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded"):
-		return "The request timed out. Please try again."
+		return "The request timed out. Please try again.", "timeout"
 	default:
-		return "Something went wrong processing your message. Please try again or start a new conversation."
+		return "Something went wrong processing your message. Please try again or start a new conversation.", "internal_error"
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -400,7 +400,13 @@ func (o *Orchestrator) handlePreparerFailure(prep ContentPreparerEntry, details 
 	if prep.FailOpen {
 		return nil
 	}
-	return &RunResult{Response: fmt.Sprintf("Request blocked: guard %s failed.", name)}
+	return &RunResult{
+		Response: fmt.Sprintf("Request blocked: guard %s failed.", name),
+		Metadata: map[string]string{
+			"type":       "error",
+			"error_code": "guard_blocked",
+		},
+	}
 }
 
 // runSTTPreparers transcribes audio/* files using STT-flagged preparers.
@@ -766,7 +772,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		resp := "Pipeline cancelled."
 		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
 		log.Debug("pipeline rejected", "pipeline_id", p.ID, "input", userMessage)
-		return &RunResult{Response: resp}, nil
+		return &RunResult{
+			Response: resp,
+			Metadata: map[string]string{
+				"type":   "system",
+				"action": "pipeline_cancelled",
+			},
+		}, nil
 	}
 
 	content := userMessage
@@ -894,6 +906,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			log.Debug("empty content and no files, returning fallback")
 			return &RunResult{
 				Response: "I received your message but couldn't read its content. Could you try sending it as text?",
+				Metadata: map[string]string{
+					"type":       "error",
+					"error_code": "empty_content",
+				},
 			}, nil
 		}
 		if content == "" && len(files) > 0 {


### PR DESCRIPTION
## Summary
All outbound websocket messages now carry machine-readable metadata so frontends can:
- Distinguish message types (`assistant`, `system`, `error`, `confirmation`)
- Translate error messages using stable `error_code` keys (i18n)
- Render system actions and confirmations with appropriate UI

## Changes

### Code
- **handler.go** — `friendlyError()` now returns `(message, errorCode)` tuple; all `errorResponse()` calls include `type: "error"` + `error_code` metadata
- **orchestrator.go** — pipeline cancellation, empty content fallback, and guard failures now include metadata

### Error codes added
| `error_code` | When |
|---|---|
| `timeout` | LLM/API deadline exceeded |
| `rate_limited` | Provider 429 |
| `context_length_exceeded` | Input too large |
| `internal_error` | Unrecognized error |
| `token_required` | Missing auth token |
| `auth_failed` | Token validation failed |
| `token_limit_exceeded` | Spend limit hit |
| `empty_content` | Empty message, no files |
| `guard_blocked` | Content guard rejected |

### Documentation
- **docs/websocket-messages.md** — complete reference for all websocket message types, metadata fields, error codes, and i18n integration pattern

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/orchestrator/... ./internal/channel/...`
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)