### PR TITLE
log: structured JSON handler + raw OpenAI HTTP capture at debug

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -52,6 +52,18 @@ func (l *Logger) Error(msg string, args ...any) {
 // Setup configures the global slog default with the given level string
 // (debug, info, warn, error). Default: info. Also redirects the old
 // log.Printf through slog at Info level.
+//
+// The handler is JSON. Earlier versions used TextHandler, which collapsed
+// multi-field events onto a single line of `key=value` pairs and quote-
+// escaped any string value containing whitespace or punctuation — fine for
+// short attrs but unreadable for the bigger payloads we already log
+// (planner system prompts, MCP tool descriptions, the raw OpenAI HTTP
+// bodies introduced for live A/B comparison). JSON keeps every attr a
+// real value (nested objects, numbers, arrays stay typed), and `kubectl
+// logs -f opentalon-0 | jq` becomes a usable live tail. The cost is one
+// extra layer for human grep'ing — solved by piping through `jq` or a
+// small awk filter — and that trade is overwhelmingly worth it as soon
+// as any single attr is bigger than a screen line.
 func Setup(level string) {
 	var lvl slog.Level
 	switch strings.ToLower(level) {
@@ -64,7 +76,7 @@ func Setup(level string) {
 	default:
 		lvl = slog.LevelInfo
 	}
-	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
 	slog.SetDefault(slog.New(handler))
 	log.SetOutput(&slogWriter{level: slog.LevelInfo})
 	log.SetFlags(0)

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -197,6 +197,19 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	}
 	p.setHeaders(httpReq)
 
+	// Raw HTTP capture for live A/B comparison against parallel clients
+	// (e.g. RubyLLM-based mockups hitting the same OVH endpoint). Off until
+	// LOG_LEVEL=debug. Body is passed as json.RawMessage so the JSON log
+	// handler embeds it as a nested object, not a quote-escaped string —
+	// `kubectl logs -f | jq 'select(.msg=="openai raw http")'` becomes a
+	// usable live tail. Tagged "openai raw http" + direction so a single
+	// jq selector covers request and response.
+	slog.DebugContext(ctx, "openai raw http",
+		"direction", "request",
+		"url", p.baseURL+openAICompletionsPath,
+		"body", json.RawMessage(body),
+	)
+
 	httpResp, err := p.client.Do(httpReq)
 	if err != nil {
 		return nil, fmt.Errorf("http request: %w", err)
@@ -207,6 +220,12 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
+
+	slog.DebugContext(ctx, "openai raw http",
+		"direction", "response",
+		"status", httpResp.StatusCode,
+		"body", rawJSONOrString(respBody),
+	)
 
 	if httpResp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
@@ -297,6 +316,15 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	p.setHeaders(httpReq)
+
+	// Capture the request only — streaming responses arrive as SSE chunks
+	// and logging each one would flood the debug stream without serving
+	// the A/B parity goal (which is "what did we send to the model").
+	slog.DebugContext(ctx, "openai raw http",
+		"direction", "request",
+		"url", p.baseURL+openAICompletionsPath,
+		"body", json.RawMessage(body),
+	)
 
 	// Use a client without timeout for streaming; context handles cancellation.
 	streamClient := &http.Client{}
@@ -438,6 +466,20 @@ func (p *OpenAIProvider) setHeaders(req *http.Request) {
 	if p.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+p.apiKey)
 	}
+}
+
+// rawJSONOrString returns body as json.RawMessage when the bytes are valid
+// JSON (so the JSON log handler embeds it inline), or as the literal
+// string otherwise (so an HTTP error page or a truncated chunk still
+// surfaces in the log instead of vanishing). Used by the raw HTTP
+// capture path on the response side, where upstream surprises are most
+// likely.
+func rawJSONOrString(body []byte) any {
+	var probe json.RawMessage
+	if json.Unmarshal(body, &probe) == nil {
+		return json.RawMessage(body)
+	}
+	return string(body)
 }
 
 // nativeArgToString converts a JSON-decoded value to a string suitable for

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -325,6 +327,173 @@ func TestNativeArgToString(t *testing.T) {
 			got := nativeArgToString(tc.v)
 			if got != tc.want {
 				t.Errorf("nativeArgToString(%v) = %q, want %q", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+// withSlogCapture redirects the package-default slog handler at the given
+// level to a buffer and returns the buffer + a restore func. Mirrors the
+// JSONHandler used in production so tests assert against the actual log
+// shape operators see.
+func withSlogCapture(t *testing.T, level slog.Level) (*bytes.Buffer, func()) {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: level})))
+	return &buf, func() { slog.SetDefault(prev) }
+}
+
+// rawHTTPRecord parses one captured "openai raw http" event from the JSON
+// log buffer, returning its parsed `body` and the surrounding attrs.
+// Test helper — fails the calling test if the matching record isn't
+// present or its shape is wrong.
+func rawHTTPRecord(t *testing.T, buf *bytes.Buffer, direction string) map[string]any {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if rec["msg"] != "openai raw http" {
+			continue
+		}
+		if rec["direction"] != direction {
+			continue
+		}
+		return rec
+	}
+	t.Fatalf("no openai raw http record with direction=%q in:\n%s", direction, buf.String())
+	return nil
+}
+
+// TestOpenAIComplete_RawHTTPLogAtDebug pins the contract that operators
+// rely on for the live A/B comparison: at LOG_LEVEL=debug, the full
+// request body and full response body are emitted on stderr (kubectl
+// logs) under a single "openai raw http" message tag with a `direction`
+// attribute, with `body` as a nested JSON object — `kubectl logs -f
+// opentalon-0 | jq 'select(.msg=="openai raw http")'` is the supported
+// live tail.
+func TestOpenAIComplete_RawHTTPLogAtDebug(t *testing.T) {
+	buf, restore := withSlogCapture(t, slog.LevelDebug)
+	defer restore()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oaiResponse{
+			ID:      "chatcmpl-raw",
+			Model:   "gpt-4o",
+			Choices: []oaiChoice{{Index: 0, Message: oaiMessage{Role: "assistant", Content: "ok"}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil)
+	if _, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Request side — body must be a nested JSON object; a request_body
+	// rendered as a quote-escaped string would defeat the purpose of the
+	// JSON log handler. We assert on shape, not on string substring.
+	reqRec := rawHTTPRecord(t, buf, "request")
+	reqBody, ok := reqRec["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("request body is not a JSON object: %v (%T)", reqRec["body"], reqRec["body"])
+	}
+	if reqBody["model"] != "gpt-4o" {
+		t.Errorf("request body model = %v, want gpt-4o", reqBody["model"])
+	}
+	msgs, ok := reqBody["messages"].([]any)
+	if !ok || len(msgs) == 0 {
+		t.Fatalf("request body messages missing or wrong type: %v (%T)", reqBody["messages"], reqBody["messages"])
+	}
+	first := msgs[0].(map[string]any)
+	if first["role"] != "user" || first["content"] != "Hi" {
+		t.Errorf("first message = %v, want role=user content=Hi", first)
+	}
+
+	// Response side — same nested-JSON shape expectation.
+	respRec := rawHTTPRecord(t, buf, "response")
+	if respRec["status"].(float64) != 200 {
+		t.Errorf("response status = %v, want 200", respRec["status"])
+	}
+	respBody, ok := respRec["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("response body is not a JSON object: %v (%T)", respRec["body"], respRec["body"])
+	}
+	if respBody["id"] != "chatcmpl-raw" {
+		t.Errorf("response body id = %v, want chatcmpl-raw", respBody["id"])
+	}
+}
+
+// TestOpenAIComplete_RawHTTPLogSilentAtInfo guarantees the capture is
+// gated by LOG_LEVEL — operators can leave the patched binary running
+// at the default `info` level without stderr getting flooded with
+// 30 KB request bodies.
+func TestOpenAIComplete_RawHTTPLogSilentAtInfo(t *testing.T) {
+	buf, restore := withSlogCapture(t, slog.LevelInfo)
+	defer restore()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(oaiResponse{
+			Choices: []oaiChoice{{Index: 0, Message: oaiMessage{Role: "assistant", Content: "ok"}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil)
+	if _, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(buf.String(), "openai raw http") {
+		t.Errorf("info-level log must not include raw http capture; got:\n%s", buf.String())
+	}
+}
+
+// TestRawJSONOrString covers the response-body fallback: valid JSON keeps
+// its shape, anything else (HTML error page, truncated chunk) survives
+// as a literal string instead of vanishing.
+func TestRawJSONOrString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want any
+	}{
+		{"json object", `{"a":1}`, json.RawMessage(`{"a":1}`)},
+		{"json array", `[1,2,3]`, json.RawMessage(`[1,2,3]`)},
+		{"html error page", `<html><body>500</body></html>`, "<html><body>500</body></html>"},
+		{"truncated json", `{"a":`, `{"a":`},
+		{"empty", ``, ``},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := rawJSONOrString([]byte(c.in))
+			switch w := c.want.(type) {
+			case json.RawMessage:
+				rm, ok := got.(json.RawMessage)
+				if !ok {
+					t.Fatalf("got %T, want json.RawMessage", got)
+				}
+				if string(rm) != string(w) {
+					t.Errorf("got %q, want %q", string(rm), string(w))
+				}
+			case string:
+				s, ok := got.(string)
+				if !ok {
+					t.Fatalf("got %T (%v), want string", got, got)
+				}
+				if s != w {
+					t.Errorf("got %q, want %q", s, w)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Two coupled changes that solve one problem: **there's no way today to sit next to a parallel client (a Ruby/RubyLLM-based mockup hitting the same OVH endpoint) and compare exactly what each stack sends to and receives from the model.**

The mid-stack slog DEBUG output gives an assembled / parsed view (\`LLM request message\`, \`openai reasoning response\`, \`openai native tool calls\`) but never the raw JSON body — which is precisely where provider-level differences hide (tools-array schema shape, \`tool_choice\`, \`parallel_tool_calls\`, \`response_format\`, \`reasoning_effort\`, message-order quirks). And the existing \`TextHandler\` collapses every event onto one line of quote-escaped key=value pairs, unreadable for any attr longer than a screen line — so even a partial capture would be terminal-hostile.

## Change 1 — global slog → JSONHandler

JSONHandler keeps every attr a real value: numbers stay numbers, nested objects stay objects, arrays stay arrays. For the bigger payloads already in the stream — planner system prompts, MCP tool descriptions, the raw OpenAI bodies introduced here — the operator UX flips from "read a 30 000-char escaped string in a single terminal line" to \`kubectl logs -f opentalon-0 | jq\` over structured records.

Aligns with the cluster log pipeline: gitops elastic-logging's event-exporter is already configured \`logFormat: json\`, so any structured-log sink (Loki / Elastic / Datadog / Splunk) auto-extracts fields without grok rules. ArgoCD's pod-log viewer displays both formats unchanged (one line per event); operators scrolling casually see one extra layer of verbosity, but any "extract this attr" need becomes a one-liner.

**No opentalon log consumer in iac / gitops / charts hard-codes the text format** — checked the tree before flipping the default.

## Change 2 — raw OpenAI HTTP capture at DEBUG

Two \`slog.DebugContext\` calls in \`openai.go::Complete\` (request + response) and one in \`Stream\` (request only — SSE chunks are streamed; per-chunk capture would flood the debug stream without serving the parity goal). All emit message \`\"openai raw http\"\` with a \`direction\` attribute. Body passed as \`json.RawMessage\` so the JSON handler embeds it inline.

Response-side fallback: \`rawJSONOrString\` returns the bytes as \`json.RawMessage\` when valid JSON, otherwise as a literal string, so an HTML error page or truncated chunk still surfaces in the log instead of vanishing on unmarshal failure.

## Activation + capture (kubectl-only flow)

```bash
# 1. flip log level — triggers rolling restart automatically
kubectl -n opentalon set env statefulset/opentalon LOG_LEVEL=debug
kubectl -n opentalon wait --for=condition=ready pod/opentalon-0 --timeout=15m

# 2. trigger the prompt in AIrene

# 3. capture (full transcript with parsed bodies, no jq escapes)
kubectl -n opentalon logs opentalon-0 \
  | jq -c 'select(.msg == "openai raw http") | {ts: .time, dir: .direction, status, body}' \
  > /tmp/airene_opentalon.jsonl

# 4. live-tail variant
kubectl -n opentalon logs -f opentalon-0 \
  | jq -c 'select(.msg == "openai raw http") | {dir: .direction, status, msgs: (.body.messages // [] | length), tools: (.body.tools // [] | length)}'

# 5. deactivate
kubectl -n opentalon set env statefulset/opentalon LOG_LEVEL-
```

Diff against the parallel RubyLLM-side capture (Timly's \`OvhConnectionSanitizer\` writes a parallel \`/tmp/airene_local.jsonl\` with the same \`{dir, body}\` shape — see \`config/initializers/ai_workflows.rb\`):

```bash
jq -S 'select(.dir == "request") | .body' /tmp/airene_local.jsonl    | head -1 > /tmp/local_req.json
jq -S 'select(.direction == "request") | .body' /tmp/airene_opentalon.jsonl | head -1 > /tmp/opentalon_req.json
diff /tmp/local_req.json /tmp/opentalon_req.json
```

## Tests

- \`TestOpenAIComplete_RawHTTPLogAtDebug\` — request + response records appear with body as a **parsed JSON object** (asserts on shape, not on substring match — verifies the JSON-handler contract operators rely on)
- \`TestOpenAIComplete_RawHTTPLogSilentAtInfo\` — gating works at default log level (no flood at info)
- \`TestRawJSONOrString\` — fallback covers valid JSON, valid array, HTML error page, truncated JSON, empty body

\`go test ./...\`: all green. \`golangci-lint run ./internal/provider/... ./internal/logger/...\`: 0 issues.

## Backward-compatibility

Source-level: no behaviour change at the existing default log level (info), and the \`LOG_LEVEL\` knob was already exposed via env / configmap (\`internal/config/config.go:243\`). Existing \`LLM request message\` / \`openai reasoning response\` debug events keep working — just rendered as JSON instead of text now.

Operator-level: anyone with grep-pipelines built on the previous \`level=DEBUG msg="..."\` shape needs to switch to JSON parsers; this is a known minor churn cost which the cluster's existing JSON-log convention already absorbs.