### PR TITLE
fix: send tool results as role=tool for native calling

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1018,7 +1018,8 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 
 		// Prefer native tool calls from the API response over text-based parsing.
 		var calls []ToolCall
-		if len(resp.ToolCalls) > 0 {
+		nativeToolCalls := len(resp.ToolCalls) > 0
+		if nativeToolCalls {
 			for _, tc := range resp.ToolCalls {
 				plugin, action, _ := parseToolName(tc.Name)
 				calls = append(calls, ToolCall{
@@ -1028,8 +1029,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 					Args:    tc.Arguments,
 					FromLLM: true,
 				})
+				log.Debug("native tool call", "id", tc.ID, "name", tc.Name, "args", tc.Arguments)
 			}
-			log.Debug("native tool calls received", "count", len(calls))
+			log.Info("native tool calls received", "round", i+1, "count", len(calls))
 		} else {
 			calls = o.parser.Parse(resp.Content)
 		}
@@ -1226,14 +1228,34 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", perCallInput, perCallOutput)
 			}
 
-			_ = sessions.AddMessage(sessionID, provider.Message{
-				Role:    provider.RoleAssistant,
-				Content: formatToolCallMessage(call),
-			})
-			_ = sessions.AddMessage(sessionID, provider.Message{
-				Role:    provider.RoleUser,
-				Content: o.guard.WrapContent(toolResult),
-			})
+			if nativeToolCalls {
+				// Native tool calling: store assistant message with tool_calls
+				// and tool result as role=tool with tool_call_id.
+				_ = sessions.AddMessage(sessionID, provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: resp.Content,
+					ToolCalls: []provider.ToolCall{{
+						ID:        call.ID,
+						Name:      call.Plugin + "." + call.Action,
+						Arguments: call.Args,
+					}},
+				})
+				_ = sessions.AddMessage(sessionID, provider.Message{
+					Role:       provider.RoleTool,
+					Content:    toolResult.Content,
+					ToolCallID: call.ID,
+				})
+			} else {
+				// Text-based tool calling: store as assistant + user messages.
+				_ = sessions.AddMessage(sessionID, provider.Message{
+					Role:    provider.RoleAssistant,
+					Content: formatToolCallMessage(call),
+				})
+				_ = sessions.AddMessage(sessionID, provider.Message{
+					Role:    provider.RoleUser,
+					Content: o.guard.WrapContent(toolResult),
+				})
+			}
 		}
 	}
 

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -234,6 +234,14 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 			)
 		}
 
+		// Log native tool calls when present.
+		if len(msg.ToolCalls) > 0 {
+			slog.DebugContext(ctx, "openai native tool calls",
+				"model", oaiResp.Model,
+				"count", len(msg.ToolCalls),
+			)
+		}
+
 		// Parse native tool calls from the response.
 		for _, tc := range msg.ToolCalls {
 			if tc.Type != "function" {
@@ -367,12 +375,29 @@ func (s *oaiResponseStream) Close() error {
 }
 
 func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error) {
-	msgs := make([]oaiMessage, len(req.Messages))
-	for i, m := range req.Messages {
+	msgs := make([]oaiMessage, 0, len(req.Messages))
+	for _, m := range req.Messages {
 		if len(m.Files) > 0 {
 			return oaiRequest{}, fmt.Errorf("provider %s does not support file attachments", p.id)
 		}
-		msgs[i] = oaiMessage{Role: string(m.Role), Content: m.Content}
+		oMsg := oaiMessage{Role: string(m.Role), Content: m.Content}
+		// Native tool calling: pass tool_call_id for tool result messages.
+		if m.Role == RoleTool && m.ToolCallID != "" {
+			oMsg.ToolCallID = m.ToolCallID
+		}
+		// Native tool calling: pass tool_calls for assistant messages.
+		for _, tc := range m.ToolCalls {
+			args, _ := json.Marshal(tc.Arguments)
+			oMsg.ToolCalls = append(oMsg.ToolCalls, oaiToolCall{
+				ID:   tc.ID,
+				Type: "function",
+				Function: oaiToolCallFunction{
+					Name:      tc.Name,
+					Arguments: string(args),
+				},
+			})
+		}
+		msgs = append(msgs, oMsg)
 	}
 	oai := oaiRequest{
 		Model:       req.Model,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,6 +8,7 @@ const (
 	RoleSystem    Role = "system"
 	RoleUser      Role = "user"
 	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool" // tool result message (native function calling)
 )
 
 // MessageFile is a binary file (image, document, etc.) attached to a message.
@@ -18,9 +19,11 @@ type MessageFile struct {
 }
 
 type Message struct {
-	Role    Role          `json:"role"`
-	Content string        `json:"content"`
-	Files   []MessageFile `json:"files,omitempty"`
+	Role       Role          `json:"role"`
+	Content    string        `json:"content"`
+	Files      []MessageFile `json:"files,omitempty"`
+	ToolCallID string        `json:"tool_call_id,omitempty"` // for role=tool messages (native function calling)
+	ToolCalls  []ToolCall    `json:"tool_calls,omitempty"`   // for role=assistant messages with native tool calls
 }
 
 // ToolDefinition describes a tool the LLM can call (native function calling).


### PR DESCRIPTION
## Summary
PR #188 added native tool calling (tools in request, tool_calls in response), but tool results were still sent back as `role: "user"` with `[plugin_output]` text. This breaks the OpenAI conversation format.

### Before (broken)
```
assistant: {tool_calls: [{id: "call_1", function: {name: "list-items"}}]}
user: "[plugin_output]\n{items: [...]}\n[/plugin_output]"    <-- WRONG
```

### After (correct)
```
assistant: {tool_calls: [{id: "call_1", function: {name: "list-items"}}]}
tool: {tool_call_id: "call_1", content: "{items: [...]}"}    <-- CORRECT
```

## Changes

### Provider layer
- Added `RoleTool` role constant
- Added `ToolCallID` and `ToolCalls` fields to `Message`
- `toOAIRequest` serializes `tool_call_id` for tool messages and `tool_calls` for assistant messages

### Orchestrator
- When native tool calls are used, stores results as `RoleTool` messages with `tool_call_id`
- Falls back to text-based `[plugin_output]` format for non-native tool calling
- Enhanced logging: logs each native tool call with id, name, args

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/provider/... ./internal/orchestrator/...`
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)