### PR TITLE
fix: skip malformed role=tool messages without tool_call_id

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -380,6 +380,15 @@ func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error
 		if len(m.Files) > 0 {
 			return oaiRequest{}, fmt.Errorf("provider %s does not support file attachments", p.id)
 		}
+		// Skip malformed messages from old sessions:
+		// - role=tool without tool_call_id (OpenAI API rejects these)
+		// - role=assistant with empty content and no tool calls (orphans)
+		if m.Role == RoleTool && m.ToolCallID == "" {
+			continue
+		}
+		if m.Role == RoleAssistant && m.Content == "" && len(m.ToolCalls) == 0 {
+			continue
+		}
 		oMsg := oaiMessage{Role: string(m.Role), Content: m.Content}
 		// Native tool calling: pass tool_call_id for tool result messages.
 		if m.Role == RoleTool && m.ToolCallID != "" {


### PR DESCRIPTION
## Root cause
Sessions created before native tool calling was properly wired contain `role: "tool"` messages with empty `tool_call_id` and `role: "assistant"` messages with empty content and no tool_calls. The OpenAI API rejects these with `missing field 'tool_call_id'`.

## Fix
In `toOAIRequest`, skip:
- `role: "tool"` messages without `tool_call_id`
- `role: "assistant"` messages with empty content and no tool calls (orphans)

These messages are silently dropped from the API request. New sessions with native tool calling store proper `tool_call_id` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)