### PR TITLE
fix: send native tools on every round for multi-step tool chaining

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1017,12 +1017,12 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			req.Model = profileModel
 		}
 
-		// Native tool calling: pass tool definitions so the LLM returns
-		// structured tool_calls instead of text-based [tool_call] blocks.
-		// Only on rounds where we expect tool calls (not after tool results
-		// when the LLM should just summarize).
+		// Native tool calling: pass tool definitions on every round so the
+		// LLM can chain multiple tool calls (e.g. list-categories → list-org-units
+		// → create-item). Without tools on follow-up rounds, the LLM just
+		// summarizes the first result instead of continuing.
 		nativeMode := o.supportsNativeTools()
-		if nativeMode && !hasToolResults(sess.Messages) {
+		if nativeMode {
 			req.Tools = o.buildToolDefinitions(ctx)
 			toolNames := make([]string, len(req.Tools))
 			for ti, td := range req.Tools {


### PR DESCRIPTION
## Summary

Native tool definitions were only sent on the first round (`!hasToolResults(sess.Messages)` gate). After the LLM called a tool and got results, subsequent rounds had no tool definitions — the LLM couldn't call more tools and just summarized the first result.

This broke multi-step workflows like "create a test object" where the LLM needs to:
1. `list-categories` → get category ID
2. `list-org-units` → get org-unit ID  
3. `create-item` → create the item

After step 1, it stopped and presented categories to the user instead of continuing.

Fix: send native tools on every round, same as we did for text-based tool descriptions in #202.

## Test plan

- [x] `go test -race ./internal/orchestrator/...` (non-VCR)
- [x] Manual: LLM should now chain tool calls across rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)