### PR TITLE
feat: forward plugin knowledge articles via sync_actions

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3100,6 +3100,16 @@ type syncActionEntry struct {
 	Parameters  []Parameter `json:"parameters"`
 }
 
+// syncKnowledgeArticleEntry mirrors the weaviate-plugin's expected JSON shape
+// for one knowledge article. ID, Title and Content are required; Tags is
+// optional and will be merged with the plugin-augmented tag set on storage.
+type syncKnowledgeArticleEntry struct {
+	ID      string   `json:"id"`
+	Title   string   `json:"title"`
+	Content string   `json:"content"`
+	Tags    []string `json:"tags,omitempty"`
+}
+
 // syncActionsPayload is the JSON shape expected by the sync_actions action.
 //
 // ServerInstructions carries the plugin's SystemPromptAddition (e.g. an MCP
@@ -3118,11 +3128,21 @@ type syncActionsPayload struct {
 	PluginName         string            `json:"plugin_name"`
 	Actions            []syncActionEntry `json:"actions"`
 	ServerInstructions string            `json:"server_instructions,omitempty"`
-	KeepPlugins        []string          `json:"keep_plugins,omitempty"`
-	// Hash is a SHA-256 digest of the plugin's actions + server_instructions.
-	// When the sync plugin receives the same hash on consecutive calls for a
-	// given plugin_name, it can skip the upsert (the data hasn't changed).
-	// Computed by the orchestrator; older sync plugins ignore unknown fields.
+	// KnowledgeArticles ships per-section knowledge contributed by the plugin
+	// (e.g. an MCP server's `initialize._meta.knowledge_articles`). The sync
+	// plugin stores each as a KnowledgeArticles record with source
+	// "mcp-knowledge:<plugin>:<id>" so the prepare-path RAG can pull just the
+	// relevant section into [knowledge_context], instead of the full prose
+	// being injected via SystemPromptAddition into every system prompt.
+	// Optional; older sync plugins that don't recognize the field MUST ignore
+	// it — the upsert path is unaffected.
+	KnowledgeArticles []syncKnowledgeArticleEntry `json:"knowledge_articles,omitempty"`
+	KeepPlugins       []string                    `json:"keep_plugins,omitempty"`
+	// Hash is a SHA-256 digest of the plugin's actions + server_instructions
+	// + knowledge_articles. When the sync plugin receives the same hash on
+	// consecutive calls for a given plugin_name, it can skip the upsert (the
+	// data hasn't changed). Computed by the orchestrator; older sync plugins
+	// ignore unknown fields.
 	Hash string `json:"hash,omitempty"`
 	// IsContinuationBatch tells the sync plugin to skip the per-plugin
 	// pre-delete on this call. Set on batches 1..N of a chunked plugin sync
@@ -3216,7 +3236,20 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 			Parameters:  a.Parameters,
 		})
 	}
-	if len(entries) == 0 && cap.SystemPromptAddition == "" {
+	knowledge := make([]syncKnowledgeArticleEntry, 0, len(cap.KnowledgeArticles))
+	for _, ka := range cap.KnowledgeArticles {
+		if ka.ID == "" || ka.Title == "" || ka.Content == "" {
+			continue
+		}
+		knowledge = append(knowledge, syncKnowledgeArticleEntry{
+			ID:      ka.ID,
+			Title:   ka.Title,
+			Content: ka.Content,
+			Tags:    ka.Tags,
+		})
+	}
+
+	if len(entries) == 0 && cap.SystemPromptAddition == "" && len(knowledge) == 0 {
 		return nil
 	}
 
@@ -3226,9 +3259,10 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 	}
 
 	// Compute a deterministic hash over the full set of actions + server
-	// instructions. The sync plugin stores this per plugin and skips the
-	// upsert when unchanged — avoids redundant Weaviate writes on restart.
-	hash := capabilityHash(entries, cap.SystemPromptAddition)
+	// instructions + knowledge articles. The sync plugin stores this per
+	// plugin and skips the upsert when unchanged — avoids redundant Weaviate
+	// writes on restart.
+	hash := capabilityHash(entries, cap.SystemPromptAddition, knowledge)
 
 	// Batch actions into chunks to avoid oversized payloads that time out
 	// on the vector store side. Instructions and keep_plugins go on the
@@ -3253,7 +3287,13 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 			// via search_instructions. The prepare action excludes mcp:-sourced
 			// articles from [knowledge_context] to avoid duplication with the
 			// system prompt's SystemPromptAddition.
+			//
+			// Knowledge articles take a different route: stored under
+			// "mcp-knowledge:<plugin>:<id>" sources which are not filtered by
+			// the prepare path, so each section can be retrieved on-demand
+			// instead of injected into every system prompt.
 			payload.ServerInstructions = cap.SystemPromptAddition
+			payload.KnowledgeArticles = knowledge
 			payload.KeepPlugins = keepPlugins
 		}
 		b, err := json.Marshal(payload)
@@ -3275,10 +3315,11 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 	return nil
 }
 
-// capabilityHash computes a SHA-256 digest over a plugin's actions and server
-// instructions. The sync plugin stores this hash and skips re-syncing when it
-// matches — avoiding redundant Weaviate writes on restart.
-func capabilityHash(entries []syncActionEntry, serverInstructions string) string {
+// capabilityHash computes a SHA-256 digest over a plugin's actions, server
+// instructions and knowledge articles. The sync plugin stores this hash and
+// skips re-syncing when it matches — avoiding redundant Weaviate writes on
+// restart.
+func capabilityHash(entries []syncActionEntry, serverInstructions string, knowledge []syncKnowledgeArticleEntry) string {
 	h := sha256.New()
 	// Deterministic: entries are built in stable order from cap.Actions.
 	for _, e := range entries {
@@ -3289,7 +3330,16 @@ func capabilityHash(entries []syncActionEntry, serverInstructions string) string
 		}
 		h.Write([]byte{'\n'})
 	}
-	_, _ = fmt.Fprintf(h, "instructions:%s", serverInstructions)
+	_, _ = fmt.Fprintf(h, "instructions:%s\n", serverInstructions)
+	// Knowledge articles arrive in stable order from cap.KnowledgeArticles.
+	for _, ka := range knowledge {
+		_, _ = fmt.Fprintf(h, "knowledge:%s\n%s\n%s\n", ka.ID, ka.Title, ka.Content)
+		if len(ka.Tags) > 0 {
+			b, _ := json.Marshal(ka.Tags)
+			h.Write(b)
+		}
+		h.Write([]byte{'\n'})
+	}
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3241,12 +3241,7 @@ func (o *Orchestrator) syncPluginCapability(ctx context.Context, cap PluginCapab
 		if ka.ID == "" || ka.Title == "" || ka.Content == "" {
 			continue
 		}
-		knowledge = append(knowledge, syncKnowledgeArticleEntry{
-			ID:      ka.ID,
-			Title:   ka.Title,
-			Content: ka.Content,
-			Tags:    ka.Tags,
-		})
+		knowledge = append(knowledge, syncKnowledgeArticleEntry(ka))
 	}
 
 	if len(entries) == 0 && cap.SystemPromptAddition == "" && len(knowledge) == 0 {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2759,6 +2759,125 @@ func TestSyncActionsOmitsServerInstructionsWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestSyncActionsCarriesKnowledgeArticles(t *testing.T) {
+	// Knowledge articles contributed by a plugin (e.g. an MCP server's
+	// initialize._meta.knowledge_articles) must be forwarded on the first
+	// batch's payload alongside server_instructions. Empty articles
+	// (missing id/title/content) are filtered out.
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "timly", Description: "Timly",
+		Actions: []Action{{Name: "list-items", Description: "List items"}},
+		KnowledgeArticles: []KnowledgeArticle{
+			{ID: "org-units-vs-containers", Title: "Org-units vs Containers (Places)", Content: "A Place is a storage unit; an Org-unit is a structural unit.", Tags: []string{"places"}},
+			{ID: "users-vs-persons", Title: "Users vs Persons", Content: "A User logs in; a Person is a managed record."},
+			{ID: "incomplete-no-title", Title: "", Content: "x"}, // dropped
+			{ID: "", Title: "no-id", Content: "x"},               // dropped
+		},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	if len(syncCalls) != 1 {
+		t.Fatalf("expected 1 sync call, got %d: %v", len(syncCalls), syncCalls)
+	}
+	payload := syncCalls[0]
+	if !strings.Contains(payload, `"knowledge_articles"`) {
+		t.Errorf("knowledge_articles key missing from payload: %s", payload)
+	}
+	if !strings.Contains(payload, `"id":"org-units-vs-containers"`) {
+		t.Errorf("expected first article id in payload: %s", payload)
+	}
+	if !strings.Contains(payload, `"id":"users-vs-persons"`) {
+		t.Errorf("expected second article id in payload: %s", payload)
+	}
+	if strings.Contains(payload, `"id":"incomplete-no-title"`) {
+		t.Errorf("article missing title should have been filtered: %s", payload)
+	}
+	if strings.Contains(payload, `"title":"no-id"`) {
+		t.Errorf("article missing id should have been filtered: %s", payload)
+	}
+}
+
+func TestSyncActionsOmitsKnowledgeArticlesWhenAbsent(t *testing.T) {
+	// Backward-compat: plugins that don't contribute knowledge articles must
+	// not cause the orchestrator to ship an empty knowledge_articles array.
+	var syncCalls []string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "weaviate", Description: "Vector DB",
+		Actions: []Action{{Name: "sync_actions", Description: "Sync actions", Parameters: []Parameter{{Name: "payload", Description: "JSON"}}}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		syncCalls = append(syncCalls, call.Args["payload"])
+		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze code"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{
+		SyncActionsPlugin: "weaviate",
+		SyncActionsAction: "sync_actions",
+	})
+
+	orch.SyncActions(context.Background())
+
+	if len(syncCalls) != 1 {
+		t.Fatalf("expected 1 sync call, got %d", len(syncCalls))
+	}
+	if strings.Contains(syncCalls[0], "knowledge_articles") {
+		t.Errorf("knowledge_articles key should be omitted when none contributed: %s", syncCalls[0])
+	}
+}
+
+func TestCapabilityHashIncludesKnowledgeArticles(t *testing.T) {
+	// Adding or changing a knowledge article must change the hash so the sync
+	// plugin re-runs the upsert (otherwise the new section would never reach
+	// the vector store on a hash-match skip).
+	entries := []syncActionEntry{{Name: "list-items", Description: "List items"}}
+	prose := "Server preamble"
+
+	base := capabilityHash(entries, prose, nil)
+	withOne := capabilityHash(entries, prose, []syncKnowledgeArticleEntry{
+		{ID: "a", Title: "A", Content: "first"},
+	})
+	withTwo := capabilityHash(entries, prose, []syncKnowledgeArticleEntry{
+		{ID: "a", Title: "A", Content: "first"},
+		{ID: "b", Title: "B", Content: "second"},
+	})
+	withDifferentContent := capabilityHash(entries, prose, []syncKnowledgeArticleEntry{
+		{ID: "a", Title: "A", Content: "first revised"},
+	})
+
+	if base == withOne {
+		t.Error("hash unchanged after adding a knowledge article")
+	}
+	if withOne == withTwo {
+		t.Error("hash unchanged after adding a second knowledge article")
+	}
+	if withOne == withDifferentContent {
+		t.Error("hash unchanged after editing knowledge article content")
+	}
+}
+
 func TestSyncActionsCarriesKeepPlugins(t *testing.T) {
 	// During a full startup sync, every sync_actions call should ship the live
 	// plugin list as keep_plugins so the sync plugin can prune orphans. The

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -21,12 +21,13 @@ type Action struct {
 }
 
 type PluginCapability struct {
-	Name                 string          `yaml:"name"`
-	Description          string          `yaml:"description"`
-	Actions              []Action        `yaml:"actions"`
-	AllowedGroups        []string        `yaml:"allowed_groups,omitempty"`         // empty = unrestricted; when set, only listed groups can use this plugin
-	SystemPromptAddition string          `yaml:"system_prompt_addition,omitempty"` // optional text appended to LLM system prompt when this plugin is loaded
-	Glossary             []GlossaryEntry `yaml:"glossary,omitempty"`               // optional glossary term/definition pairs from the plugin
+	Name                 string             `yaml:"name"`
+	Description          string             `yaml:"description"`
+	Actions              []Action           `yaml:"actions"`
+	AllowedGroups        []string           `yaml:"allowed_groups,omitempty"`         // empty = unrestricted; when set, only listed groups can use this plugin
+	SystemPromptAddition string             `yaml:"system_prompt_addition,omitempty"` // optional text appended to LLM system prompt when this plugin is loaded
+	Glossary             []GlossaryEntry    `yaml:"glossary,omitempty"`               // optional glossary term/definition pairs from the plugin
+	KnowledgeArticles    []KnowledgeArticle `yaml:"knowledge_articles,omitempty"`     // optional per-section knowledge for retrieval-time injection (mcp-knowledge:* in vector store)
 }
 
 // GlossaryEntry is a domain term with its definition, provided by a plugin
@@ -38,6 +39,18 @@ type GlossaryEntry struct {
 	Category   string   `yaml:"category,omitempty"`
 	Tags       []string `yaml:"tags,omitempty"`
 	Synonyms   []string `yaml:"synonyms,omitempty"`
+}
+
+// KnowledgeArticle is one self-contained reference section a plugin
+// contributes for retrieval-time injection (rather than always-on inclusion
+// via SystemPromptAddition). The orchestrator forwards these to the vector
+// store via sync_actions's knowledge_articles[] field; the prepare-path RAG
+// then pulls just the relevant section into [knowledge_context] per query.
+type KnowledgeArticle struct {
+	ID      string   `yaml:"id"`
+	Title   string   `yaml:"title"`
+	Content string   `yaml:"content"`
+	Tags    []string `yaml:"tags,omitempty"`
 }
 
 type ToolCall struct {

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -164,11 +164,21 @@ func toPluginCapability(pb *pluginpb.PluginCapabilities) orchestrator.PluginCapa
 			Synonyms:   g.Synonyms,
 		}
 	}
+	knowledge := make([]orchestrator.KnowledgeArticle, len(pb.KnowledgeArticles))
+	for i, k := range pb.KnowledgeArticles {
+		knowledge[i] = orchestrator.KnowledgeArticle{
+			ID:      k.Id,
+			Title:   k.Title,
+			Content: k.Content,
+			Tags:    k.Tags,
+		}
+	}
 	return orchestrator.PluginCapability{
 		Name:                 pb.Name,
 		Description:          pb.Description,
 		Actions:              actions,
 		SystemPromptAddition: pb.SystemPromptAddition,
 		Glossary:             glossary,
+		KnowledgeArticles:    knowledge,
 	}
 }

--- a/pkg/plugin/convert.go
+++ b/pkg/plugin/convert.go
@@ -36,12 +36,22 @@ func capsToProto(c CapabilitiesMsg) *pluginpb.PluginCapabilities {
 			Synonyms:   g.Synonyms,
 		}
 	}
+	knowledge := make([]*pluginpb.KnowledgeArticle, len(c.KnowledgeArticles))
+	for i, k := range c.KnowledgeArticles {
+		knowledge[i] = &pluginpb.KnowledgeArticle{
+			Id:      k.ID,
+			Title:   k.Title,
+			Content: k.Content,
+			Tags:    k.Tags,
+		}
+	}
 	return &pluginpb.PluginCapabilities{
 		Name:                 c.Name,
 		Description:          c.Description,
 		Actions:              actions,
 		SystemPromptAddition: c.SystemPromptAddition,
 		Glossary:             glossary,
+		KnowledgeArticles:    knowledge,
 	}
 }
 

--- a/pkg/plugin/protocol.go
+++ b/pkg/plugin/protocol.go
@@ -47,12 +47,12 @@ type Response struct {
 
 // CapabilitiesMsg carries the plugin's self-description.
 type CapabilitiesMsg struct {
-	Name                 string                 `json:"name"`
-	Description          string                 `json:"description"`
-	Actions              []ActionMsg            `json:"actions"`
-	SystemPromptAddition string                 `json:"system_prompt_addition,omitempty"`
-	Glossary             []GlossaryEntryMsg     `json:"glossary,omitempty"`
-	KnowledgeArticles    []KnowledgeArticleMsg  `json:"knowledge_articles,omitempty"`
+	Name                 string                `json:"name"`
+	Description          string                `json:"description"`
+	Actions              []ActionMsg           `json:"actions"`
+	SystemPromptAddition string                `json:"system_prompt_addition,omitempty"`
+	Glossary             []GlossaryEntryMsg    `json:"glossary,omitempty"`
+	KnowledgeArticles    []KnowledgeArticleMsg `json:"knowledge_articles,omitempty"`
 }
 
 // GlossaryEntryMsg is a single term/definition pair provided by a plugin.

--- a/pkg/plugin/protocol.go
+++ b/pkg/plugin/protocol.go
@@ -47,11 +47,12 @@ type Response struct {
 
 // CapabilitiesMsg carries the plugin's self-description.
 type CapabilitiesMsg struct {
-	Name                 string             `json:"name"`
-	Description          string             `json:"description"`
-	Actions              []ActionMsg        `json:"actions"`
-	SystemPromptAddition string             `json:"system_prompt_addition,omitempty"`
-	Glossary             []GlossaryEntryMsg `json:"glossary,omitempty"`
+	Name                 string                 `json:"name"`
+	Description          string                 `json:"description"`
+	Actions              []ActionMsg            `json:"actions"`
+	SystemPromptAddition string                 `json:"system_prompt_addition,omitempty"`
+	Glossary             []GlossaryEntryMsg     `json:"glossary,omitempty"`
+	KnowledgeArticles    []KnowledgeArticleMsg  `json:"knowledge_articles,omitempty"`
 }
 
 // GlossaryEntryMsg is a single term/definition pair provided by a plugin.
@@ -61,6 +62,17 @@ type GlossaryEntryMsg struct {
 	Category   string   `json:"category,omitempty"`
 	Tags       []string `json:"tags,omitempty"`
 	Synonyms   []string `json:"synonyms,omitempty"`
+}
+
+// KnowledgeArticleMsg is one self-contained reference section a plugin
+// contributes for retrieval-time injection (rather than always-on inclusion
+// via SystemPromptAddition). The orchestrator forwards these to the vector
+// store via sync_actions's knowledge_articles[] field for per-section RAG.
+type KnowledgeArticleMsg struct {
+	ID      string   `json:"id"`
+	Title   string   `json:"title"`
+	Content string   `json:"content"`
+	Tags    []string `json:"tags,omitempty"`
 }
 
 // ActionMsg describes one action a plugin supports.

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -65,6 +65,13 @@ message PluginCapabilities {
   // The orchestrator collects entries from all plugins and syncs them to the
   // vector store via the sync_glossary action for automatic context injection.
   repeated GlossaryEntry glossary = 5;
+  // Optional per-section knowledge articles provided by the plugin (e.g. an
+  // MCP server's `initialize._meta.knowledge_articles`). Each entry becomes
+  // one KnowledgeArticles record on the vector store with source
+  // "mcp-knowledge:<plugin>:<id>" so the prepare-path RAG can pull just
+  // the relevant section into [knowledge_context], instead of having the
+  // whole prose go into every system prompt via system_prompt_addition.
+  repeated KnowledgeArticle knowledge_articles = 6;
 }
 
 message GlossaryEntry {
@@ -73,6 +80,16 @@ message GlossaryEntry {
   string category = 3;          // optional grouping (e.g. "hr", "support")
   repeated string tags = 4;     // optional free-form tags
   repeated string synonyms = 5; // alternative terms for better vector matching
+}
+
+// KnowledgeArticle is one self-contained reference section a plugin
+// contributes for retrieval-time injection (as opposed to always-on
+// inclusion via system_prompt_addition). Required fields: id, title, content.
+message KnowledgeArticle {
+  string id = 1;
+  string title = 2;
+  string content = 3;
+  repeated string tags = 4; // optional free-form tags merged with the auto-set ["opentalon", "mcp", "knowledge", <plugin>] on storage
 }
 
 message Action {

--- a/proto/pluginpb/plugin.pb.go
+++ b/proto/pluginpb/plugin.pb.go
@@ -289,9 +289,16 @@ type PluginCapabilities struct {
 	// Optional glossary entries provided by the plugin (e.g. from an MCP server).
 	// The orchestrator collects entries from all plugins and syncs them to the
 	// vector store via the sync_glossary action for automatic context injection.
-	Glossary      []*GlossaryEntry `protobuf:"bytes,5,rep,name=glossary,proto3" json:"glossary,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Glossary []*GlossaryEntry `protobuf:"bytes,5,rep,name=glossary,proto3" json:"glossary,omitempty"`
+	// Optional per-section knowledge articles provided by the plugin (e.g. an
+	// MCP server's `initialize._meta.knowledge_articles`). Each entry becomes
+	// one KnowledgeArticles record on the vector store with source
+	// "mcp-knowledge:<plugin>:<id>" so the prepare-path RAG can pull just
+	// the relevant section into [knowledge_context], instead of having the
+	// whole prose go into every system prompt via system_prompt_addition.
+	KnowledgeArticles []*KnowledgeArticle `protobuf:"bytes,6,rep,name=knowledge_articles,json=knowledgeArticles,proto3" json:"knowledge_articles,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *PluginCapabilities) Reset() {
@@ -355,6 +362,13 @@ func (x *PluginCapabilities) GetSystemPromptAddition() string {
 func (x *PluginCapabilities) GetGlossary() []*GlossaryEntry {
 	if x != nil {
 		return x.Glossary
+	}
+	return nil
+}
+
+func (x *PluginCapabilities) GetKnowledgeArticles() []*KnowledgeArticle {
+	if x != nil {
+		return x.KnowledgeArticles
 	}
 	return nil
 }
@@ -435,6 +449,77 @@ func (x *GlossaryEntry) GetSynonyms() []string {
 	return nil
 }
 
+// KnowledgeArticle is one self-contained reference section a plugin
+// contributes for retrieval-time injection (as opposed to always-on
+// inclusion via system_prompt_addition). Required fields: id, title, content.
+type KnowledgeArticle struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Title         string                 `protobuf:"bytes,2,opt,name=title,proto3" json:"title,omitempty"`
+	Content       string                 `protobuf:"bytes,3,opt,name=content,proto3" json:"content,omitempty"`
+	Tags          []string               `protobuf:"bytes,4,rep,name=tags,proto3" json:"tags,omitempty"` // optional free-form tags merged with the auto-set ["opentalon", "mcp", "knowledge", <plugin>] on storage
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KnowledgeArticle) Reset() {
+	*x = KnowledgeArticle{}
+	mi := &file_plugin_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KnowledgeArticle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KnowledgeArticle) ProtoMessage() {}
+
+func (x *KnowledgeArticle) ProtoReflect() protoreflect.Message {
+	mi := &file_plugin_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KnowledgeArticle.ProtoReflect.Descriptor instead.
+func (*KnowledgeArticle) Descriptor() ([]byte, []int) {
+	return file_plugin_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *KnowledgeArticle) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *KnowledgeArticle) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *KnowledgeArticle) GetContent() string {
+	if x != nil {
+		return x.Content
+	}
+	return ""
+}
+
+func (x *KnowledgeArticle) GetTags() []string {
+	if x != nil {
+		return x.Tags
+	}
+	return nil
+}
+
 type Action struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	Name              string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
@@ -448,7 +533,7 @@ type Action struct {
 
 func (x *Action) Reset() {
 	*x = Action{}
-	mi := &file_plugin_proto_msgTypes[6]
+	mi := &file_plugin_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +545,7 @@ func (x *Action) String() string {
 func (*Action) ProtoMessage() {}
 
 func (x *Action) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[6]
+	mi := &file_plugin_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +558,7 @@ func (x *Action) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Action.ProtoReflect.Descriptor instead.
 func (*Action) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{6}
+	return file_plugin_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *Action) GetName() string {
@@ -523,7 +608,7 @@ type Parameter struct {
 
 func (x *Parameter) Reset() {
 	*x = Parameter{}
-	mi := &file_plugin_proto_msgTypes[7]
+	mi := &file_plugin_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -535,7 +620,7 @@ func (x *Parameter) String() string {
 func (*Parameter) ProtoMessage() {}
 
 func (x *Parameter) ProtoReflect() protoreflect.Message {
-	mi := &file_plugin_proto_msgTypes[7]
+	mi := &file_plugin_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -548,7 +633,7 @@ func (x *Parameter) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Parameter.ProtoReflect.Descriptor instead.
 func (*Parameter) Descriptor() ([]byte, []int) {
-	return file_plugin_proto_rawDescGZIP(), []int{7}
+	return file_plugin_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Parameter) GetName() string {
@@ -606,13 +691,14 @@ const file_plugin_proto_rawDesc = "" +
 	"\acall_id\x18\x01 \x01(\tR\x06callId\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x12\x14\n" +
 	"\x05error\x18\x03 \x01(\tR\x05error\x12-\n" +
-	"\x12structured_content\x18\x04 \x01(\tR\x11structuredContent\"\xf7\x01\n" +
+	"\x12structured_content\x18\x04 \x01(\tR\x11structuredContent\"\xcd\x02\n" +
 	"\x12PluginCapabilities\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x125\n" +
 	"\aactions\x18\x03 \x03(\v2\x1b.opentalon.plugin.v1.ActionR\aactions\x124\n" +
 	"\x16system_prompt_addition\x18\x04 \x01(\tR\x14systemPromptAddition\x12>\n" +
-	"\bglossary\x18\x05 \x03(\v2\".opentalon.plugin.v1.GlossaryEntryR\bglossary\"\x8f\x01\n" +
+	"\bglossary\x18\x05 \x03(\v2\".opentalon.plugin.v1.GlossaryEntryR\bglossary\x12T\n" +
+	"\x12knowledge_articles\x18\x06 \x03(\v2%.opentalon.plugin.v1.KnowledgeArticleR\x11knowledgeArticles\"\x8f\x01\n" +
 	"\rGlossaryEntry\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\tR\x04term\x12\x1e\n" +
 	"\n" +
@@ -620,7 +706,12 @@ const file_plugin_proto_rawDesc = "" +
 	"definition\x12\x1a\n" +
 	"\bcategory\x18\x03 \x01(\tR\bcategory\x12\x12\n" +
 	"\x04tags\x18\x04 \x03(\tR\x04tags\x12\x1a\n" +
-	"\bsynonyms\x18\x05 \x03(\tR\bsynonyms\"\xcb\x01\n" +
+	"\bsynonyms\x18\x05 \x03(\tR\bsynonyms\"f\n" +
+	"\x10KnowledgeArticle\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05title\x18\x02 \x01(\tR\x05title\x12\x18\n" +
+	"\acontent\x18\x03 \x01(\tR\acontent\x12\x12\n" +
+	"\x04tags\x18\x04 \x03(\tR\x04tags\"\xcb\x01\n" +
 	"\x06Action\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12>\n" +
@@ -651,7 +742,7 @@ func file_plugin_proto_rawDescGZIP() []byte {
 	return file_plugin_proto_rawDescData
 }
 
-var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_plugin_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_plugin_proto_goTypes = []any{
 	(*PluginInitRequest)(nil),  // 0: opentalon.plugin.v1.PluginInitRequest
 	(*ToolCallRequest)(nil),    // 1: opentalon.plugin.v1.ToolCallRequest
@@ -659,30 +750,32 @@ var file_plugin_proto_goTypes = []any{
 	(*ToolResultResponse)(nil), // 3: opentalon.plugin.v1.ToolResultResponse
 	(*PluginCapabilities)(nil), // 4: opentalon.plugin.v1.PluginCapabilities
 	(*GlossaryEntry)(nil),      // 5: opentalon.plugin.v1.GlossaryEntry
-	(*Action)(nil),             // 6: opentalon.plugin.v1.Action
-	(*Parameter)(nil),          // 7: opentalon.plugin.v1.Parameter
-	nil,                        // 8: opentalon.plugin.v1.ToolCallRequest.ArgsEntry
-	nil,                        // 9: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
-	(*emptypb.Empty)(nil),      // 10: google.protobuf.Empty
+	(*KnowledgeArticle)(nil),   // 6: opentalon.plugin.v1.KnowledgeArticle
+	(*Action)(nil),             // 7: opentalon.plugin.v1.Action
+	(*Parameter)(nil),          // 8: opentalon.plugin.v1.Parameter
+	nil,                        // 9: opentalon.plugin.v1.ToolCallRequest.ArgsEntry
+	nil,                        // 10: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
+	(*emptypb.Empty)(nil),      // 11: google.protobuf.Empty
 }
 var file_plugin_proto_depIdxs = []int32{
-	8,  // 0: opentalon.plugin.v1.ToolCallRequest.args:type_name -> opentalon.plugin.v1.ToolCallRequest.ArgsEntry
-	9,  // 1: opentalon.plugin.v1.ToolCallRequest.credential_headers:type_name -> opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
-	6,  // 2: opentalon.plugin.v1.PluginCapabilities.actions:type_name -> opentalon.plugin.v1.Action
+	9,  // 0: opentalon.plugin.v1.ToolCallRequest.args:type_name -> opentalon.plugin.v1.ToolCallRequest.ArgsEntry
+	10, // 1: opentalon.plugin.v1.ToolCallRequest.credential_headers:type_name -> opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry
+	7,  // 2: opentalon.plugin.v1.PluginCapabilities.actions:type_name -> opentalon.plugin.v1.Action
 	5,  // 3: opentalon.plugin.v1.PluginCapabilities.glossary:type_name -> opentalon.plugin.v1.GlossaryEntry
-	7,  // 4: opentalon.plugin.v1.Action.parameters:type_name -> opentalon.plugin.v1.Parameter
-	2,  // 5: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry.value:type_name -> opentalon.plugin.v1.CredentialHeader
-	0,  // 6: opentalon.plugin.v1.PluginService.Init:input_type -> opentalon.plugin.v1.PluginInitRequest
-	1,  // 7: opentalon.plugin.v1.PluginService.Execute:input_type -> opentalon.plugin.v1.ToolCallRequest
-	10, // 8: opentalon.plugin.v1.PluginService.Capabilities:input_type -> google.protobuf.Empty
-	10, // 9: opentalon.plugin.v1.PluginService.Init:output_type -> google.protobuf.Empty
-	3,  // 10: opentalon.plugin.v1.PluginService.Execute:output_type -> opentalon.plugin.v1.ToolResultResponse
-	4,  // 11: opentalon.plugin.v1.PluginService.Capabilities:output_type -> opentalon.plugin.v1.PluginCapabilities
-	9,  // [9:12] is the sub-list for method output_type
-	6,  // [6:9] is the sub-list for method input_type
-	6,  // [6:6] is the sub-list for extension type_name
-	6,  // [6:6] is the sub-list for extension extendee
-	0,  // [0:6] is the sub-list for field type_name
+	6,  // 4: opentalon.plugin.v1.PluginCapabilities.knowledge_articles:type_name -> opentalon.plugin.v1.KnowledgeArticle
+	8,  // 5: opentalon.plugin.v1.Action.parameters:type_name -> opentalon.plugin.v1.Parameter
+	2,  // 6: opentalon.plugin.v1.ToolCallRequest.CredentialHeadersEntry.value:type_name -> opentalon.plugin.v1.CredentialHeader
+	0,  // 7: opentalon.plugin.v1.PluginService.Init:input_type -> opentalon.plugin.v1.PluginInitRequest
+	1,  // 8: opentalon.plugin.v1.PluginService.Execute:input_type -> opentalon.plugin.v1.ToolCallRequest
+	11, // 9: opentalon.plugin.v1.PluginService.Capabilities:input_type -> google.protobuf.Empty
+	11, // 10: opentalon.plugin.v1.PluginService.Init:output_type -> google.protobuf.Empty
+	3,  // 11: opentalon.plugin.v1.PluginService.Execute:output_type -> opentalon.plugin.v1.ToolResultResponse
+	4,  // 12: opentalon.plugin.v1.PluginService.Capabilities:output_type -> opentalon.plugin.v1.PluginCapabilities
+	10, // [10:13] is the sub-list for method output_type
+	7,  // [7:10] is the sub-list for method input_type
+	7,  // [7:7] is the sub-list for extension type_name
+	7,  // [7:7] is the sub-list for extension extendee
+	0,  // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_plugin_proto_init() }
@@ -696,7 +789,7 @@ func file_plugin_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_plugin_proto_rawDesc), len(file_plugin_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
## Summary

Extends the plugin capability protocol with an optional
`knowledge_articles[]` field, alongside the existing `system_prompt_addition`
and `glossary`, so a plugin (e.g. mcp-plugin bridging Timly's MCP server)
can ship per-section reference material that the prepare-path RAG can
pull on-demand into \`[knowledge_context]\` — instead of having the full
prose duplicated in every system prompt via \`SystemPromptAddition\`.

End-to-end flow for each \`PluginCapability.KnowledgeArticles\` entry
\`{id, title, content, tags?}\`:

- \`proto\`: \`PluginCapabilities.knowledge_articles\` → \`KnowledgeArticle\` msg
- \`pkg/plugin\`: \`CapabilitiesMsg.KnowledgeArticles\` → \`KnowledgeArticleMsg\`
- \`internal/plugin/client\`: pb → \`orchestrator.KnowledgeArticle\`
- \`internal/orchestrator\`: \`PluginCapability.KnowledgeArticles\`
- \`sync_actions\` payload: \`knowledge_articles[]\` alongside \`server_instructions\`

The orchestrator filters incomplete entries (missing id/title/content)
before forwarding so individual plugin bugs don't pollute the vector store.
Hash is extended to cover knowledge articles too — without that, an
articles-only change after restart would be dropped by the sync plugin's
hash-match skip path. Stable iteration order over \`cap.KnowledgeArticles\`
keeps the hash deterministic.

## Tests

- \`TestSyncActionsCarriesKnowledgeArticles\`: payload includes articles
  and filters incomplete ones
- \`TestSyncActionsOmitsKnowledgeArticlesWhenAbsent\`: backward-compat —
  no key when none contributed
- \`TestCapabilityHashIncludesKnowledgeArticles\`: hash changes on
  add/edit so the sync plugin re-runs the upsert

## Backward-compatible

\`KnowledgeArticles\` is optional everywhere; older
plugins/sync-plugins/timly versions that don't recognize the field
keep working unchanged.

## Companion PRs

- **weaviate-plugin** (sync plugin): https://github.com/opentalon/weaviate-plugin/pull/28
- **mcp-plugin**: captures \`initialize.knowledge_articles\` from upstream MCP servers, depends on this PR being merged + tagged
- **timly** (GitLab): splits \`SERVER_INSTRUCTIONS\` into preamble + sections, emits \`knowledge_articles\` on initialize

## Test plan

- [ ] \`go test ./...\` passes
- [ ] manual: a plugin shipping KnowledgeArticles produces a sync_actions payload with \`knowledge_articles[]\`
- [ ] tag \`v0.0.12\` after merge so mcp-plugin can bump its dep