### PR TITLE
fix: preserve array/object types in native tool call args

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -251,7 +253,7 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 			var rawArgs map[string]interface{}
 			if err := json.Unmarshal([]byte(tc.Function.Arguments), &rawArgs); err == nil {
 				for k, v := range rawArgs {
-					args[k] = fmt.Sprintf("%v", v)
+					args[k] = nativeArgToString(v)
 				}
 			}
 			toolCalls = append(toolCalls, ToolCall{
@@ -435,5 +437,38 @@ func (p *OpenAIProvider) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
 	if p.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+}
+
+// nativeArgToString converts a JSON-decoded value to a string suitable for
+// the wire-level map[string]string in ToolCall.Arguments.
+//
+// Unlike toStringMap in parser.go, this preserves all values including nil,
+// false, and zero — the LLM explicitly chose these in structured tool calls.
+func nativeArgToString(v interface{}) string {
+	if v == nil {
+		return "null"
+	}
+	switch x := v.(type) {
+	case string:
+		return x
+	case bool:
+		return strconv.FormatBool(x)
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return fmt.Sprintf("%v", x)
+		}
+		if x == math.Trunc(x) && math.Abs(x) < 1e18 {
+			return strconv.FormatInt(int64(x), 10)
+		}
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case json.Number:
+		return string(x)
+	default:
+		b, err := json.Marshal(x)
+		if err != nil {
+			return fmt.Sprintf("%v", x)
+		}
+		return string(b)
 	}
 }

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -299,3 +299,33 @@ func TestOpenAIRejectsFileAttachments(t *testing.T) {
 		t.Fatal("expected error for file attachment, got nil")
 	}
 }
+
+func TestNativeArgToString(t *testing.T) {
+	cases := []struct {
+		name string
+		v    interface{}
+		want string
+	}{
+		{"string", "hello", "hello"},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"nil", nil, "null"},
+		{"integer float64", float64(42), "42"},
+		{"large integer float64", float64(2037838), "2037838"},
+		{"fractional float64", float64(3.14), "3.14"},
+		{"array", []interface{}{"all"}, `["all"]`},
+		{"nested object", map[string]interface{}{"status": "active"}, `{"status":"active"}`},
+		{"empty array", []interface{}{}, `[]`},
+		{"integer array", []interface{}{float64(1), float64(2)}, `[1,2]`},
+		{"zero float64", float64(0), "0"},
+		{"json.Number", json.Number("999"), "999"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nativeArgToString(tc.v)
+			if got != tc.want {
+				t.Errorf("nativeArgToString(%v) = %q, want %q", tc.v, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `fmt.Sprintf("%v", v)` in OpenAI provider's native tool call parsing rendered arrays as `[all]` (Go format) instead of `["all"]` (valid JSON), causing MCP servers to reject `include_fields` with `type string did not match... array`
- Added `nativeArgToString()` helper that JSON-marshals compound types and renders floats in plain decimal form
- Unlike `toStringMap` in parser.go, this preserves nil/false/zero since the LLM explicitly chose them in structured tool calls

## Test plan

- [x] `TestNativeArgToString` — 13 cases: string, bool, nil, floats, arrays, objects, json.Number
- [x] Full `go test -race ./internal/provider/... ./internal/orchestrator/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)