### PR TITLE
fix: reasoning downgrade wasn't firing (empty string != high)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1033,7 +1033,9 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// Downgrade reasoning effort on summary rounds: when tool results
 			// are already in session, the LLM only needs to format a response,
 			// not reason deeply about which tools to call. Saves ~10s per round.
-			if hasToolResults(sess.Messages) && req.ReasoningEffort == "high" {
+			// Check for empty too — applyModelDefaults sets it later, so at this
+			// point it's "" which would become "high" from config.
+			if hasToolResults(sess.Messages) && (req.ReasoningEffort == "high" || req.ReasoningEffort == "") {
 				req.ReasoningEffort = "medium"
 				log.Debug("reasoning effort downgraded for summary round", "round", i+1)
 			}


### PR DESCRIPTION
## Summary
The reasoning downgrade from PR #190 checked `req.ReasoningEffort == "high"`, but at that point in the orchestrator the field is still empty (`""`). The `defaultModelClient.applyModelDefaults()` sets it to `"high"` from config LATER when `Complete()` is called.

Fix: also match empty string, since it will become `"high"` via config defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)