### PR TITLE
fix: stringifyForInterpolation renders nil as null

### DIFF
--- a/internal/pipeline/substitution.go
+++ b/internal/pipeline/substitution.go
@@ -241,7 +241,7 @@ func splitPath(path string) ([]any, error) {
 func stringifyForInterpolation(v any) string {
 	switch x := v.(type) {
 	case nil:
-		return ""
+		return "null"
 	case string:
 		return x
 	case bool:


### PR DESCRIPTION
## Summary

- `stringifyForInterpolation(nil)` now returns `"null"` instead of `""`, consistent with `argToWireString`
- Companion to opentalon/mcp-plugin#28 which teaches the coercion layer to convert `"null"` back to JSON null

## Test plan

- [x] `go test ./internal/pipeline/...` — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)