### PR TITLE
feat: pipeline step-output substitution + typed-args end-to-end

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -870,7 +870,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 					ID:     fmt.Sprintf("planner-%s-%s", step.Command.Plugin, step.Command.Action),
 					Plugin: step.Command.Plugin,
 					Action: step.Command.Action,
-					Args:   step.Command.Args,
+					Args:   pipelineArgsToWire(step.Command.Args),
 				}
 				toolResult := o.executeCall(ctx, call)
 				if toolResult.Error == "" {
@@ -1756,13 +1756,17 @@ func (o *Orchestrator) runGuardPlugins(ctx context.Context, messages []provider.
 
 func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p *pipeline.Pipeline) (*RunResult, error) {
 	log := logger.FromContext(ctx)
-	runner := func(ctx context.Context, pluginName, action string, args map[string]string) pipeline.StepRunResult {
-		log.Debug("pipeline executing step", "plugin", pluginName, "action", action, "args", args)
+	runner := func(ctx context.Context, pluginName, action string, args map[string]any) pipeline.StepRunResult {
+		// Stringify typed args at the wire boundary; ToolCall.Args is
+		// map[string]string by gRPC contract. The downstream plugin re-
+		// coerces per its declared input schema.
+		wireArgs := pipelineArgsToWire(args)
+		log.Debug("pipeline executing step", "plugin", pluginName, "action", action, "args", wireArgs)
 		call := ToolCall{
 			ID:     fmt.Sprintf("pipeline-%s-%s", pluginName, action),
 			Plugin: pluginName,
 			Action: action,
-			Args:   args,
+			Args:   wireArgs,
 		}
 		result := o.executeCall(ctx, call)
 		if result.Error != "" {
@@ -1774,7 +1778,11 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 			}
 			log.Debug("pipeline step succeeded", "plugin", pluginName, "action", action, "result", preview)
 		}
-		return pipeline.StepRunResult{Content: result.Content, Error: result.Error}
+		return pipeline.StepRunResult{
+			Content:           result.Content,
+			StructuredContent: result.StructuredContent,
+			Error:             result.Error,
+		}
 	}
 	executor := pipeline.NewExecutor(runner, p.Config)
 	execResult, err := executor.Run(ctx, p)
@@ -1784,7 +1792,8 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 
 	log.Debug("pipeline execution done", "success", execResult.Success, "steps_executed", len(execResult.Steps))
 
-	// Record step results in session history
+	// Record step results in session history. Args are stringified at the
+	// recording boundary so the trace mirrors what hit the wire.
 	var toolCalls []ToolCall
 	var toolResults []ToolResult
 	for _, es := range execResult.Steps {
@@ -1792,7 +1801,7 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 			ID:     fmt.Sprintf("pipeline-%s-%s", es.Plugin, es.Action),
 			Plugin: es.Plugin,
 			Action: es.Action,
-			Args:   es.Args,
+			Args:   pipelineArgsToWire(es.Args),
 		}
 		tr := ToolResult{CallID: tc.ID, Content: es.Content, Error: es.Error}
 		toolCalls = append(toolCalls, tc)
@@ -2782,9 +2791,14 @@ func buildToolCallNudge(steps []*pipeline.Step) string {
 			continue
 		}
 		tool := s.Command.Plugin + "." + s.Command.Action
-		args := map[string]string{}
-		if s.Command.Args != nil {
-			args = s.Command.Args
+		// Marshal typed args directly — JSON preserves number/bool/array
+		// shape exactly as the LLM should re-emit them in the [tool_call]
+		// block. Stringification (used for the gRPC wire) would force the
+		// LLM to read "2037838" and decide whether to quote it; better to
+		// hand the JSON form straight back.
+		args := s.Command.Args
+		if args == nil {
+			args = map[string]any{}
 		}
 		argsJSON, err := json.Marshal(args)
 		if err != nil {
@@ -2801,21 +2815,18 @@ func buildToolCallNudge(steps []*pipeline.Step) string {
 
 // plannerStepsToInvoke converts planner pipeline steps to InvokeSteps for
 // server-side execution. Steps without a concrete command (e.g. sentinel
-// "direct" steps) are skipped.
+// "direct" steps) are skipped. Typed args are stringified at this boundary
+// — InvokeStep is a wire-shaped value passed to the websocket / hint layer.
 func plannerStepsToInvoke(steps []*pipeline.Step) []InvokeStep {
 	var out []InvokeStep
 	for _, s := range steps {
 		if s.Command == nil || s.Command.Plugin == "" || s.Command.Action == "" {
 			continue
 		}
-		args := make(map[string]string)
-		for k, v := range s.Command.Args {
-			args[k] = v
-		}
 		out = append(out, InvokeStep{
 			Plugin: s.Command.Plugin,
 			Action: s.Command.Action,
-			Args:   args,
+			Args:   pipelineArgsToWire(s.Command.Args),
 		})
 	}
 	return out

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3254,7 +3254,7 @@ func TestBuildToolCallNudgeWithConcreteStep(t *testing.T) {
 			Command: &pipeline.PluginCommand{
 				Plugin: "timly",
 				Action: "timly__list-person-types",
-				Args:   map[string]string{},
+				Args:   map[string]any{},
 			},
 		},
 	}
@@ -3284,7 +3284,7 @@ func TestBuildToolCallNudgeWithArgs(t *testing.T) {
 			Command: &pipeline.PluginCommand{
 				Plugin: "timly",
 				Action: "timly__list-items",
-				Args:   map[string]string{"query": "status:active", "per_page": "1"},
+				Args:   map[string]any{"query": "status:active", "per_page": "1"},
 			},
 		},
 	}
@@ -3305,7 +3305,7 @@ func TestPlannerStepsToInvoke(t *testing.T) {
 			Command: &pipeline.PluginCommand{
 				Plugin: "timly",
 				Action: "timly__list-person-types",
-				Args:   map[string]string{"per_page": "1"},
+				Args:   map[string]any{"per_page": "1"},
 			},
 		},
 	}

--- a/internal/orchestrator/pipeline_args.go
+++ b/internal/orchestrator/pipeline_args.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"strconv"
+)
+
+// pipelineArgsToWire converts typed pipeline-step args to the wire-level
+// map[string]string used by ToolCall and the gRPC plugin protocol.
+//
+// The pipeline package keeps args typed (map[string]any) so the planner's
+// JSON numbers and step-output substitution survive round-trip. The wire
+// format is map<string,string> by definition (proto/plugin.proto), so this
+// is the boundary where types collapse into strings. Each plugin re-coerces
+// per its declared input schema on the receiving side; correctness here is
+// "no information loss in the round-trip".
+//
+// Specifically: integer-valued floats render as plain decimals (not
+// scientific notation), booleans render as "true"/"false", strings pass
+// through unchanged, and compound values (slice/map) round-trip via JSON.
+//
+// nil values are emitted as "null" — sending a key with an empty string
+// would be ambiguous with a deliberately-blank string param.
+func pipelineArgsToWire(args map[string]any) map[string]string {
+	out := make(map[string]string, len(args))
+	for k, v := range args {
+		out[k] = argToWireString(v)
+	}
+	return out
+}
+
+// argToWireString formats a single typed value for the wire layer.
+//
+// The plain-decimal float rendering matters for IDs: a Timly item id like
+// 2_037_838 becomes float64 after JSON unmarshal, and fmt.Sprintf("%v", v)
+// (the previous behaviour) renders it as "2.037838e+06", which the
+// downstream MCP server then rejects as "type string did not match the
+// following type: integer". strconv.FormatFloat with 'f', -1 keeps the
+// integer-valued float in plain decimal form regardless of magnitude.
+func argToWireString(v any) string {
+	if v == nil {
+		return "null"
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		return strconv.FormatBool(x)
+	case json.Number:
+		return string(x)
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int32:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float32:
+		return formatFloat(float64(x))
+	case float64:
+		return formatFloat(x)
+	default:
+		// Slice / map / anything richer — JSON-marshal so the downstream
+		// plugin re-parses with structure intact (its coerce() reads the
+		// schema type and json.Unmarshals as needed).
+		b, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprintf("%v", v)
+		}
+		return string(b)
+	}
+}
+
+// formatFloat renders a float64 in the way users expect when staring at IDs
+// in a log line — integers stay integer, fractions stay decimal, never
+// scientific notation. We mirror Go's strconv 'f' verb with -1 precision
+// (shortest round-trip representation) but special-case integer values to
+// avoid the "1.7e+02" surprise on whole numbers above the %v threshold.
+func formatFloat(x float64) string {
+	if math.IsNaN(x) || math.IsInf(x, 0) {
+		// JSON marshal handles these as errors; fall through to %v which
+		// renders "NaN" / "+Inf" rather than crashing the call.
+		return fmt.Sprintf("%v", x)
+	}
+	if x == math.Trunc(x) && !math.IsInf(x, 0) && math.Abs(x) < 1e18 {
+		return strconv.FormatInt(int64(x), 10)
+	}
+	return strconv.FormatFloat(x, 'f', -1, 64)
+}

--- a/internal/orchestrator/pipeline_args_test.go
+++ b/internal/orchestrator/pipeline_args_test.go
@@ -1,0 +1,96 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// TestArgToWireString covers the type-aware stringification used at the
+// pipeline → ToolCall.Args boundary. Every case where the previous default
+// (fmt.Sprintf("%v", v)) lost information OR introduced surprises is
+// captured here as a regression test.
+func TestArgToWireString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want string
+	}{
+		// Plain scalars
+		{"string", "hello", "hello"},
+		{"empty string", "", ""},
+		{"true", true, "true"},
+		{"false", false, "false"},
+		{"int", 42, "42"},
+		{"int64 large", int64(2_000_000_000_000), "2000000000000"},
+		{"nil", nil, "null"},
+
+		// Floats — the regression heart. JSON unmarshal into interface{}
+		// produces float64 for every numeric. Default %v on a 7-digit
+		// integer-valued float renders as "2.037838e+06"; the wire layer
+		// must keep the plain decimal so the downstream MCP server's
+		// integer-typed schema still accepts it.
+		{"float64 integer-valued", float64(2037838), "2037838"},
+		{"float64 zero", float64(0), "0"},
+		{"float64 negative integer", float64(-7), "-7"},
+		{"float64 fractional", 1.5, "1.5"},
+		{"float64 small", 0.001, "0.001"},
+
+		// JSON-flavoured numerics (when planner uses json.Number, e.g. via
+		// UseNumber()). Pass-through unchanged.
+		{"json.Number int", json.Number("99"), "99"},
+		{"json.Number float", json.Number("3.14"), "3.14"},
+
+		// Compound values round-trip via JSON so the downstream plugin
+		// can re-coerce per its declared input schema (array/object).
+		{"[]any of strings", []any{"a", "b"}, `["a","b"]`},
+		{"[]any of numbers", []any{float64(1), float64(2)}, `[1,2]`},
+		{"map[string]any", map[string]any{"k": "v"}, `{"k":"v"}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := argToWireString(c.in)
+			if got != c.want {
+				t.Errorf("argToWireString(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestArgToWireStringSpecialFloats(t *testing.T) {
+	// NaN / ±Inf must not crash and must not produce "1.797e+308"-style
+	// surprises that would slip through to the wire.
+	if got := argToWireString(math.NaN()); got != "NaN" {
+		t.Errorf("NaN → %q, want NaN", got)
+	}
+	if got := argToWireString(math.Inf(+1)); got != "+Inf" {
+		t.Errorf("+Inf → %q, want +Inf", got)
+	}
+	if got := argToWireString(math.Inf(-1)); got != "-Inf" {
+		t.Errorf("-Inf → %q, want -Inf", got)
+	}
+}
+
+func TestPipelineArgsToWireMixed(t *testing.T) {
+	// Mirrors a realistic post-substitution pipeline arg set: integer id
+	// (from a list-* lookup), string query, array, optional bool flag.
+	in := map[string]any{
+		"item_id":        float64(2037838),
+		"query":          "name:Tesla",
+		"include_fields": []any{"id", "name", "type"},
+		"published":      true,
+	}
+	out := pipelineArgsToWire(in)
+	if out["item_id"] != "2037838" {
+		t.Errorf("item_id = %q, want 2037838", out["item_id"])
+	}
+	if out["query"] != "name:Tesla" {
+		t.Errorf("query = %q", out["query"])
+	}
+	if out["include_fields"] != `["id","name","type"]` {
+		t.Errorf("include_fields = %q", out["include_fields"])
+	}
+	if out["published"] != "true" {
+		t.Errorf("published = %q", out["published"])
+	}
+}

--- a/internal/pipeline/command.go
+++ b/internal/pipeline/command.go
@@ -1,8 +1,19 @@
 package pipeline
 
 // PluginCommand is the only command type for Phase 1.
+//
+// Args carries typed values (string / number / bool / slice / map). The
+// pipeline-internal model is typed because the planner emits JSON whose
+// numbers become float64 / bool / nested structures, and step-output
+// substitution resolves typed values from prior step results — both lose
+// information when collapsed to map[string]string mid-pipeline (notably
+// large integer IDs rendered with default fmt.Sprintf("%v", float64(N))
+// switch to scientific notation, e.g. "2.037838e+06"). The conversion to
+// the wire-level map[string]string happens once, at the orchestrator's
+// pipeline-runner boundary, where typed-aware stringification preserves
+// integer form and JSON-marshals non-scalars.
 type PluginCommand struct {
 	Plugin string
 	Action string
-	Args   map[string]string
+	Args   map[string]any
 }

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -9,12 +10,24 @@ import (
 
 // StepRunnerFunc executes a single plugin command. The orchestrator provides an adapter
 // that bridges its own ToolCall/ToolResult types to these pipeline-local types.
-type StepRunnerFunc func(ctx context.Context, plugin, action string, args map[string]string) StepRunResult
+//
+// Args carries typed values; the runner is responsible for the string conversion
+// at the wire-level boundary (per-protocol — gRPC plugin proto declares args as
+// map<string,string>, so the boundary is the natural place for typed-aware
+// rendering — see pipelineArgsToWire in the orchestrator package).
+type StepRunnerFunc func(ctx context.Context, plugin, action string, args map[string]any) StepRunResult
 
 // StepRunResult is the pipeline-local result of running a step.
+//
+// StructuredContent, when non-empty, is the JSON-encoded structured payload
+// returned by the underlying tool (MCP `structuredContent`, spec revision
+// 2025-06+). The executor parses it for step-output substitution; tools
+// without a structured channel leave it empty and substitution falls back to
+// the text content.
 type StepRunResult struct {
-	Content string
-	Error   string
+	Content           string
+	StructuredContent string
+	Error             string
 }
 
 // Executor runs a pipeline's steps sequentially with retry logic.
@@ -31,10 +44,16 @@ type ExecutionResult struct {
 }
 
 // ExecutedStep records each attempt made during pipeline execution.
+//
+// Args is captured POST-substitution so the trace shows the values that
+// actually reached the runner — useful for understanding "what really got
+// called" when a step fails. Unsubstituted placeholders never appear here:
+// resolution happens before runner-dispatch and substitution failures take
+// the step straight to StepFailed without an attempt entry.
 type ExecutedStep struct {
 	Plugin  string
 	Action  string
-	Args    map[string]string
+	Args    map[string]any
 	Content string
 	Error   string
 }
@@ -81,6 +100,35 @@ func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, erro
 			maxRetries = e.config.MaxStepRetries
 		}
 
+		// Resolve {{stepN.output.<path>}} references in args against the
+		// pipeline context BEFORE the first runner attempt. A failure here
+		// (unresolved ref / malformed path) is a deterministic error of
+		// the plan, not a transient one — fail the step immediately
+		// without retrying. Tracked as one ExecutedStep so the trace
+		// records the substitution failure.
+		resolvedArgs, resolveErr := resolveArgs(step.Command.Args, p.Context)
+		if resolveErr != nil {
+			step.State = StepFailed
+			step.Result = &StepResult{
+				Success: false,
+				Output:  resolveErr.Error(),
+			}
+			result.Steps = append(result.Steps, &ExecutedStep{
+				Plugin: step.Command.Plugin,
+				Action: step.Command.Action,
+				Args:   step.Command.Args,
+				Error:  resolveErr.Error(),
+			})
+			anyFailed = true
+			if e.config.FailFast {
+				p.State = StateFailed
+				result.Success = false
+				result.Summary = buildSummary(p, false)
+				return result, nil
+			}
+			continue
+		}
+
 		success := false
 		step.State = StepRunning
 
@@ -95,13 +143,13 @@ func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, erro
 				stepCtx, cancel = context.WithCancel(ctx)
 			}
 
-			runResult := e.runner(stepCtx, step.Command.Plugin, step.Command.Action, step.Command.Args)
+			runResult := e.runner(stepCtx, step.Command.Plugin, step.Command.Action, resolvedArgs)
 			cancel()
 
 			result.Steps = append(result.Steps, &ExecutedStep{
 				Plugin:  step.Command.Plugin,
 				Action:  step.Command.Action,
-				Args:    step.Command.Args,
+				Args:    resolvedArgs,
 				Content: runResult.Content,
 				Error:   runResult.Error,
 			})
@@ -111,7 +159,7 @@ func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, erro
 				step.Result = &StepResult{
 					Success: true,
 					Output:  runResult.Content,
-					Data:    map[string]any{"output": runResult.Content},
+					Data:    map[string]any{"output": parseStepOutput(runResult)},
 				}
 				p.Context.Merge(step.ID, step.Result.Data)
 				completed[step.ID] = true
@@ -167,6 +215,23 @@ func (e *Executor) Run(ctx context.Context, p *Pipeline) (*ExecutionResult, erro
 		result.Summary = buildSummary(p, true)
 	}
 	return result, nil
+}
+
+// parseStepOutput chooses what to expose as `<step>.output` to subsequent
+// step references. The structured channel wins when it parses as JSON —
+// references like `containers[0].id` only make sense against typed data.
+// We fall back to the text content (string) when no structured payload is
+// available; references that try to traverse it will fail with "expected
+// object, got string", which is the right error to surface.
+func parseStepOutput(r StepRunResult) any {
+	if r.StructuredContent == "" {
+		return r.Content
+	}
+	var parsed any
+	if err := json.Unmarshal([]byte(r.StructuredContent), &parsed); err != nil {
+		return r.Content
+	}
+	return parsed
 }
 
 func buildSummary(p *Pipeline, success bool) string {

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -7,17 +7,17 @@ import (
 	"time"
 )
 
-func successRunner(_ context.Context, plugin, action string, _ map[string]string) StepRunResult {
+func successRunner(_ context.Context, plugin, action string, _ map[string]any) StepRunResult {
 	return StepRunResult{Content: "executed " + plugin + "." + action}
 }
 
-func failRunner(_ context.Context, _, _ string, _ map[string]string) StepRunResult {
+func failRunner(_ context.Context, _, _ string, _ map[string]any) StepRunResult {
 	return StepRunResult{Error: "step failed"}
 }
 
 func makeCountingRunner() (StepRunnerFunc, *int) {
 	count := 0
-	return func(_ context.Context, _, _ string, _ map[string]string) StepRunResult {
+	return func(_ context.Context, _, _ string, _ map[string]any) StepRunResult {
 		count++
 		if count <= 2 {
 			return StepRunResult{Error: "transient error"}
@@ -35,7 +35,7 @@ func makeSteps(names ...string) []*Step {
 			Command: &PluginCommand{
 				Plugin: "test",
 				Action: name,
-				Args:   map[string]string{},
+				Args:   map[string]any{},
 			},
 			State:      StepPending,
 			MaxRetries: -1,
@@ -206,5 +206,169 @@ func TestExecutorFailedSummary(t *testing.T) {
 
 	if !strings.Contains(result.Summary, "failed") {
 		t.Errorf("summary should mention failure: %q", result.Summary)
+	}
+}
+
+// TestExecutorSubstitutesStepReferences exercises the end-to-end path:
+// step1 returns structured JSON, step2's args reference it via
+// {{step1.output.<path>}}, executor resolves before dispatching step2.
+//
+// Mirrors the Tesla-reservation flow that motivated the feature: list-
+// containers + list-items + schedule-item with two cross-step references.
+func TestExecutorSubstitutesStepReferences(t *testing.T) {
+	captured := make(map[string]map[string]any)
+	runner := func(_ context.Context, plugin, action string, args map[string]any) StepRunResult {
+		captured[action] = args
+		switch action {
+		case "list-containers":
+			return StepRunResult{
+				Content:           "Containers: 1 total",
+				StructuredContent: `{"containers":[{"id":170910,"name":"Berlin Garage"}]}`,
+			}
+		case "list-items":
+			return StepRunResult{
+				Content:           "Items: 1 total",
+				StructuredContent: `{"items":[{"id":2004556,"name":"Tesla in NYC"}]}`,
+			}
+		case "schedule-item":
+			return StepRunResult{Content: "scheduled"}
+		}
+		return StepRunResult{Error: "unknown action: " + action}
+	}
+
+	steps := []*Step{
+		{ID: "step1", Name: "Find container", Command: &PluginCommand{Plugin: "timly", Action: "list-containers", Args: map[string]any{"query": "name:Berlin"}}, MaxRetries: -1, State: StepPending},
+		{ID: "step2", Name: "Find item", Command: &PluginCommand{Plugin: "timly", Action: "list-items", Args: map[string]any{"query": "name:Tesla"}}, MaxRetries: -1, State: StepPending},
+		{
+			ID: "step3", Name: "Schedule",
+			Command: &PluginCommand{
+				Plugin: "timly", Action: "schedule-item",
+				Args: map[string]any{
+					"container_id": "{{step1.output.containers[0].id}}",
+					"item_id":      "{{step2.output.items[0].id}}",
+					"start_date":   "2026-06-01T00:00:00",
+				},
+			},
+			DependsOn: []string{"step1", "step2"}, MaxRetries: -1, State: StepPending,
+		},
+	}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	res, err := NewExecutor(runner, p.Config).Run(context.Background(), p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Success {
+		t.Fatalf("expected success, got summary: %s", res.Summary)
+	}
+
+	step3 := captured["schedule-item"]
+	if step3 == nil {
+		t.Fatal("schedule-item never received args")
+	}
+	// Solo placeholders preserve the resolved value's type — a numeric id
+	// stays float64 (from the JSON unmarshal), NOT the literal placeholder
+	// string. The wire-boundary stringification (orchestrator) is the only
+	// layer that collapses to string, so types stay correct mid-pipeline.
+	if id, ok := step3["container_id"].(float64); !ok || id != 170910 {
+		t.Errorf("container_id = %v (%T), want float64(170910)", step3["container_id"], step3["container_id"])
+	}
+	if id, ok := step3["item_id"].(float64); !ok || id != 2004556 {
+		t.Errorf("item_id = %v (%T), want float64(2004556)", step3["item_id"], step3["item_id"])
+	}
+	if step3["start_date"] != "2026-06-01T00:00:00" {
+		t.Errorf("start_date mutated: %v", step3["start_date"])
+	}
+}
+
+// TestExecutorRecordsSubstitutedArgsInTrace asserts that ExecutedStep.Args
+// captures the POST-substitution values, not the pre-substitution literals.
+// This is the trace the orchestrator records into the session and the
+// debug log — operators reading "what really got called" need the
+// resolved values.
+func TestExecutorRecordsSubstitutedArgsInTrace(t *testing.T) {
+	runner := func(_ context.Context, _, action string, _ map[string]any) StepRunResult {
+		if action == "step1" {
+			return StepRunResult{StructuredContent: `{"id":42}`}
+		}
+		return StepRunResult{Content: "ok"}
+	}
+	steps := []*Step{
+		{ID: "step1", Command: &PluginCommand{Plugin: "p", Action: "step1", Args: map[string]any{}}, MaxRetries: -1, State: StepPending},
+		{ID: "step2", Command: &PluginCommand{Plugin: "p", Action: "step2", Args: map[string]any{"id": "{{step1.output.id}}"}}, DependsOn: []string{"step1"}, MaxRetries: -1, State: StepPending},
+	}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	res, _ := NewExecutor(runner, p.Config).Run(context.Background(), p)
+	if !res.Success {
+		t.Fatal("expected success")
+	}
+	// ExecutedStep[1] is step2 — its recorded Args should hold the
+	// resolved value, not the placeholder.
+	if got, ok := res.Steps[1].Args["id"].(float64); !ok || got != 42 {
+		t.Errorf("ExecutedStep.Args[id] = %v (%T), want resolved float64(42)", res.Steps[1].Args["id"], res.Steps[1].Args["id"])
+	}
+}
+
+// TestExecutorFailsFastOnUnresolvedReference ensures a malformed/dangling
+// reference is treated as a permanent error of the plan: the step fails
+// without entering the retry loop, and on FailFast the pipeline halts. No
+// runner attempt is recorded — substitution is pre-dispatch.
+func TestExecutorFailsFastOnUnresolvedReference(t *testing.T) {
+	calls := 0
+	runner := func(_ context.Context, _, _ string, _ map[string]any) StepRunResult {
+		calls++
+		return StepRunResult{Content: "should not be called"}
+	}
+	steps := []*Step{
+		{
+			ID:         "step1",
+			Command:    &PluginCommand{Plugin: "p", Action: "a", Args: map[string]any{"x": "{{step99.output.id}}"}},
+			MaxRetries: 5, // would retry 5 times for a transient error
+			State:      StepPending,
+		},
+	}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 5, StepTimeout: 10 * time.Second, FailFast: true})
+
+	res, _ := NewExecutor(runner, p.Config).Run(context.Background(), p)
+	if res.Success {
+		t.Fatal("expected failure")
+	}
+	if calls != 0 {
+		t.Errorf("runner called %d time(s) on unresolved reference; expected 0 (substitution must be pre-dispatch)", calls)
+	}
+	if !strings.Contains(res.Summary, "produced no output") {
+		t.Errorf("summary should explain unresolved-reference; got: %s", res.Summary)
+	}
+}
+
+// TestExecutorContextStoresStructuredOutput asserts that the parsed
+// structured content (not the text content) lands in PipelineContext for
+// downstream substitution. This is the difference between "step1.output =
+// 'Containers: 1 total'" (useless for path traversal) and "step1.output =
+// {containers: [...]}" (traversable).
+func TestExecutorContextStoresStructuredOutput(t *testing.T) {
+	runner := func(_ context.Context, _, _ string, _ map[string]any) StepRunResult {
+		return StepRunResult{
+			Content:           "human-readable summary",
+			StructuredContent: `{"id":7,"name":"x"}`,
+		}
+	}
+	steps := []*Step{{ID: "step1", Command: &PluginCommand{Plugin: "p", Action: "a", Args: map[string]any{}}, MaxRetries: -1, State: StepPending}}
+	p := NewPipeline(steps, PipelineConfig{MaxStepRetries: 0, StepTimeout: 10 * time.Second, FailFast: true})
+
+	if _, err := NewExecutor(runner, p.Config).Run(context.Background(), p); err != nil {
+		t.Fatal(err)
+	}
+	v, ok := p.Context.Get("step1", "output")
+	if !ok {
+		t.Fatal("missing step1.output")
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected parsed object in context, got %T (%v)", v, v)
+	}
+	if m["id"].(float64) != 7 {
+		t.Errorf("step1.output.id = %v, want 7", m["id"])
 	}
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -66,9 +67,16 @@ func (p *Pipeline) FormatForConfirmation() string {
 			fmt.Fprintf(&sb, "   Action: `%s.%s`\n", step.Command.Plugin, step.Command.Action)
 			if len(step.Command.Args) > 0 {
 				sb.WriteString("   Args: ")
-				parts := make([]string, 0, len(step.Command.Args))
-				for k, v := range step.Command.Args {
-					parts = append(parts, fmt.Sprintf("%s=%s", k, v))
+				// Stable order so the confirmation message is deterministic
+				// across renders (Go map iteration is randomised).
+				keys := make([]string, 0, len(step.Command.Args))
+				for k := range step.Command.Args {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				parts := make([]string, 0, len(keys))
+				for _, k := range keys {
+					parts = append(parts, fmt.Sprintf("%s=%v", k, step.Command.Args[k]))
 				}
 				sb.WriteString(strings.Join(parts, ", "))
 				sb.WriteString("\n")

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -47,7 +47,7 @@ func TestFormatForConfirmation(t *testing.T) {
 			Command: &PluginCommand{
 				Plugin: "appsignal",
 				Action: "get_error",
-				Args:   map[string]string{"error_id": "123"},
+				Args:   map[string]any{"error_id": "123"},
 			},
 		},
 		{
@@ -56,7 +56,7 @@ func TestFormatForConfirmation(t *testing.T) {
 			Command: &PluginCommand{
 				Plugin: "jira",
 				Action: "create_issue",
-				Args:   map[string]string{"title": "Fix error"},
+				Args:   map[string]any{"title": "Fix error"},
 			},
 			DependsOn: []string{"1"},
 		},

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -172,9 +172,13 @@ func parsePlanResponse(content string) (*PlanResult, error) {
 		if id == "" {
 			id = fmt.Sprintf("%d", i+1)
 		}
-		args := make(map[string]string, len(s.Args))
-		for k, v := range s.Args {
-			args[k] = fmt.Sprintf("%v", v)
+		// Pass the planner's args through unchanged; types are preserved
+		// (numbers stay float64, strings carry placeholder text). Stringification
+		// happens at the orchestrator/pipeline-runner boundary where typed-aware
+		// rendering avoids the float→scientific-notation pitfall on large IDs.
+		args := s.Args
+		if args == nil {
+			args = map[string]any{}
 		}
 		steps[i] = &Step{
 			ID:   id,

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -177,6 +177,26 @@ func TestBuildPlannerPrompt(t *testing.T) {
 	}
 }
 
+// TestBuildPlannerPrompt_DocumentsChainingSyntax pins the cross-step
+// reference contract into the planner prompt: an LLM that doesn't know
+// the {{<step>.output.<path>}} form invents one (we observed
+// {{step1.output.results[0].id}} against responses that use
+// `containers[]`/`items[]`), and the executor's substitution layer is
+// only useful if the planner emits paths it can actually resolve.
+func TestBuildPlannerPrompt_DocumentsChainingSyntax(t *testing.T) {
+	prompt := buildPlannerPrompt(nil, "")
+	for _, want := range []string{
+		"Referencing prior step output",
+		"{{<step-id>.output.<json-path>}}",
+		"depends_on",
+		"Inspect the action description for the actual response shape",
+	} {
+		if !containsStr(prompt, want) {
+			t.Errorf("planner prompt missing %q", want)
+		}
+	}
+}
+
 // TestBuildPlannerPromptMCPDotActions verifies that when a plugin (e.g. "mcp") has
 // action names containing dots (e.g. "appsignal.get_applications"), the prompt uses
 // an explicit plugin= | action= format so the LLM cannot misparse the boundary.

--- a/internal/pipeline/substitution.go
+++ b/internal/pipeline/substitution.go
@@ -1,0 +1,295 @@
+package pipeline
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// placeholderRe matches `{{<step-id>.output.<json-path>}}` — the only
+// reference form supported in step args. Anchoring on the literal `.output.`
+// is deliberate: it forces a deterministic shape ("which step? which
+// channel? which path?") and rejects ambiguous forms like `{{step1.id}}`
+// that would have multiple plausible interpretations.
+//
+// Submatches:
+//
+//	[1] step ID
+//	[2] path (dot- and bracket-separated)
+//
+// The path matcher is deliberately permissive — `[0-9a-zA-Z_.\[\]]+` —
+// because it's parsed in a second pass by splitPath, which produces a
+// precise diagnostic on malformed expressions.
+var placeholderRe = regexp.MustCompile(`\{\{([a-zA-Z0-9_-]+)\.output\.([0-9a-zA-Z_.\[\]]+)\}\}`)
+
+// soloPlaceholderRe matches a string whose ENTIRE content is one
+// placeholder. When it matches, substitution preserves the resolved
+// value's type (an integer ID stays int) instead of stringifying;
+// otherwise the value is interpolated into surrounding text.
+var soloPlaceholderRe = regexp.MustCompile(`^\{\{([a-zA-Z0-9_-]+)\.output\.([0-9a-zA-Z_.\[\]]+)\}\}$`)
+
+// resolveArgs returns a copy of args with every `{{<step>.output.<path>}}`
+// placeholder replaced by the resolved value from ctx.
+//
+// On any unresolved or malformed reference, resolveArgs returns an error
+// describing the failure and the offending argument key — the executor
+// surfaces this directly to the user / agent loop. Partial substitution
+// (some args resolved, some left literal) is never returned: a step either
+// runs with all references concrete or fails fast with a clear message.
+func resolveArgs(args map[string]any, ctx *PipelineContext) (map[string]any, error) {
+	if len(args) == 0 {
+		return args, nil
+	}
+	out := make(map[string]any, len(args))
+	// Stable iteration so error messages are deterministic across runs.
+	keys := make([]string, 0, len(args))
+	for k := range args {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v, err := resolveValue(args[k], ctx)
+		if err != nil {
+			return nil, fmt.Errorf("arg %q: %w", k, err)
+		}
+		out[k] = v
+	}
+	return out, nil
+}
+
+// resolveValue applies substitution to a single value. Strings are
+// inspected for placeholders; maps and slices are walked recursively (the
+// planner can emit them via JSON, e.g. `include_fields: ["a","b"]`); other
+// scalars are passed through.
+func resolveValue(v any, ctx *PipelineContext) (any, error) {
+	switch x := v.(type) {
+	case string:
+		return resolveString(x, ctx)
+	case []any:
+		out := make([]any, len(x))
+		for i, e := range x {
+			r, err := resolveValue(e, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("[%d]: %w", i, err)
+			}
+			out[i] = r
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, e := range x {
+			r, err := resolveValue(e, ctx)
+			if err != nil {
+				return nil, fmt.Errorf("%q: %w", k, err)
+			}
+			out[k] = r
+		}
+		return out, nil
+	default:
+		return v, nil
+	}
+}
+
+// resolveString returns the value of s with every placeholder replaced.
+// When s consists of a single placeholder, the resolved value is returned
+// untyped (string / number / bool / nested) so the caller can hand it to
+// the wire layer with type intact. Otherwise placeholders are stringified
+// and embedded into the surrounding text.
+func resolveString(s string, ctx *PipelineContext) (any, error) {
+	if m := soloPlaceholderRe.FindStringSubmatch(s); m != nil {
+		return lookup(m[1], m[2], ctx)
+	}
+	if !strings.Contains(s, "{{") {
+		return s, nil
+	}
+	var firstErr error
+	out := placeholderRe.ReplaceAllStringFunc(s, func(match string) string {
+		m := placeholderRe.FindStringSubmatch(match)
+		if m == nil {
+			return match // leave literal — regex never disagrees with itself
+		}
+		v, err := lookup(m[1], m[2], ctx)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			return match
+		}
+		return stringifyForInterpolation(v)
+	})
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+// lookup resolves `<step>.output.<path>` against the pipeline context. The
+// step's stored "output" is the parsed structured payload; resolvePath
+// walks the user-supplied path through it.
+func lookup(stepID, path string, ctx *PipelineContext) (any, error) {
+	root, ok := ctx.Get(stepID, "output")
+	if !ok {
+		return nil, fmt.Errorf("unresolved reference {{%s.output.%s}}: step %q produced no output (or has not run yet)", stepID, path, stepID)
+	}
+	v, err := resolvePath(root, path)
+	if err != nil {
+		return nil, fmt.Errorf("unresolved reference {{%s.output.%s}}: %w", stepID, path, err)
+	}
+	return v, nil
+}
+
+// resolvePath walks dot- and bracket-separated segments through a parsed
+// JSON value. Errors include the segment that failed and the keys / index
+// range available at that point — actionable diagnostics for the
+// downstream surfaced-to-LLM error.
+func resolvePath(root any, path string) (any, error) {
+	segments, err := splitPath(path)
+	if err != nil {
+		return nil, err
+	}
+	cur := root
+	traversed := ""
+	for _, seg := range segments {
+		switch s := seg.(type) {
+		case string:
+			obj, ok := cur.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("at %q: expected object, got %s", traversed, kindOf(cur))
+			}
+			next, ok := obj[s]
+			if !ok {
+				keys := make([]string, 0, len(obj))
+				for k := range obj {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				return nil, fmt.Errorf("at %q: key %q not found (available: %s)", traversed, s, strings.Join(keys, ", "))
+			}
+			cur = next
+			traversed = appendSegment(traversed, s)
+		case int:
+			arr, ok := cur.([]any)
+			if !ok {
+				return nil, fmt.Errorf("at %q: expected array, got %s", traversed, kindOf(cur))
+			}
+			if s < 0 || s >= len(arr) {
+				return nil, fmt.Errorf("at %q: index [%d] out of range (length %d)", traversed, s, len(arr))
+			}
+			cur = arr[s]
+			traversed = appendIndex(traversed, s)
+		}
+	}
+	return cur, nil
+}
+
+// splitPath turns a path string ("containers[0].id") into a sequence of
+// segments — strings for keys, ints for array indices. It rejects empty
+// segments, trailing dots, and unmatched brackets up front so resolvePath
+// can iterate without re-validating.
+func splitPath(path string) ([]any, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	var segs []any
+	i := 0
+	for i < len(path) {
+		switch path[i] {
+		case '[':
+			end := strings.IndexByte(path[i:], ']')
+			if end < 0 {
+				return nil, fmt.Errorf("unclosed '[' in path %q", path)
+			}
+			idxStr := path[i+1 : i+end]
+			idx, err := strconv.Atoi(idxStr)
+			if err != nil || idxStr == "" {
+				return nil, fmt.Errorf("invalid array index %q in path %q", idxStr, path)
+			}
+			segs = append(segs, idx)
+			i += end + 1
+			if i < len(path) && path[i] == '.' {
+				i++ // accept the join dot between [N] and the next key
+			}
+		case '.':
+			return nil, fmt.Errorf("empty segment in path %q", path)
+		default:
+			j := i
+			for j < len(path) && path[j] != '.' && path[j] != '[' {
+				j++
+			}
+			if j == i {
+				return nil, fmt.Errorf("empty segment in path %q", path)
+			}
+			segs = append(segs, path[i:j])
+			i = j
+			if i < len(path) && path[i] == '.' {
+				i++
+				if i == len(path) {
+					return nil, fmt.Errorf("trailing '.' in path %q", path)
+				}
+			}
+		}
+	}
+	return segs, nil
+}
+
+// stringifyForInterpolation renders a value when it's embedded into
+// surrounding text. Mirrors argToWireString in the orchestrator (no
+// scientific notation on floats, JSON for compounds), but lives here so
+// the pipeline package stays self-contained.
+func stringifyForInterpolation(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case bool:
+		return strconv.FormatBool(x)
+	case int:
+		return strconv.FormatInt(int64(x), 10)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		if x == float64(int64(x)) && x > -1e18 && x < 1e18 {
+			return strconv.FormatInt(int64(x), 10)
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+// kindOf names a value's runtime shape for error messages — "object" /
+// "array" / "string" / "number" / "boolean" / "null" — independent of Go
+// types. Matches the JSON vocabulary the planner LLM emits, which is what
+// the LLM reads in the surfaced error.
+func kindOf(v any) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case map[string]any:
+		return "object"
+	case []any:
+		return "array"
+	case string:
+		return "string"
+	case bool:
+		return "boolean"
+	case float64, int, int64, float32, int32:
+		return "number"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+func appendSegment(s, key string) string {
+	if s == "" {
+		return key
+	}
+	return s + "." + key
+}
+
+func appendIndex(s string, idx int) string {
+	return s + "[" + strconv.Itoa(idx) + "]"
+}

--- a/internal/pipeline/substitution_test.go
+++ b/internal/pipeline/substitution_test.go
@@ -1,0 +1,300 @@
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func ctxWith(stepID string, output any) *PipelineContext {
+	c := NewContext()
+	c.Set(stepID, "output", output)
+	return c
+}
+
+// --- resolvePath / splitPath ---
+
+func TestSplitPath(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    []any
+		wantErr string // substring; "" → no error
+	}{
+		{"id", []any{"id"}, ""},
+		{"containers.id", []any{"containers", "id"}, ""},
+		{"containers[0]", []any{"containers", 0}, ""},
+		{"containers[0].id", []any{"containers", 0, "id"}, ""},
+		{"a.b[2].c", []any{"a", "b", 2, "c"}, ""},
+		{"items[0].nested[1].deep", []any{"items", 0, "nested", 1, "deep"}, ""},
+		// Errors
+		{"", nil, "empty path"},
+		{".id", nil, "empty segment"},
+		{"id.", nil, "trailing"},
+		{"items[0", nil, "unclosed"},
+		{"items[]", nil, "invalid array index"},
+		{"items[abc]", nil, "invalid array index"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, err := splitPath(c.in)
+			if c.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+					t.Errorf("err = %v, want substring %q", err, c.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if len(got) != len(c.want) {
+				t.Fatalf("len(got) = %d, want %d (got=%v)", len(got), len(c.want), got)
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Errorf("seg[%d] = %v (%T), want %v (%T)", i, got[i], got[i], c.want[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolvePathTraversal(t *testing.T) {
+	root := map[string]any{
+		"containers": []any{
+			map[string]any{"id": float64(170910), "name": "Berlin Garage"},
+			map[string]any{"id": float64(170911), "name": "Munich Workshop"},
+		},
+		"pagination": map[string]any{"total": float64(2)},
+	}
+	cases := []struct {
+		path string
+		want any
+	}{
+		{"containers[0].id", float64(170910)},
+		{"containers[1].name", "Munich Workshop"},
+		{"pagination.total", float64(2)},
+		{"containers", root["containers"]},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			got, err := resolvePath(root, c.path)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			// Slice equality via length only (deep eq is nil unless we import reflect)
+			if s, ok := c.want.([]any); ok {
+				gs, _ := got.([]any)
+				if len(gs) != len(s) {
+					t.Errorf("len = %d, want %d", len(gs), len(s))
+				}
+				return
+			}
+			if got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestResolvePathDiagnostics(t *testing.T) {
+	root := map[string]any{
+		"containers": []any{map[string]any{"id": float64(1)}},
+	}
+	cases := []struct {
+		path    string
+		wantErr string
+	}{
+		{"items[0].id", "key \"items\" not found (available: containers)"},
+		{"containers[5].id", "[5] out of range (length 1)"},
+		{"containers[0].id.foo", "expected object, got number"},
+		{"pagination.total", "key \"pagination\" not found"},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			_, err := resolvePath(root, c.path)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("err = %q, want substring %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+// --- resolveArgs / resolveValue ---
+
+func TestResolveArgsSoloPlaceholderPreservesType(t *testing.T) {
+	ctx := ctxWith("step1", map[string]any{
+		"containers": []any{
+			map[string]any{"id": float64(170910)},
+		},
+	})
+	args := map[string]any{
+		"container_id": "{{step1.output.containers[0].id}}",
+	}
+	got, err := resolveArgs(args, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, ok := got["container_id"].(float64); !ok || v != 170910 {
+		t.Errorf("container_id = %v (%T), want float64(170910)", got["container_id"], got["container_id"])
+	}
+}
+
+func TestResolveArgsInterpolation(t *testing.T) {
+	ctx := ctxWith("step1", map[string]any{
+		"items": []any{map[string]any{"id": float64(42), "name": "Tesla"}},
+	})
+	args := map[string]any{
+		"label": "item-{{step1.output.items[0].id}}",
+		"note":  "{{step1.output.items[0].name}} ({{step1.output.items[0].id}})",
+	}
+	got, err := resolveArgs(args, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["label"] != "item-42" {
+		t.Errorf("label = %v, want 'item-42'", got["label"])
+	}
+	if got["note"] != "Tesla (42)" {
+		t.Errorf("note = %v, want 'Tesla (42)'", got["note"])
+	}
+}
+
+func TestResolveArgsLargeIntegerNoScientificNotation(t *testing.T) {
+	// Regression for the planner-emitted IDs: a Timly item id like 2_037_838
+	// becomes float64 after JSON unmarshal and would render as
+	// "2.037838e+06" with a default fmt.Sprintf("%v", v). That broke the
+	// downstream MCP server before the boundary stringification was fixed.
+	ctx := ctxWith("step1", map[string]any{
+		"items": []any{map[string]any{"id": float64(2037838)}},
+	})
+	args := map[string]any{
+		"label": "item-{{step1.output.items[0].id}}",
+	}
+	got, err := resolveArgs(args, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["label"] != "item-2037838" {
+		t.Errorf("label = %v, want 'item-2037838' (no scientific notation)", got["label"])
+	}
+}
+
+func TestResolveArgsNoPlaceholders(t *testing.T) {
+	ctx := NewContext()
+	args := map[string]any{"a": "literal", "b": float64(5), "c": true}
+	got, err := resolveArgs(args, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["a"] != "literal" || got["b"] != float64(5) || got["c"] != true {
+		t.Errorf("non-placeholder args mutated: %v", got)
+	}
+}
+
+func TestResolveArgsNestedValues(t *testing.T) {
+	// The planner can emit array / object values containing placeholders.
+	// resolveValue must recurse into them.
+	ctx := ctxWith("step1", map[string]any{"id": float64(7)})
+	args := map[string]any{
+		"include": []any{"name", "{{step1.output.id}}"},
+		"filter":  map[string]any{"id": "{{step1.output.id}}"},
+	}
+	got, err := resolveArgs(args, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inc := got["include"].([]any)
+	if inc[1].(float64) != 7 {
+		t.Errorf("include[1] = %v, want float64(7)", inc[1])
+	}
+	flt := got["filter"].(map[string]any)
+	if flt["id"].(float64) != 7 {
+		t.Errorf("filter.id = %v, want float64(7)", flt["id"])
+	}
+}
+
+func TestResolveArgsErrorPaths(t *testing.T) {
+	ctx := ctxWith("step1", map[string]any{
+		"containers": []any{map[string]any{"id": float64(1)}},
+	})
+	cases := []struct {
+		name    string
+		args    map[string]any
+		wantErr string
+	}{
+		{
+			name:    "unknown step",
+			args:    map[string]any{"x": "{{step9.output.id}}"},
+			wantErr: "step \"step9\" produced no output",
+		},
+		{
+			name:    "missing key",
+			args:    map[string]any{"x": "{{step1.output.items[0].id}}"},
+			wantErr: "key \"items\" not found (available: containers)",
+		},
+		{
+			name:    "out-of-range index",
+			args:    map[string]any{"x": "{{step1.output.containers[5].id}}"},
+			wantErr: "out of range",
+		},
+		{
+			name:    "type mismatch",
+			args:    map[string]any{"x": "{{step1.output.containers[0].id.foo}}"},
+			wantErr: "expected object, got number",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := resolveArgs(c.args, ctx)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("err = %q, want substring %q", err.Error(), c.wantErr)
+			}
+			// Errors must surface the offending arg key for actionable diagnostics.
+			if !strings.Contains(err.Error(), "arg \"x\"") {
+				t.Errorf("err missing arg-key context: %q", err.Error())
+			}
+		})
+	}
+}
+
+// --- step output: structured vs text ---
+
+func TestParseStepOutputStructured(t *testing.T) {
+	r := StepRunResult{
+		Content:           "Containers: 1 total",
+		StructuredContent: `{"containers":[{"id":42}]}`,
+	}
+	v := parseStepOutput(r)
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object, got %T", v)
+	}
+	if cs, _ := m["containers"].([]any); len(cs) != 1 {
+		t.Errorf("containers length = %d, want 1", len(cs))
+	}
+}
+
+func TestParseStepOutputFallsBackToText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   StepRunResult
+		want string
+	}{
+		{"empty structured", StepRunResult{Content: "hello"}, "hello"},
+		{"malformed structured", StepRunResult{Content: "txt", StructuredContent: "not-json"}, "txt"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			v := parseStepOutput(c.in)
+			s, ok := v.(string)
+			if !ok || s != c.want {
+				t.Errorf("got %v (%T), want string %q", v, v, c.want)
+			}
+		})
+	}
+}

--- a/internal/prompts/planner_preamble.txt
+++ b/internal/prompts/planner_preamble.txt
@@ -5,4 +5,33 @@ Even for single-action requests, return a pipeline with one step.
 Each step must have: {"id": "<unique>", "name": "<human description>", "plugin": "<plugin>", "action": "<action>", "args": {}, "depends_on": []}
 The "plugin" field must be the exact plugin name shown below (the part before the "|"). The "action" field must be the exact action name shown below (the part after "action=").
 
-Available tools:
+## Referencing prior step output
+
+A later step may need a value produced by an earlier step (e.g. an id from a list lookup). Use the placeholder
+
+  {{<step-id>.output.<json-path>}}
+
+inside any string arg. The path walks the structured JSON returned by the referenced step using dot-separated keys and `[N]` for array indices. The runtime substitutes placeholders before dispatching the step; an unresolved or malformed reference fails the step before any tool call.
+
+Inspect the action description for the actual response shape — keys differ per tool (a list-containers response holds `containers[]`, a list-items response holds `items[]`, etc.). Do NOT invent a generic key like "results" if the tool's response uses a specific name.
+
+When an entire arg is one placeholder the resolved value's type is preserved (an integer id stays integer); when a placeholder is embedded into surrounding text the resolved value is interpolated as a string ("ticket-{{step1.output.tickets[0].id}}" → "ticket-42").
+
+Example:
+  [
+    {"id": "step1", "plugin": "timly", "action": "list-containers", "args": {"query": "name:\"Berlin Garage\""}, "depends_on": []},
+    {"id": "step2", "plugin": "timly", "action": "list-items",      "args": {"query": "name:Tesla"},                "depends_on": []},
+    {"id": "step3", "plugin": "timly", "action": "schedule-item",
+                "args": {
+                  "container_id": "{{step1.output.containers[0].id}}",
+                  "item_id":      "{{step2.output.items[0].id}}",
+                  "start_date":   "2026-06-01T00:00:00",
+                  "end_date":     "2026-06-05T23:59:59"
+                },
+                "depends_on": ["step1", "step2"]}
+  ]
+
+A step that needs a prior step's output MUST list it under "depends_on" so execution order is correct.
+
+## Available tools
+


### PR DESCRIPTION
## TL;DR

Multi-step planner pipelines could not reference values produced by earlier steps. The planner LLM emitted placeholders like `{{step1.output.containers[0].id}}` based on common templating conventions, but the executor had no substitution layer — the literal string went to the wire, the downstream MCP server rejected with "property '#/item_id' of type string did not match the following type: integer", and the agent loop had no path to recover.

This PR closes the gap end-to-end and cleans up the four collocated bugs that fall out of the same diagnosis.

## Reproduction (live trace, current master)

User asked: *"Can you reserve the Tesla in the Berlin garage from 1 June to 5 June?"*

```
2026/05/08 19:47:33 mcp-plugin: server timly: CallTool begin tool="schedule-item" arg_count=4
  args=[
    container_id={{step1.output.containers[0].id}}(string),
    end_date=2024-06-05T23:59:59Z(string),
    item_id={{step2.output.items[0].id}}(string),
    start_date=2024-06-01T00:00:00Z(string)
  ]
2026/05/08 19:47:33 mcp-plugin: server timly: CallTool tool="schedule-item" rpc error:
  Invalid params: Invalid arguments:
  The property '#/item_id'      of type string did not match the following type: integer
  The property '#/container_id' of type string did not match the following type: integer
```

The placeholder strings reach the MCP server unsubstituted. (Note: this trace is only readable thanks to opentalon/mcp-plugin#26 surfacing JSON-RPC `error.data` — without that, "Invalid params" had no detail.)

## What's wrong, in one place

| File | Bug |
|---|---|
| `internal/pipeline/executor.go:Run` | `step.Command.Args` goes to runner unchanged — no substitution. `step.Result.Data["output"] = runResult.Content` — text only, no JSON path. |
| `internal/orchestrator/orchestrator.go:executePipeline` | runner forwards `Content`, drops `StructuredContent` — no traversable shape. |
| `internal/pipeline/planner.go:parsePlanResponse` | `args[k] = fmt.Sprintf("%v", v)` — `float64(2_037_838)` → `"2.037838e+06"`. |
| `internal/prompts/planner_preamble.txt` | no contract for chaining syntax — LLM invents one. |

## What the PR does

### 1. Step-output substitution (`internal/pipeline/substitution.go`)

New engine resolving `{{<step-id>.output.<json-path>}}` against the pipeline context. JSON-path walk: dot-separated keys + `[N]` for array indices.

When a string IS one placeholder, the resolved value's type is preserved (an integer id stays integer); when embedded into surrounding text, the value is stringified with no scientific-notation surprise. Errors include the offending arg key, the failed segment, and the available alternatives — actionable diagnostics that the agent loop can surface verbatim.

### 2. Typed args throughout the pipeline

`PluginCommand.Args` is now `map[string]any` (was `map[string]string`). The planner stops doing `fmt.Sprintf("%v", v)` — JSON numbers stay `float64`, booleans stay `bool`, nested values keep shape. The collapse to `map[string]string` happens once, at the orchestrator/runner boundary, where typed-aware rendering keeps integer-valued floats in plain decimal form.

### 3. Structured output into the pipeline context

`StepRunResult.StructuredContent` is added; the orchestrator's pipeline runner forwards it; the executor parses it as JSON and stores the parsed value at `<step>.output`. References traverse real data, not text. Tools without a structured channel fall back to text — references against text fail with "expected object, got string", which is the right error to surface.

### 4. Wire-boundary stringification (`internal/orchestrator/pipeline_args.go`)

`pipelineArgsToWire` collapses typed args to `map[string]string` for ToolCall and the gRPC plugin protocol. Integer-valued floats render as plain decimals (regression-tested up to 10^18), arrays and objects round-trip via JSON so the downstream plugin can re-coerce per its declared input schema.

### 5. Planner prompt contract

`planner_preamble.txt` now documents the substitution syntax with a concrete example (list-containers + list-items + schedule-item). The example response keys (`containers[]`, `items[]`) match what real tools return, with an explicit reminder to check the action description before guessing path names.

## Why one PR, not five

Each piece is a hard prerequisite for the next:

```
substitution needs typed values
              ⇕
typed values need a typed-aware wire boundary (else %v breaks IDs)
              ⇕
substitution needs structured output (else paths can't traverse)
              ⇕
the LLM must know the syntax (else it invents one)
```

Splitting them ships a partial fix that demonstrably worsens behaviour in the agent loop (the LLM saw the rich error surfaced by opentalon/mcp-plugin#26 and tried to self-correct, but had no syntax to use; or it had syntax but no real data behind it). They land together or not at all.

## Failure modes (all fail-fast, all actionable)

- Unresolved step: `step "step9" produced no output`
- Key not found: `key "items" not found (available: containers, pagination)`
- Out-of-range index: `index [5] out of range (length 1)`
- Type mismatch: `expected object, got number`
- Malformed path: `unclosed '[' in path "items[0"`
- All errors prefixed with the offending arg key

Substitution failures put the step straight to `StepFailed` without a runner attempt; `FailFast` halts the pipeline. No retries on deterministic plan errors.

## Tests (~430 LOC of new test code)

```
internal/pipeline/substitution_test.go
  TestSplitPath:                              12 cases (paths + diagnostics)
  TestResolvePathTraversal:                    4 cases
  TestResolvePathDiagnostics:                  4 cases (each error class)
  TestResolveArgsSoloPlaceholderPreservesType
  TestResolveArgsInterpolation
  TestResolveArgsLargeIntegerNoScientificNotation  ← regression for original bug
  TestResolveArgsNoPlaceholders                                ← backward-compat
  TestResolveArgsNestedValues                                  ← recurse []/map
  TestResolveArgsErrorPaths:                   4 cases (each error surfaces arg key)
  TestParseStepOutput*:                        3 cases (structured / fall-back / malformed)

internal/pipeline/executor_test.go (additions)
  TestExecutorSubstitutesStepReferences        ← Tesla-reservation scenario, full E2E
  TestExecutorRecordsSubstitutedArgsInTrace
  TestExecutorFailsFastOnUnresolvedReference   ← NO retry on plan error
  TestExecutorContextStoresStructuredOutput

internal/orchestrator/pipeline_args_test.go
  TestArgToWireString:                        17 cases incl. NaN / ±Inf / json.Number
  TestPipelineArgsToWireMixed                  ← realistic post-substitution shape

internal/pipeline/planner_test.go (addition)
  TestBuildPlannerPrompt_DocumentsChainingSyntax  ← pin the contract in the prompt
```

`go test ./...` (excl. VCR — see below): all green. `golangci-lint run ./internal/pipeline/... ./internal/orchestrator/...`: 0 issues.

## ⚠️ VCR cassettes need re-recording

`internal/prompts/planner_preamble.txt` change rotates `prompts.Hash()`, which is the staleness guard for VCR cassettes. The following fail with the documented "stale cassette" error and require `make vcr-record-all` against the live LLM (`ANTHROPIC_API_KEY` + `OPENROUTER_API_KEY`):

- `TestVCRScenarios/{direct_response,single_tool_call,...}` (both providers)
- `TestVCRSelfIntroduction`
- `TestVCRPipelineConfirmation`
- `TestVCRFormatSlack`
- `TestVCRFormatTelegram`

This is the documented behaviour — the hash guard exists to force a manual re-record on prompt changes — and matches the precedent set in #174 (planner-prompt change, cassette hashes rebumped). Maintainer with API keys re-records before merge.

## Backward-compatibility

- Steps without placeholders pass through unchanged.
- Tools without `StructuredContent` fall back to the existing text-only context.
- The wire format (`proto/plugin.proto`) is unchanged — args still reach the plugin as `map<string,string>`.
- The planner prompt addition is additive.

## Companion / context

- opentalon/mcp-plugin#26 (already merged, tagged in opentalon v0.0.14) — surfaced the JSON-RPC `error.data` field that made this bug visible. Together they restore the "tool error → LLM self-correct" loop end-to-end.