### PR TITLE
feat: per-session deep debug capture (/debug command)

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/opentalon/opentalon/internal/actor"
 	"github.com/opentalon/opentalon/internal/bootstrap"
 	"github.com/opentalon/opentalon/internal/bundle"
 	"github.com/opentalon/opentalon/internal/channel"
@@ -131,34 +132,19 @@ func main() {
 		}
 	}
 
-	// Build LLM provider and default model from config
-	prov, defaultModel, err := buildProvider(cfg)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error building provider: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Build model lookup map for defaultModelClient.
-	modelMap := make(map[string]provider.ModelInfo)
-	for _, m := range prov.Models() {
-		modelMap[m.ID] = m
-	}
-
-	// LLM client that sets default model when orchestrator doesn't
-	llm := &defaultModelClient{provider: prov, model: defaultModel, models: modelMap}
-
-	// Look up context window for the default model.
-	var contextWindow int
-	if m, ok := modelMap[defaultModel]; ok {
-		contextWindow = m.ContextWindow
-	}
-
+	// State store is opened first because the LLM provider needs the
+	// per-session debug-capture sink (an async writer over the state DB)
+	// at construction time. Sessions and other state pieces are wired the
+	// same way as before — just earlier in the bootstrap.
 	dataDir := cfg.State.DataDir
 	var memory orchestrator.MemoryStoreInterface
 	var sessions orchestrator.SessionStoreInterface
 	var groupPluginStore *store.GroupPluginStore
 	var usageStore *store.UsageStore
 	var entityStore *store.EntityStore
+	var debugStore *store.DebugEventStore
+	var debugWriter *store.DebugEventWriter
+	var debugRetentionCancel context.CancelFunc
 	if dataDir != "" || cfg.State.DB.Driver == "postgres" {
 		db, err := store.Open(cfg.State.DB, dataDir)
 		if err != nil {
@@ -175,6 +161,25 @@ func main() {
 			groupPluginStore = store.NewGroupPluginStore(db)
 			usageStore = store.NewUsageStore(db)
 			entityStore = store.NewEntityStore(db)
+			debugStore = store.NewDebugEventStore(db)
+			debugWriter = store.NewDebugEventWriter(debugStore)
+			debugWriter.Start(context.Background())
+			// Retention: explicit RetentionDisabled overrides the days field;
+			// RetentionDays==0 means "use the default 30", not "disable" —
+			// see DebugConfig docstring for the reasoning. retentionCtx is
+			// cancelled in the shutdown sequence at the bottom of main(),
+			// alongside dispatcher and writer teardown.
+			var retention time.Duration
+			if !cfg.State.Debug.RetentionDisabled {
+				days := cfg.State.Debug.RetentionDays
+				if days <= 0 {
+					days = 30
+				}
+				retention = time.Duration(days) * 24 * time.Hour
+			}
+			var retentionCtx context.Context
+			retentionCtx, debugRetentionCancel = context.WithCancel(context.Background())
+			go store.RunDebugRetention(retentionCtx, debugStore, retention)
 			// Seed static group→plugin assignments from config (source="config"; does not overwrite whoami/admin).
 			seedGroupPlugins(context.Background(), groupPluginStore, cfg.Profiles.Groups)
 			// Seed group→plugin assignments from remote bootstrap response (source="bootstrap"; lower priority than "config", does not overwrite whoami/admin).
@@ -182,6 +187,46 @@ func main() {
 		}
 	} else {
 		memory, sessions = newInMemoryState()
+	}
+
+	// Build the resolver for /debug capture: trace_id is derived from the
+	// session key and stamped onto ctx by orchestrator.Run; logger.IsSession-
+	// Debug reflects whether the session has metadata["debug"]=true. When
+	// debugStore is nil (no state DB configured) we still build a sink
+	// adapter for completeness, but the resolver short-circuits anyway.
+	var debugSink provider.DebugEventSink
+	var debugResolver provider.DebugContextResolver
+	if debugWriter != nil {
+		debugSink = &providerDebugSink{writer: debugWriter}
+		debugResolver = func(ctx context.Context) (string, string, bool) {
+			if !logger.IsSessionDebug(ctx) {
+				return "", "", false
+			}
+			return actor.SessionID(ctx), logger.TraceID(ctx), true
+		}
+	}
+
+	// Build LLM provider and default model from config. The (sink,resolver)
+	// pair feeds per-session /debug capture; either nil disables capture.
+	prov, defaultModel, err := buildProvider(cfg, debugSink, debugResolver)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error building provider: %v\n", err)
+		os.Exit(1) //nolint:gocritic // matches the other main()-level fatal paths; the deferred db.Close is best-effort, the OS reclaims handles on exit
+	}
+
+	// Build model lookup map for defaultModelClient.
+	modelMap := make(map[string]provider.ModelInfo)
+	for _, m := range prov.Models() {
+		modelMap[m.ID] = m
+	}
+
+	// LLM client that sets default model when orchestrator doesn't
+	llm := &defaultModelClient{provider: prov, model: defaultModel, models: modelMap}
+
+	// Look up context window for the default model.
+	var contextWindow int
+	if m, ok := modelMap[defaultModel]; ok {
+		contextWindow = m.ContextWindow
 	}
 
 	// Sessions created on first message per channel (session key from channel ID)
@@ -379,6 +424,9 @@ func main() {
 	cmdExecutor := commands.NewExecutor(toolRegistry, sessions, dataDir, cfg, runtimePromptPath).
 		WithMCPReload(pluginManager, mcpCacheDir).
 		WithProfileStore(groupPluginStore)
+	if debugStore != nil {
+		cmdExecutor.WithDebugEventCounter(debugStore)
+	}
 	if err := toolRegistry.Register(commands.Capability(), cmdExecutor); err != nil {
 		slog.Warn("register opentalon commands failed", "error", err)
 	}
@@ -727,6 +775,15 @@ func main() {
 	signal.Notify(sigCh, os.Interrupt)
 	<-sigCh
 
+	// Flush debug-event writer first so any /debug rows captured up to the
+	// signal are persisted. Bounded wait — never block shutdown forever.
+	if debugWriter != nil {
+		debugWriter.Stop(5 * time.Second)
+	}
+	if debugRetentionCancel != nil {
+		debugRetentionCancel()
+	}
+
 	// Stop health server first so K8s stops routing traffic during teardown.
 	healthSrv.Shutdown()
 
@@ -747,6 +804,27 @@ func main() {
 		dispatchCancel()
 		dispatcher.Wait()
 	}
+}
+
+// providerDebugSink adapts the state-store async writer to the
+// provider.DebugEventSink interface. The provider package can't import
+// store directly without dragging the SQL drivers into every test build,
+// so this thin shim keeps the dependency direction one-way: main.go
+// composes both packages.
+type providerDebugSink struct {
+	writer *store.DebugEventWriter
+}
+
+func (s *providerDebugSink) Submit(ctx context.Context, e provider.DebugEvent) {
+	s.writer.Submit(store.DebugEvent{
+		SessionID: e.SessionID,
+		TraceID:   e.TraceID,
+		Direction: e.Direction,
+		Status:    e.Status,
+		URL:       e.URL,
+		Body:      e.Body,
+		Timestamp: e.Timestamp,
+	})
 }
 
 // seedGroupPlugins seeds the static group→plugin config baseline to the DB.
@@ -1025,7 +1103,7 @@ func runClean(configPath, category string) {
 }
 
 // buildProvider returns a provider and the default model ID from config.
-func buildProvider(cfg *config.Config) (provider.Provider, string, error) {
+func buildProvider(cfg *config.Config, debugSink provider.DebugEventSink, debugResolve provider.DebugContextResolver) (provider.Provider, string, error) {
 	providerID := ""
 	modelID := ""
 
@@ -1088,11 +1166,13 @@ func buildProvider(cfg *config.Config) (provider.Provider, string, error) {
 	}
 
 	provCfg := provider.ProviderConfig{
-		ID:      providerID,
-		BaseURL: pc.BaseURL,
-		APIKey:  pc.APIKey,
-		API:     pc.API,
-		Models:  models,
+		ID:           providerID,
+		BaseURL:      pc.BaseURL,
+		APIKey:       pc.APIKey,
+		API:          pc.API,
+		Models:       models,
+		DebugSink:    debugSink,
+		DebugResolve: debugResolve,
 	}
 	prov, err := provider.FromConfig(provCfg)
 	if err != nil {

--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -24,6 +24,7 @@ const (
 	ActionSetPrompt        = "set_prompt"
 	ActionClearSession     = "clear_session"
 	ActionReloadMCP        = "reload_mcp"
+	ActionSetDebugMode     = "set_debug_mode"
 	ActionProfileAssign    = "profile_assign"
 	ActionProfileRevoke    = "profile_revoke"
 	ActionProfileListGroup = "profile_list_group"
@@ -47,6 +48,14 @@ type GroupPluginManager interface {
 	RevokePlugin(ctx context.Context, groupID, pluginID string) error
 }
 
+// DebugEventCounter reports the per-session row count in ai_debug_events.
+// Used by ActionSetDebugMode "status" replies so users can see whether
+// capture is actually filling the table. Optional — when nil the status
+// reply just reports on/off without a row count.
+type DebugEventCounter interface {
+	CountForSession(ctx context.Context, sessionID string) (int64, error)
+}
+
 // Executor runs built-in opentalon actions (install_skill, show_config, list_commands, set_prompt, clear_session, reload_mcp).
 // It implements orchestrator.PluginExecutor.
 type Executor struct {
@@ -58,6 +67,7 @@ type Executor struct {
 	pluginReloader     PluginReloader     // optional; enables reload_mcp
 	mcpCacheDir        string             // optional; mcp-cache dir for cache invalidation on reload
 	groupPluginManager GroupPluginManager // optional; enables profile_assign/revoke/list_group
+	debugEventCounter  DebugEventCounter  // optional; populates "status" reply with row counts
 	onClearActions     []OnClearAction
 	runAction          func(ctx context.Context, plugin, action string, args map[string]string) (string, error)
 }
@@ -74,6 +84,7 @@ func Capability() orchestrator.PluginCapability {
 			{Name: ActionSetPrompt, Description: "Set the editable runtime prompt.", Parameters: []orchestrator.Parameter{{Name: "text", Description: "Prompt text", Required: true}}},
 			{Name: ActionClearSession, Description: "Clear the current session.", Parameters: nil, InjectContextArgs: []string{"session_id"}},
 			{Name: ActionReloadMCP, Description: "Reload MCP server connections and refresh available tools. Optionally target one server by name.", Parameters: []orchestrator.Parameter{{Name: "server", Description: "MCP server name to reload (leave empty to reload all)", Required: false}}},
+			{Name: ActionSetDebugMode, Description: "Toggle per-session deep debug logging (the user-facing /debug command). When on, raw LLM HTTP request and response bodies for this session are emitted on stderr at INFO level and persisted to the ai_debug_events table for 30 days. Use to capture the full prompt/response pair when diagnosing why the model produced a wrong answer. Other sessions are unaffected. Persistence requires the state store to be configured.", Parameters: []orchestrator.Parameter{{Name: "mode", Description: "on, off, toggle (default), or status", Required: false}}, InjectContextArgs: []string{"session_id"}},
 			{Name: ActionProfileAssign, Description: "Assign a plugin to a profile group (admin). Source is set to 'admin' and cannot be overwritten by WhoAmI.", Parameters: []orchestrator.Parameter{{Name: "group", Description: "Group name", Required: true}, {Name: "plugin", Description: "Plugin ID", Required: true}}, AuditLog: true, UserOnly: true},
 			{Name: ActionProfileRevoke, Description: "Revoke a plugin from a profile group (admin).", Parameters: []orchestrator.Parameter{{Name: "group", Description: "Group name", Required: true}, {Name: "plugin", Description: "Plugin ID", Required: true}}, AuditLog: true, UserOnly: true},
 			{Name: ActionProfileListGroup, Description: "List plugins assigned to a profile group.", Parameters: []orchestrator.Parameter{{Name: "group", Description: "Group name", Required: true}}, UserOnly: true},
@@ -121,6 +132,14 @@ func (e *Executor) WithProfileStore(m GroupPluginManager) *Executor {
 	return e
 }
 
+// WithDebugEventCounter wires the row-count source for set_debug_mode status
+// replies. Optional — without it the status reply still works but skips the
+// row-count line.
+func (e *Executor) WithDebugEventCounter(c DebugEventCounter) *Executor {
+	e.debugEventCounter = c
+	return e
+}
+
 // Execute implements orchestrator.PluginExecutor.
 func (e *Executor) Execute(ctx context.Context, call orchestrator.ToolCall) orchestrator.ToolResult {
 	switch call.Action {
@@ -136,6 +155,8 @@ func (e *Executor) Execute(ctx context.Context, call orchestrator.ToolCall) orch
 		return e.clearSession(ctx, call)
 	case ActionReloadMCP:
 		return e.reloadMCP(ctx, call)
+	case ActionSetDebugMode:
+		return e.setDebugMode(ctx, call)
 	case ActionProfileAssign:
 		return e.profileAssign(ctx, call)
 	case ActionProfileRevoke:
@@ -303,7 +324,8 @@ func (e *Executor) listCommands(call orchestrator.ToolCall) orchestrator.ToolRes
 /commands — List available commands (this message).
 /set prompt <text> — Set the editable runtime prompt; applies to the next message.
 /clear or /new — Clear the current session.
-/reload mcp [server] — Reload MCP server connections and refresh available tools. Optionally name a specific server (e.g. /reload mcp magtuner).`
+/reload mcp [server] — Reload MCP server connections and refresh available tools. Optionally name a specific server (e.g. /reload mcp magtuner).
+/debug [on|off|status] — Toggle per-session deep debug logging. With no arg the flag toggles. Captured raw LLM HTTP bodies stay in ai_debug_events for 30 days.`
 	return orchestrator.ToolResult{CallID: call.ID, Content: msg}
 }
 
@@ -360,6 +382,104 @@ func (e *Executor) setPrompt(call orchestrator.ToolCall) orchestrator.ToolResult
 		CallID:  call.ID,
 		Content: "Prompt updated. It will apply to the next message.",
 	}
+}
+
+// setDebugMode toggles per-session deep debug capture. The flag lives in
+// session.Metadata["debug"]; orchestrator.Run() reads it on every turn and
+// promotes the slog level + tees raw HTTP bodies into the ai_debug_events
+// table accordingly. Persistence requires the state store to be configured —
+// without it the toggle still works but only the slog promotion takes
+// effect.
+func (e *Executor) setDebugMode(ctx context.Context, call orchestrator.ToolCall) orchestrator.ToolResult {
+	sessionID := call.Args["session_id"]
+	if sessionID == "" {
+		return orchestrator.ToolResult{CallID: call.ID, Error: "session_id not set (internal error)"}
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(call.Args["mode"]))
+	if mode == "" {
+		mode = "toggle"
+	}
+
+	sess, err := e.sessions.Get(sessionID)
+	if err != nil {
+		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("session lookup: %v", err)}
+	}
+	current := sess != nil && sess.Metadata["debug"] == "true"
+
+	var enable bool
+	switch mode {
+	case "on", "enable", "true":
+		enable = true
+	case "off", "disable", "false":
+		enable = false
+	case "status":
+		return e.debugStatusReply(ctx, call.ID, sessionID, current)
+	case "toggle":
+		enable = !current
+	default:
+		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("unknown mode %q (expected on, off, toggle, or status)", mode)}
+	}
+
+	if enable == current {
+		return e.debugStatusReply(ctx, call.ID, sessionID, current)
+	}
+
+	value := ""
+	if enable {
+		value = "true"
+	}
+	if err := e.sessions.SetMetadata(sessionID, "debug", value); err != nil {
+		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("persist debug flag: %v", err)}
+	}
+
+	if enable {
+		return orchestrator.ToolResult{
+			CallID:  call.ID,
+			Content: "Debug mode ON. " + e.debugCaptureScopeText() + " Send /debug off to stop.",
+		}
+	}
+	return orchestrator.ToolResult{
+		CallID:  call.ID,
+		Content: "Debug mode OFF." + e.debugRetentionTrailerText(),
+	}
+}
+
+// debugCaptureScopeText describes what /debug-on actually captures, honest
+// about whether persistence is wired. The Counter being non-nil is the
+// proxy for "state-store + async writer are configured" — sessions that
+// only get console promotion say so explicitly.
+func (e *Executor) debugCaptureScopeText() string {
+	if e.debugEventCounter == nil {
+		return "The next LLM exchange will be logged at INFO level on stderr (no state store configured, so events are not persisted)."
+	}
+	return "The next LLM exchange will be logged at INFO level on stderr and persisted to the ai_debug_events table."
+}
+
+// debugRetentionTrailerText is the second sentence of the OFF reply: only
+// meaningful when persistence is wired, otherwise omitted to avoid the
+// false promise of historical retention.
+func (e *Executor) debugRetentionTrailerText() string {
+	if e.debugEventCounter == nil {
+		return ""
+	}
+	return " Already-captured events stay in ai_debug_events until they age out."
+}
+
+func (e *Executor) debugStatusReply(ctx context.Context, callID, sessionID string, on bool) orchestrator.ToolResult {
+	state := "OFF"
+	if on {
+		state = "ON"
+	}
+	msg := "Debug mode " + state + "."
+	if e.debugEventCounter != nil {
+		if n, err := e.debugEventCounter.CountForSession(ctx, sessionID); err == nil {
+			msg = fmt.Sprintf("Debug mode %s. %d events captured for this session so far.", state, n)
+		}
+	} else {
+		msg += " (Persistence disabled — no state store configured.)"
+	}
+	return orchestrator.ToolResult{CallID: callID, Content: msg}
 }
 
 func (e *Executor) clearSession(ctx context.Context, call orchestrator.ToolCall) orchestrator.ToolResult {

--- a/internal/commands/set_debug_mode_test.go
+++ b/internal/commands/set_debug_mode_test.go
@@ -1,0 +1,209 @@
+package commands
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/orchestrator"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// stubCounter satisfies DebugEventCounter for status-reply tests.
+type stubCounter struct{ n int64 }
+
+func (s *stubCounter) CountForSession(ctx context.Context, _ string) (int64, error) {
+	return s.n, nil
+}
+
+func newDebugTestExecutor(t *testing.T) (*Executor, *state.SessionStore) {
+	t.Helper()
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess-1", "", "")
+	registry := orchestrator.NewToolRegistry()
+	exec := NewExecutor(registry, sessions, t.TempDir(), nil, "")
+	if err := registry.Register(Capability(), exec); err != nil {
+		t.Fatalf("register capability: %v", err)
+	}
+	return exec, sessions
+}
+
+func TestSetDebugMode_DefaultToggle(t *testing.T) {
+	exec, sessions := newDebugTestExecutor(t)
+
+	// First call (default mode) flips OFF -> ON.
+	res := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "c1",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"session_id": "sess-1"},
+	})
+	if res.Error != "" {
+		t.Fatalf("first toggle returned error: %v", res.Error)
+	}
+	if !strings.Contains(strings.ToUpper(res.Content), "ON") {
+		t.Errorf("first toggle Content = %q, expected ON state", res.Content)
+	}
+	sess, _ := sessions.Get("sess-1")
+	if sess.Metadata["debug"] != "true" {
+		t.Errorf("metadata[debug] = %q, want \"true\"", sess.Metadata["debug"])
+	}
+
+	// Second toggle flips back OFF.
+	res = exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "c2",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"session_id": "sess-1"},
+	})
+	if res.Error != "" {
+		t.Fatalf("second toggle returned error: %v", res.Error)
+	}
+	sess, _ = sessions.Get("sess-1")
+	if v, present := sess.Metadata["debug"]; present {
+		t.Errorf("after second toggle: metadata[debug] = %q, want absent", v)
+	}
+}
+
+func TestSetDebugMode_ExplicitOnOff(t *testing.T) {
+	exec, sessions := newDebugTestExecutor(t)
+
+	for _, mode := range []string{"on", "ON", "enable", "true"} {
+		res := exec.Execute(context.Background(), orchestrator.ToolCall{
+			ID:     "x",
+			Plugin: PluginName,
+			Action: ActionSetDebugMode,
+			Args:   map[string]string{"session_id": "sess-1", "mode": mode},
+		})
+		if res.Error != "" {
+			t.Fatalf("mode=%q error: %v", mode, res.Error)
+		}
+		sess, _ := sessions.Get("sess-1")
+		if sess.Metadata["debug"] != "true" {
+			t.Errorf("after mode=%q, metadata[debug] = %q, want \"true\"", mode, sess.Metadata["debug"])
+		}
+	}
+
+	for _, mode := range []string{"off", "disable", "false"} {
+		_ = exec.Execute(context.Background(), orchestrator.ToolCall{
+			ID:     "x",
+			Plugin: PluginName,
+			Action: ActionSetDebugMode,
+			Args:   map[string]string{"session_id": "sess-1", "mode": mode},
+		})
+		sess, _ := sessions.Get("sess-1")
+		if _, present := sess.Metadata["debug"]; present {
+			t.Errorf("after mode=%q, metadata[debug] still present", mode)
+		}
+	}
+}
+
+func TestSetDebugMode_StatusWithCounter(t *testing.T) {
+	exec, sessions := newDebugTestExecutor(t)
+	exec.WithDebugEventCounter(&stubCounter{n: 7})
+
+	// Turn debug on first.
+	_ = exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "x",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"session_id": "sess-1", "mode": "on"},
+	})
+
+	res := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "s",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"session_id": "sess-1", "mode": "status"},
+	})
+	if res.Error != "" {
+		t.Fatalf("status error: %v", res.Error)
+	}
+	if !strings.Contains(res.Content, "ON") || !strings.Contains(res.Content, "7 events") {
+		t.Errorf("status content missing ON/7 events: %q", res.Content)
+	}
+
+	// Status must not flip the flag.
+	sess, _ := sessions.Get("sess-1")
+	if sess.Metadata["debug"] != "true" {
+		t.Errorf("status mutated debug flag: metadata[debug] = %q", sess.Metadata["debug"])
+	}
+}
+
+func TestSetDebugMode_RejectsUnknownMode(t *testing.T) {
+	exec, _ := newDebugTestExecutor(t)
+	res := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "x",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"session_id": "sess-1", "mode": "wat"},
+	})
+	if res.Error == "" {
+		t.Error("expected error for unknown mode, got nil")
+	}
+}
+
+func TestSetDebugMode_MissingSessionID(t *testing.T) {
+	exec, _ := newDebugTestExecutor(t)
+	res := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID:     "x",
+		Plugin: PluginName,
+		Action: ActionSetDebugMode,
+		Args:   map[string]string{"mode": "on"},
+	})
+	if res.Error == "" {
+		t.Error("expected error for missing session_id, got nil")
+	}
+}
+
+// TestSetDebugMode_RepliesHonestlyWithoutCounter exercises the no-DB path:
+// the action must not promise persistence when the executor was wired
+// without a DebugEventCounter (i.e. no state store configured).
+func TestSetDebugMode_RepliesHonestlyWithoutCounter(t *testing.T) {
+	exec, _ := newDebugTestExecutor(t)
+	// No WithDebugEventCounter — counter remains nil.
+
+	on := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID: "x", Plugin: PluginName, Action: ActionSetDebugMode,
+		Args: map[string]string{"session_id": "sess-1", "mode": "on"},
+	})
+	if strings.Contains(on.Content, "ai_debug_events") || strings.Contains(on.Content, "persisted to") {
+		t.Errorf("ON reply must not promise persistence when no counter wired: %q", on.Content)
+	}
+	if !strings.Contains(on.Content, "no state store configured") &&
+		!strings.Contains(on.Content, "not persisted") {
+		t.Errorf("ON reply should disclose that persistence is disabled: %q", on.Content)
+	}
+
+	off := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID: "x", Plugin: PluginName, Action: ActionSetDebugMode,
+		Args: map[string]string{"session_id": "sess-1", "mode": "off"},
+	})
+	if strings.Contains(off.Content, "Already-captured events") {
+		t.Errorf("OFF reply must not reference retention when no counter wired: %q", off.Content)
+	}
+
+	status := exec.Execute(context.Background(), orchestrator.ToolCall{
+		ID: "x", Plugin: PluginName, Action: ActionSetDebugMode,
+		Args: map[string]string{"session_id": "sess-1", "mode": "status"},
+	})
+	if !strings.Contains(status.Content, "Persistence disabled") {
+		t.Errorf("status reply should say Persistence disabled when no counter: %q", status.Content)
+	}
+}
+
+func TestSetDebugMode_IdempotentEnable(t *testing.T) {
+	exec, _ := newDebugTestExecutor(t)
+	// Enable twice — second call should not error and reply with status.
+	for i := 0; i < 2; i++ {
+		res := exec.Execute(context.Background(), orchestrator.ToolCall{
+			ID:     "x",
+			Plugin: PluginName,
+			Action: ActionSetDebugMode,
+			Args:   map[string]string{"session_id": "sess-1", "mode": "on"},
+		})
+		if res.Error != "" {
+			t.Fatalf("call %d error: %v", i, res.Error)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,6 +343,29 @@ type StateConfig struct {
 	DataDir string        `yaml:"data_dir"`
 	DB      DBConfig      `yaml:"db,omitempty"`
 	Session SessionConfig `yaml:"session,omitempty"`
+	Debug   DebugConfig   `yaml:"debug,omitempty"`
+}
+
+// DebugConfig configures per-session deep debug capture (toggled by the
+// /debug command). Without an /debug-active session, this subsystem does
+// nothing — the table stays empty and the writer goroutine is idle.
+//
+// Retention semantics, deliberately split into two fields rather than a
+// sentinel value (e.g. "0 means disabled"):
+//   - RetentionDays:    integer days; 0 or omitted means "use default 30"
+//   - RetentionDisabled: explicit off-switch; takes precedence over
+//     RetentionDays. Use this to turn pruning off,
+//     not RetentionDays=0 — that path applies the
+//     default and would surprise an operator who
+//     meant "off".
+//
+// The async-writer buffer size is intentionally not configurable: 100 is
+// adequate for any realistic /debug load (opt-in per session, drained at
+// ~1k inserts/s by the worker), and a knob nobody will turn is just
+// surface area.
+type DebugConfig struct {
+	RetentionDays     int  `yaml:"retention_days,omitempty"`     // default 30 when 0 or omitted
+	RetentionDisabled bool `yaml:"retention_disabled,omitempty"` // when true, never prune (overrides RetentionDays)
 }
 
 // DBConfig selects the database backend. Driver defaults to "sqlite".

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -53,17 +53,22 @@ func (l *Logger) Error(msg string, args ...any) {
 // (debug, info, warn, error). Default: info. Also redirects the old
 // log.Printf through slog at Info level.
 //
-// The handler is JSON. Earlier versions used TextHandler, which collapsed
+// The handler chain is: JSONHandler at the configured level, wrapped by
+// sessionDebugHandler. The wrapper promotes Debug records carrying the
+// session-debug ctx flag (set by /debug command) to Info, so the per-
+// session deep-debug stream is visible on stderr without having to flip
+// the global level.
+//
+// JSON instead of Text: earlier versions used TextHandler, which collapsed
 // multi-field events onto a single line of `key=value` pairs and quote-
 // escaped any string value containing whitespace or punctuation — fine for
-// short attrs but unreadable for the bigger payloads we already log
-// (planner system prompts, MCP tool descriptions, the raw OpenAI HTTP
-// bodies introduced for live A/B comparison). JSON keeps every attr a
-// real value (nested objects, numbers, arrays stay typed), and `kubectl
-// logs -f opentalon-0 | jq` becomes a usable live tail. The cost is one
-// extra layer for human grep'ing — solved by piping through `jq` or a
-// small awk filter — and that trade is overwhelmingly worth it as soon
-// as any single attr is bigger than a screen line.
+// short attrs but unreadable for the bigger payloads we log (planner
+// system prompts, MCP tool descriptions, raw OpenAI HTTP bodies). JSON
+// keeps every attr a real value (nested objects, numbers, arrays stay
+// typed), and `kubectl logs -f opentalon-0 | jq` becomes a usable live
+// tail. The cost is one extra layer for human grep'ing — solved by piping
+// through `jq` — and that trade is overwhelmingly worth it as soon as any
+// single attr is bigger than a screen line.
 func Setup(level string) {
 	var lvl slog.Level
 	switch strings.ToLower(level) {
@@ -76,8 +81,8 @@ func Setup(level string) {
 	default:
 		lvl = slog.LevelInfo
 	}
-	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
-	slog.SetDefault(slog.New(handler))
+	base := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})
+	slog.SetDefault(slog.New(NewSessionDebugHandler(base)))
 	log.SetOutput(&slogWriter{level: slog.LevelInfo})
 	log.SetFlags(0)
 }

--- a/internal/logger/session_debug.go
+++ b/internal/logger/session_debug.go
@@ -1,0 +1,93 @@
+package logger
+
+import (
+	"context"
+	"log/slog"
+)
+
+// sessionDebugKey carries a per-session flag in ctx that, when set, promotes
+// any Debug-level log on that ctx through the slog handler regardless of the
+// global level. The promoted record is also tagged so `jq` can split out
+// "regular debug" (when LOG_LEVEL=debug) from "this session asked for it
+// explicitly via /debug".
+type sessionDebugKey struct{}
+
+// WithSessionDebug returns a derived ctx with the session-debug flag set.
+// All log calls using this ctx route through the sessionDebugHandler that
+// the global slog.Default carries (installed by Setup), so Debug events
+// emitted via slog.DebugContext become Info-level for this ctx only.
+func WithSessionDebug(ctx context.Context) context.Context {
+	return context.WithValue(ctx, sessionDebugKey{}, true)
+}
+
+// IsSessionDebug returns true when the session-debug flag is present in ctx.
+// Used by the OpenAI provider to decide whether to capture raw HTTP bodies
+// and to fan them into the persistent ai_debug_events table.
+func IsSessionDebug(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	v, _ := ctx.Value(sessionDebugKey{}).(bool)
+	return v
+}
+
+// sessionDebugHandler wraps a base slog.Handler so Debug-level records on a
+// session-debug ctx are emitted at Info-level (and tagged session_debug=true)
+// while every other record is delegated unchanged to the base handler. The
+// design keeps two properties:
+//
+//  1. Sessions without /debug see *no* additional verbosity — the global
+//     LOG_LEVEL still gates everything else.
+//  2. Sessions with /debug see the full LLM traffic on stderr at Info,
+//     so `kubectl logs -f` (which defaults to Info-or-above) tails the
+//     captured bodies live without needing to flip global LOG_LEVEL.
+//
+// We deliberately do not implement WithGroup/WithAttrs as a passthrough +
+// re-wrap pair: slog calls those before passing the handler down, so the
+// base handler must receive them so attrs survive. The wrapper around it
+// only needs to inspect ctx + level on Handle().
+type sessionDebugHandler struct {
+	base slog.Handler
+}
+
+// NewSessionDebugHandler wraps base. Only meaningful when base.Enabled is
+// gated at Info or above; below that, Debug records flow through anyway and
+// the handler is a no-op.
+func NewSessionDebugHandler(base slog.Handler) slog.Handler {
+	return &sessionDebugHandler{base: base}
+}
+
+func (h *sessionDebugHandler) Enabled(ctx context.Context, lvl slog.Level) bool {
+	if h.base.Enabled(ctx, lvl) {
+		return true
+	}
+	if lvl == slog.LevelDebug && IsSessionDebug(ctx) {
+		// Re-evaluate at Info — this is the level the record will be
+		// rewritten to in Handle().
+		return h.base.Enabled(ctx, slog.LevelInfo)
+	}
+	return false
+}
+
+func (h *sessionDebugHandler) Handle(ctx context.Context, r slog.Record) error {
+	if r.Level == slog.LevelDebug && IsSessionDebug(ctx) {
+		// Promote to Info and mark the record so log filters can pick out
+		// session-debug traffic specifically.
+		promoted := slog.NewRecord(r.Time, slog.LevelInfo, r.Message, r.PC)
+		r.Attrs(func(a slog.Attr) bool {
+			promoted.AddAttrs(a)
+			return true
+		})
+		promoted.AddAttrs(slog.Bool("session_debug", true))
+		return h.base.Handle(ctx, promoted)
+	}
+	return h.base.Handle(ctx, r)
+}
+
+func (h *sessionDebugHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &sessionDebugHandler{base: h.base.WithAttrs(attrs)}
+}
+
+func (h *sessionDebugHandler) WithGroup(name string) slog.Handler {
+	return &sessionDebugHandler{base: h.base.WithGroup(name)}
+}

--- a/internal/logger/session_debug_test.go
+++ b/internal/logger/session_debug_test.go
@@ -1,0 +1,98 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestIsSessionDebug(t *testing.T) {
+	if IsSessionDebug(context.Background()) {
+		t.Error("background ctx must not have session-debug flag")
+	}
+	// IsSessionDebug must guard against a nil ctx for safety, even though
+	// callers should not pass one. Using a typed-nil var avoids the
+	// staticcheck warning for passing a literal nil to context-typed args.
+	var nilCtx context.Context
+	if IsSessionDebug(nilCtx) {
+		t.Error("nil ctx must return false")
+	}
+	ctx := WithSessionDebug(context.Background())
+	if !IsSessionDebug(ctx) {
+		t.Error("WithSessionDebug ctx should report true")
+	}
+}
+
+// TestSessionDebugHandlerPromotesDebug verifies the central guarantee: a
+// Debug record on a session-debug ctx is emitted at Info even when the
+// underlying handler is Info-level.
+func TestSessionDebugHandlerPromotesDebug(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewSessionDebugHandler(base))
+
+	// Without flag: Debug record dropped.
+	logger.DebugContext(context.Background(), "should-be-dropped", "k", "v")
+	if buf.Len() > 0 {
+		t.Errorf("expected no output, got %q", buf.String())
+	}
+
+	// With flag: same Debug call emits at Info.
+	logger.DebugContext(WithSessionDebug(context.Background()), "promoted", "k", "v")
+	if buf.Len() == 0 {
+		t.Fatal("expected promoted record on stderr, got nothing")
+	}
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("emitted record not valid JSON: %v", err)
+	}
+	if rec["level"] != "INFO" {
+		t.Errorf("level = %v, want INFO (promoted)", rec["level"])
+	}
+	if rec["msg"] != "promoted" {
+		t.Errorf("msg = %v, want %q", rec["msg"], "promoted")
+	}
+	if rec["session_debug"] != true {
+		t.Errorf("session_debug attr missing or wrong value: %v", rec["session_debug"])
+	}
+	if rec["k"] != "v" {
+		t.Errorf("attr k missing: rec=%v", rec)
+	}
+}
+
+// TestSessionDebugHandlerLeavesNonDebugAlone ensures that records at Info
+// or higher pass through unchanged whether or not the flag is set — the
+// wrapper only tinkers with promoted Debug records.
+func TestSessionDebugHandlerLeavesNonDebugAlone(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	logger := slog.New(NewSessionDebugHandler(base))
+
+	logger.InfoContext(WithSessionDebug(context.Background()), "info-with-flag")
+	if !strings.Contains(buf.String(), `"level":"INFO"`) {
+		t.Errorf("Info record should pass through unchanged: %q", buf.String())
+	}
+	if strings.Contains(buf.String(), `"session_debug":true`) {
+		t.Errorf("Info-level records must NOT be tagged with session_debug; got %q", buf.String())
+	}
+}
+
+// TestSessionDebugHandlerLogLevelDebugStillWorks ensures the wrapper does
+// not break the LOG_LEVEL=debug case — Debug records still flow even
+// without the per-session flag.
+func TestSessionDebugHandlerLogLevelDebugStillWorks(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := slog.New(NewSessionDebugHandler(base))
+
+	logger.DebugContext(context.Background(), "global-debug")
+	if !strings.Contains(buf.String(), `"msg":"global-debug"`) {
+		t.Errorf("Debug record should flow when global level is Debug; got %q", buf.String())
+	}
+	if strings.Contains(buf.String(), `"session_debug":true`) {
+		t.Errorf("global Debug records must not be tagged session_debug; got %q", buf.String())
+	}
+}

--- a/internal/orchestrator/cached_session.go
+++ b/internal/orchestrator/cached_session.go
@@ -63,6 +63,23 @@ func (c *cachedSessionStore) SetModel(id string, model provider.ModelRef) error 
 	return nil
 }
 
+func (c *cachedSessionStore) SetMetadata(id, key, value string) error {
+	if err := c.inner.SetMetadata(id, key, value); err != nil {
+		return err
+	}
+	if s, ok := c.cache[id]; ok {
+		if s.Metadata == nil {
+			s.Metadata = make(map[string]string)
+		}
+		if value == "" {
+			delete(s.Metadata, key)
+		} else {
+			s.Metadata[key] = value
+		}
+	}
+	return nil
+}
+
 func (c *cachedSessionStore) SetSummary(id string, summary string, messages []provider.Message) error {
 	if err := c.inner.SetSummary(id, summary, messages); err != nil {
 		return err

--- a/internal/orchestrator/cached_session_test.go
+++ b/internal/orchestrator/cached_session_test.go
@@ -64,6 +64,22 @@ func (s *stubSessionStore) SetSummary(id string, summary string, messages []prov
 	return nil
 }
 
+func (s *stubSessionStore) SetMetadata(id, key, value string) error {
+	sess := s.sessions[id]
+	if sess == nil {
+		return &sessionNotFoundError{id}
+	}
+	if sess.Metadata == nil {
+		sess.Metadata = map[string]string{}
+	}
+	if value == "" {
+		delete(sess.Metadata, key)
+	} else {
+		sess.Metadata[key] = value
+	}
+	return nil
+}
+
 func (s *stubSessionStore) Delete(id string) error {
 	delete(s.sessions, id)
 	return nil

--- a/internal/orchestrator/concurrency_test.go
+++ b/internal/orchestrator/concurrency_test.go
@@ -249,6 +249,9 @@ func (s *blockingSetSummaryStore) AddMessage(id string, msg provider.Message) er
 	defer s.writeEnd()
 	return s.inner.AddMessage(id, msg)
 }
+func (s *blockingSetSummaryStore) SetMetadata(id, key, value string) error {
+	return s.inner.SetMetadata(id, key, value)
+}
 func (s *blockingSetSummaryStore) SetSummary(id, summary string, msgs []provider.Message) error {
 	s.writeStart()
 	// Signal the test that we're inside SetSummary, then block until released.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -160,6 +160,7 @@ type SessionStoreInterface interface {
 	AddMessage(id string, msg provider.Message) error
 	SetModel(id string, model provider.ModelRef) error
 	SetSummary(id string, summary string, messages []provider.Message) error // for summarization; optional, may be no-op
+	SetMetadata(id, key, value string) error                                 // upsert a single metadata key; empty value removes it
 	Delete(id string) error                                                  // remove session (e.g. for clear_session command)
 }
 
@@ -727,7 +728,8 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// above guarantees single-writer access.
 	sessions := newCachedSessionStore(o.sessions)
 
-	if _, err := sessions.Get(sessionID); err != nil {
+	sess, err := sessions.Get(sessionID)
+	if err != nil {
 		return nil, fmt.Errorf("session lookup: %w", err)
 	}
 	ctx = actor.WithSessionID(ctx, sessionID)
@@ -735,6 +737,16 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// Set up trace_id for this session so all logs are correlated.
 	traceID := logger.TraceIDFromSessionKey(sessionID)
 	ctx = logger.WithTraceID(ctx, traceID)
+
+	// Per-session deep debug: enabled by the set_debug_mode command, which
+	// stores debug=true in session metadata. With the flag set, the slog
+	// session-debug handler promotes all Debug records on this ctx to Info
+	// and the OpenAI provider tees raw HTTP bodies into the persistent
+	// ai_debug_events table. Sessions without the flag are unaffected.
+	if sess != nil && sess.Metadata["debug"] == "true" {
+		ctx = logger.WithSessionDebug(ctx)
+	}
+
 	log := logger.FromContext(ctx)
 
 	// Block A: Check for pending pipeline confirmation.

--- a/internal/provider/debug_sink.go
+++ b/internal/provider/debug_sink.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"context"
+	"time"
+)
+
+// DebugEvent is a captured request/response/error from a provider's HTTP
+// path, suitable for persistence by a /debug-aware sink. URL is the actual
+// endpoint hit; Body is JSON text for request and non-streaming response
+// payloads, "Class: message" for error rows.
+type DebugEvent struct {
+	SessionID string
+	TraceID   string
+	Direction string // "request" | "response" | "error"
+	Status    int
+	URL       string
+	Body      string
+	Timestamp time.Time
+}
+
+// DebugEventSink is implemented by anything that wants to persist captured
+// LLM-endpoint exchanges. The state-store's async writer (in
+// internal/state/store) is the only production implementation; tests use
+// in-memory recorders.
+//
+// The sink lives in package provider rather than in state/store to avoid an
+// import cycle and to keep the provider package self-contained — it knows
+// about HTTP captures, not about postgres tables.
+type DebugEventSink interface {
+	Submit(ctx context.Context, e DebugEvent)
+}
+
+// DebugContextResolver is consulted before any debug-capture work runs in
+// the provider. When enabled is false the provider skips capture entirely
+// (zero cost on the LLM hot path for sessions without /debug). When true,
+// sessionID and traceID are tagged on every emitted DebugEvent so they
+// correlate cleanly in postgres queries and stderr logs.
+//
+// Wired in main.go from actor.SessionID + logger.TraceID + logger.IsSession-
+// Debug. Keeping this a single callback means the provider stays decoupled
+// from those packages — no imports, no risk of cycles.
+type DebugContextResolver func(ctx context.Context) (sessionID, traceID string, enabled bool)

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -8,12 +8,19 @@ const (
 )
 
 // ProviderConfig mirrors config.ProviderConfig to avoid circular imports.
+//
+// DebugSink and DebugResolve are optional and currently consumed only by the
+// OpenAI-compatible provider (the Anthropic provider has no raw HTTP
+// capture today). Wire both from main.go to enable per-session /debug
+// capture; leaving either nil disables capture entirely.
 type ProviderConfig struct {
-	ID      string
-	BaseURL string
-	APIKey  string
-	API     string
-	Models  []ModelInfo
+	ID           string
+	BaseURL      string
+	APIKey       string
+	API          string
+	Models       []ModelInfo
+	DebugSink    DebugEventSink
+	DebugResolve DebugContextResolver
 }
 
 // FromConfig creates a Provider from a config entry. The api field
@@ -23,7 +30,14 @@ type ProviderConfig struct {
 func FromConfig(cfg ProviderConfig) (Provider, error) {
 	switch cfg.API {
 	case APIOpenAI, "":
-		return NewOpenAIProvider(cfg.ID, cfg.BaseURL, cfg.APIKey, cfg.Models), nil
+		opts := []OpenAIOption{}
+		if cfg.DebugSink != nil {
+			opts = append(opts, WithOpenAIDebugSink(cfg.DebugSink))
+		}
+		if cfg.DebugResolve != nil {
+			opts = append(opts, WithOpenAIDebugResolver(cfg.DebugResolve))
+		}
+		return NewOpenAIProvider(cfg.ID, cfg.BaseURL, cfg.APIKey, cfg.Models, opts...), nil
 	case APIAnthropic:
 		return NewAnthropicProvider(cfg.ID, cfg.BaseURL, cfg.APIKey, cfg.Models), nil
 	default:

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -24,11 +24,13 @@ const (
 // OpenAI-compatible API (OpenAI, Azure, Ollama, vLLM, Groq,
 // Together, OVH, etc.).
 type OpenAIProvider struct {
-	id      string
-	baseURL string
-	apiKey  string
-	models  []ModelInfo
-	client  *http.Client
+	id           string
+	baseURL      string
+	apiKey       string
+	models       []ModelInfo
+	client       *http.Client
+	debugSink    DebugEventSink       // optional; nil disables persistent debug capture
+	debugResolve DebugContextResolver // optional; returns (sessionID, traceID, enabled?) for this ctx
 }
 
 // OpenAIOption configures an OpenAIProvider.
@@ -37,6 +39,32 @@ type OpenAIOption func(*OpenAIProvider)
 // WithOpenAIHTTPClient sets a custom HTTP client.
 func WithOpenAIHTTPClient(c *http.Client) OpenAIOption {
 	return func(p *OpenAIProvider) { p.client = c }
+}
+
+// WithOpenAIDebugSink wires a DebugEventSink so request/response/error
+// exchanges are persisted whenever the resolver (see WithOpenAIDebugResolver)
+// reports enabled=true. Both options are required to actually capture: a nil
+// sink or a missing resolver disables the path entirely.
+func WithOpenAIDebugSink(s DebugEventSink) OpenAIOption {
+	return func(p *OpenAIProvider) { p.debugSink = s }
+}
+
+// WithOpenAIDebugResolver wires the per-request resolver that returns
+// (sessionID, traceID, enabled?). In production this is fed by
+// actor.SessionID + logger.TraceID + logger.IsSessionDebug from main.go.
+func WithOpenAIDebugResolver(r DebugContextResolver) OpenAIOption {
+	return func(p *OpenAIProvider) { p.debugResolve = r }
+}
+
+// resolveDebug returns capture metadata for ctx. When any wiring is missing
+// or the session has not opted in, ok is false and the caller skips capture
+// before any body work — keeping the LLM hot path zero-cost for non-debug
+// sessions.
+func (p *OpenAIProvider) resolveDebug(ctx context.Context) (sessionID, traceID string, ok bool) {
+	if p.debugSink == nil || p.debugResolve == nil {
+		return "", "", false
+	}
+	return p.debugResolve(ctx)
 }
 
 // NewOpenAIProvider creates a provider for any OpenAI-compatible endpoint.
@@ -165,9 +193,48 @@ type oaiStreamDelta struct {
 }
 
 // oaiResponseStream implements ResponseStream over an SSE connection.
+//
+// When debug capture is on for the originating session, accumulator collects
+// every SSE line the bufio.Scanner returns, joined back with single '\n'
+// separators. This is line-normalized SSE replay (it would render any real
+// `\r\n\r\n` event boundary as a single '\n'), not byte-for-byte wire
+// fidelity — sufficient for diagnosing what the upstream actually sent
+// (deltas, malformed chunks, the [DONE] marker) without the cost of a
+// TeeReader on the raw response body. On Close() the accumulated body is
+// forwarded to onClose, which writes it as a single `direction=response`
+// row. We capture the line stream rather than the assembled
+// CompletionResponse so /debug shows what came over the network — including
+// chunks the orchestrator skipped on parse failure — which is exactly the
+// surface area /debug exists to expose.
 type oaiResponseStream struct {
-	body    io.ReadCloser
-	scanner *bufio.Scanner
+	body        io.ReadCloser
+	scanner     *bufio.Scanner
+	accumulator *streamAccumulator // nil when capture disabled for this stream
+	onClose     func(rawBody []byte)
+	closed      bool // guard for double-Close (body.Close + onClose flush)
+}
+
+// streamAccumulator buffers the raw SSE wire bytes for end-of-stream debug
+// capture. Bounded so a runaway stream cannot blow up memory: events
+// truncate at maxStreamCaptureBytes with a sentinel marker.
+type streamAccumulator struct {
+	buf       []byte
+	truncated bool
+}
+
+const maxStreamCaptureBytes = 4 * 1024 * 1024 // 4MB; large gpt-oss responses fit, runaway streams do not
+
+func (a *streamAccumulator) append(line string) {
+	if a == nil || a.truncated {
+		return
+	}
+	if len(a.buf)+len(line)+1 > maxStreamCaptureBytes {
+		a.buf = append(a.buf, []byte("\n[truncated by /debug capture]\n")...)
+		a.truncated = true
+		return
+	}
+	a.buf = append(a.buf, line...)
+	a.buf = append(a.buf, '\n')
 }
 
 // Complete sends a non-streaming completion request.
@@ -204,35 +271,28 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	}
 	p.setHeaders(httpReq)
 
-	// Raw HTTP capture for live A/B comparison against parallel clients
-	// (e.g. RubyLLM-based mockups hitting the same OVH endpoint). Off until
-	// LOG_LEVEL=debug. Body is passed as json.RawMessage so the JSON log
-	// handler embeds it as a nested object, not a quote-escaped string —
-	// `kubectl logs -f | jq 'select(.msg=="openai raw http")'` becomes a
-	// usable live tail. Tagged "openai raw http" + direction so a single
-	// jq selector covers request and response.
-	slog.DebugContext(ctx, "openai raw http",
-		"direction", "request",
-		"url", p.baseURL+openAICompletionsPath,
-		"body", json.RawMessage(body),
-	)
+	// Raw HTTP capture: emitted as a slog event for live tailing and (when
+	// /debug capture is wired + this session opted in) persisted to the
+	// ai_debug_events table. Tagged "openai raw http" + direction so a
+	// single `kubectl logs -f | jq 'select(.msg=="openai raw http")'`
+	// covers both request and response.
+	url := p.baseURL + openAICompletionsPath
+	p.captureRawHTTP(ctx, "request", url, 0, body)
 
 	httpResp, err := p.client.Do(httpReq)
 	if err != nil {
+		p.captureRawHTTPError(ctx, url, err)
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
 	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
+		p.captureRawHTTPError(ctx, url, err)
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
-	slog.DebugContext(ctx, "openai raw http",
-		"direction", "response",
-		"status", httpResp.StatusCode,
-		"body", rawJSONOrString(respBody),
-	)
+	p.captureRawHTTP(ctx, "response", url, httpResp.StatusCode, respBody)
 
 	if httpResp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
@@ -329,37 +389,64 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 	}
 	p.setHeaders(httpReq)
 
-	// Capture the request only — streaming responses arrive as SSE chunks
-	// and logging each one would flood the debug stream without serving
-	// the A/B parity goal (which is "what did we send to the model").
-	slog.DebugContext(ctx, "openai raw http",
-		"direction", "request",
-		"url", p.baseURL+openAICompletionsPath,
-		"body", json.RawMessage(body),
-	)
+	// Request is captured the same way as in the non-streaming path; the
+	// streaming response is captured at end-of-stream by the accumulator
+	// inside oaiResponseStream.
+	url := p.baseURL + openAICompletionsPath
+	p.captureRawHTTP(ctx, "request", url, 0, body)
 
 	// Use a client without timeout for streaming; context handles cancellation.
 	streamClient := &http.Client{}
 	httpResp, err := streamClient.Do(httpReq)
 	if err != nil {
+		p.captureRawHTTPError(ctx, url, err)
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
 		respBody, _ := io.ReadAll(httpResp.Body)
+		p.captureRawHTTP(ctx, "response", url, httpResp.StatusCode, respBody)
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
 	}
 
-	return &oaiResponseStream{
+	stream := &oaiResponseStream{
 		body:    httpResp.Body,
 		scanner: bufio.NewScanner(httpResp.Body),
-	}, nil
+	}
+	// Wire end-of-stream capture only when this session opted in. Sessions
+	// without /debug get the lighter struct without the buffer.
+	if sessionID, traceID, ok := p.resolveDebug(ctx); ok {
+		stream.accumulator = &streamAccumulator{}
+		sink := p.debugSink
+		stream.onClose = func(rawBody []byte) {
+			sink.Submit(ctx, DebugEvent{
+				SessionID: sessionID,
+				TraceID:   traceID,
+				Direction: "response",
+				Status:    httpResp.StatusCode,
+				URL:       url,
+				Body:      string(rawBody),
+				Timestamp: time.Now().UTC(),
+			})
+			slog.DebugContext(ctx, "openai raw http",
+				"direction", "response",
+				"url", url,
+				"status", httpResp.StatusCode,
+				"body", rawJSONOrString(rawBody),
+				"streaming", true,
+			)
+		}
+	}
+	return stream, nil
 }
 
 func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 	for s.scanner.Scan() {
 		line := s.scanner.Text()
+		// Capture every SSE line (data: payloads, blank separators, anything
+		// the upstream sent) so /debug shows the wire-level stream verbatim.
+		s.accumulator.append(line)
 
 		// SSE format: lines prefixed with "data: "
 		if !strings.HasPrefix(line, "data: ") {
@@ -412,7 +499,21 @@ func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 	return StreamChunk{Done: true}, nil
 }
 
+// Close flushes the captured body (if any) to the debug sink and closes the
+// underlying response body. Idempotent: a second Close is a no-op rather
+// than re-running onClose or returning the "use of closed network
+// connection" error from the body. The orchestrator calls Close via defer,
+// so a panic-during-Recv path could in principle hit Close twice if the
+// caller has its own defer too — guarding here costs one bool.
 func (s *oaiResponseStream) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.onClose != nil && s.accumulator != nil {
+		s.onClose(s.accumulator.buf)
+		s.onClose = nil
+	}
 	return s.body.Close()
 }
 
@@ -492,6 +593,59 @@ func rawJSONOrString(body []byte) any {
 		return json.RawMessage(body)
 	}
 	return string(body)
+}
+
+// captureRawHTTP is the single point where raw OpenAI HTTP exchanges are
+// surfaced — both as a slog event (for live tailing on stderr) and, when
+// /debug capture is wired and the session opted in, as a row in the
+// ai_debug_events table.
+//
+// The slog call is unconditional at DebugContext level — the global handler
+// chain decides what to emit: the session-debug wrapper promotes it to Info
+// for sessions that toggled /debug, the underlying JSON handler still gates
+// non-debug sessions at the configured LOG_LEVEL.
+//
+// Persistence is gated on resolveDebug() reporting enabled=true so non-debug
+// sessions cost nothing beyond the slog call (which itself short-circuits
+// when the level filters it out).
+func (p *OpenAIProvider) captureRawHTTP(ctx context.Context, direction, url string, status int, body []byte) {
+	slog.DebugContext(ctx, "openai raw http",
+		"direction", direction,
+		"url", url,
+		"status", status,
+		"body", rawJSONOrString(body),
+	)
+	sessionID, traceID, ok := p.resolveDebug(ctx)
+	if !ok {
+		return
+	}
+	p.debugSink.Submit(ctx, DebugEvent{
+		SessionID: sessionID,
+		TraceID:   traceID,
+		Direction: direction,
+		Status:    status,
+		URL:       url,
+		Body:      string(body),
+		Timestamp: time.Now().UTC(),
+	})
+}
+
+// captureRawHTTPError records a non-HTTP failure (DNS, dial, marshalling,
+// stream-read aborts) so /debug session histories show the failure in the
+// same row stream as successful exchanges.
+func (p *OpenAIProvider) captureRawHTTPError(ctx context.Context, url string, err error) {
+	sessionID, traceID, ok := p.resolveDebug(ctx)
+	if !ok {
+		return
+	}
+	p.debugSink.Submit(ctx, DebugEvent{
+		SessionID: sessionID,
+		TraceID:   traceID,
+		Direction: "error",
+		URL:       url,
+		Body:      fmt.Sprintf("%T: %s", err, err.Error()),
+		Timestamp: time.Now().UTC(),
+	})
 }
 
 // nativeArgToString converts a JSON-decoded value to a string suitable for

--- a/internal/provider/openai_debug_test.go
+++ b/internal/provider/openai_debug_test.go
@@ -1,0 +1,415 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingSink captures DebugEvent submissions for assertion.
+type recordingSink struct {
+	mu     sync.Mutex
+	events []DebugEvent
+}
+
+func (r *recordingSink) Submit(_ context.Context, e DebugEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, e)
+}
+
+func (r *recordingSink) snapshot() []DebugEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]DebugEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+// alwaysOnResolver feeds the OpenAI provider session/trace IDs and returns
+// enabled=true for every ctx — used to drive the capture path in tests.
+func alwaysOnResolver(sessionID, traceID string) DebugContextResolver {
+	return func(_ context.Context) (string, string, bool) {
+		return sessionID, traceID, true
+	}
+}
+
+func disabledResolver() DebugContextResolver {
+	return func(_ context.Context) (string, string, bool) {
+		return "", "", false
+	}
+}
+
+func TestOpenAI_Complete_PersistsRequestAndResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID:    "chatcmpl-1",
+			Model: "gpt-4o",
+			Choices: []oaiChoice{
+				{Index: 0, Message: oaiMessage{Role: "assistant", Content: "ok"}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("sess-A", "trace-A")),
+	)
+
+	if _, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	events := sink.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("captured %d events, want 2 (request+response): %+v", len(events), events)
+	}
+	if events[0].Direction != "request" || events[1].Direction != "response" {
+		t.Errorf("directions = %q, %q; want request, response", events[0].Direction, events[1].Direction)
+	}
+	if events[0].SessionID != "sess-A" || events[0].TraceID != "trace-A" {
+		t.Errorf("event[0] correlation: session=%q trace=%q", events[0].SessionID, events[0].TraceID)
+	}
+	if events[1].Status != http.StatusOK {
+		t.Errorf("response Status = %d, want 200", events[1].Status)
+	}
+	if !strings.Contains(events[0].Body, `"model":"gpt-4o"`) {
+		t.Errorf("request body missing model: %q", events[0].Body)
+	}
+	if !strings.Contains(events[1].Body, `"chatcmpl-1"`) {
+		t.Errorf("response body missing id: %q", events[1].Body)
+	}
+}
+
+func TestOpenAI_Complete_DisabledResolverSkipsCapture(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(oaiResponse{ID: "x", Choices: []oaiChoice{{}}})
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(disabledResolver()),
+	)
+	_, _ = p.Complete(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Errorf("captured %d events, want 0 (resolver said no)", len(got))
+	}
+}
+
+func TestOpenAI_Complete_NoSinkConfiguredSkipsCapture(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(oaiResponse{ID: "x", Choices: []oaiChoice{{}}})
+	}))
+	defer server.Close()
+
+	// Resolver returns enabled but no sink wired.
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugResolver(alwaysOnResolver("s", "t")),
+	)
+	_, err := p.Complete(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// No way for the test to inspect a nil sink — assertion is just "doesn't panic".
+}
+
+func TestOpenAI_Complete_CapturesNon200ResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"bad request"}`)
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("s", "t")),
+	)
+	_, err := p.Complete(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err == nil {
+		t.Error("expected error from 400 response")
+	}
+
+	events := sink.snapshot()
+	if len(events) != 2 {
+		t.Fatalf("events = %d, want 2 (request + non-200 response): %+v", len(events), events)
+	}
+	if events[1].Direction != "response" || events[1].Status != http.StatusBadRequest {
+		t.Errorf("event[1]: direction=%q status=%d, want response/400", events[1].Direction, events[1].Status)
+	}
+}
+
+func TestOpenAI_Complete_CapturesTransportError(t *testing.T) {
+	// Hand the provider a deliberately broken URL so client.Do fails.
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", "http://127.0.0.1:1", "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("s", "t")),
+	)
+
+	_, err := p.Complete(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err == nil {
+		t.Error("expected error from unreachable endpoint")
+	}
+
+	events := sink.snapshot()
+	// Expect: request (always) + error (from failed Do).
+	var sawError bool
+	for _, e := range events {
+		if e.Direction == "error" {
+			sawError = true
+			if !strings.Contains(strings.ToLower(e.Body), "connect") &&
+				!strings.Contains(strings.ToLower(e.Body), "refused") &&
+				!strings.Contains(strings.ToLower(e.Body), "dial") {
+				t.Errorf("error event body did not look like a connection error: %q", e.Body)
+			}
+		}
+	}
+	if !sawError {
+		t.Errorf("no error-direction event captured; events: %+v", events)
+	}
+}
+
+func TestOpenAI_Stream_AggregatesEndOfStreamResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}`)
+		f.Flush()
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"gpt-4o","choices":[{"index":0,"delta":{"content":" world"}}]}`)
+		f.Flush()
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"gpt-4o","usage":{"prompt_tokens":3,"completion_tokens":2}}`)
+		f.Flush()
+		_, _ = fmt.Fprintln(w, `data: [DONE]`)
+		f.Flush()
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("sess-S", "trace-S")),
+	)
+
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	for {
+		c, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		if c.Done {
+			break
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Errorf("Close: %v", err)
+	}
+
+	events := sink.snapshot()
+	// Request + aggregated streaming response.
+	if len(events) < 2 {
+		t.Fatalf("events = %d, want >=2: %+v", len(events), events)
+	}
+	last := events[len(events)-1]
+	if last.Direction != "response" {
+		t.Errorf("last event direction = %q, want response", last.Direction)
+	}
+	if last.SessionID != "sess-S" {
+		t.Errorf("last.SessionID = %q, want sess-S", last.SessionID)
+	}
+	// Aggregated body must contain both deltas + the [DONE] marker.
+	if !strings.Contains(last.Body, "Hello") || !strings.Contains(last.Body, " world") {
+		t.Errorf("aggregated body missing deltas: %q", last.Body)
+	}
+	if !strings.Contains(last.Body, "[DONE]") {
+		t.Errorf("aggregated body missing [DONE] marker: %q", last.Body)
+	}
+}
+
+func TestOpenAI_Stream_NoCaptureWhenDisabled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"x","choices":[{"index":0,"delta":{"content":"hi"}}]}`)
+		f.Flush()
+		_, _ = fmt.Fprintln(w, `data: [DONE]`)
+		f.Flush()
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(disabledResolver()),
+	)
+
+	stream, err := p.Stream(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for {
+		c, err := stream.Recv()
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		if c.Done {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	if got := sink.snapshot(); len(got) != 0 {
+		t.Errorf("disabled resolver still produced %d events: %+v", len(got), got)
+	}
+}
+
+// TestOpenAI_Stream_FlushesPartialBodyOnReadError verifies that capture
+// survives a network-level abort mid-stream: the orchestrator's deferred
+// Close() runs, onClose flushes whatever lines accumulated before the
+// error, and the response row appears in the sink with the partial body.
+func TestOpenAI_Stream_FlushesPartialBodyOnReadError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"x","choices":[{"index":0,"delta":{"content":"partial"}}]}`)
+		f.Flush()
+		// Hijack and close abruptly without sending [DONE].
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("test server does not support hijacking")
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("sess-P", "trace-P")),
+	)
+
+	stream, err := p.Stream(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Read until exhaustion (Recv may return Done because Scanner.Scan
+	// returns false on EOF without surfacing the abrupt close as an error).
+	for {
+		c, err := stream.Recv()
+		if err != nil || c.Done {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	events := sink.snapshot()
+	if len(events) < 2 {
+		t.Fatalf("events=%d, want >=2 (request+partial response)", len(events))
+	}
+	last := events[len(events)-1]
+	if last.Direction != "response" {
+		t.Errorf("last event direction = %q, want response", last.Direction)
+	}
+	if !strings.Contains(last.Body, "partial") {
+		t.Errorf("partial body lost on abort: %q", last.Body)
+	}
+}
+
+// TestOpenAI_Stream_CloseIsIdempotent ensures double Close() doesn't
+// double-flush onClose or return a use-of-closed-connection error.
+func TestOpenAI_Stream_CloseIsIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		f := w.(http.Flusher)
+		_, _ = fmt.Fprintln(w, `data: {"id":"1","model":"x","choices":[{"index":0,"delta":{"content":"hi"}}]}`)
+		f.Flush()
+		_, _ = fmt.Fprintln(w, `data: [DONE]`)
+		f.Flush()
+	}))
+	defer server.Close()
+
+	sink := &recordingSink{}
+	p := NewOpenAIProvider("openai", server.URL, "k", nil,
+		WithOpenAIDebugSink(sink),
+		WithOpenAIDebugResolver(alwaysOnResolver("s", "t")),
+	)
+	stream, err := p.Stream(context.Background(), &CompletionRequest{Model: "x", Messages: []Message{{Role: RoleUser, Content: "h"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for {
+		c, err := stream.Recv()
+		if err != nil || c.Done {
+			break
+		}
+	}
+	if err := stream.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := stream.Close(); err != nil {
+		t.Errorf("second Close should be no-op, got: %v", err)
+	}
+
+	// Exactly one response row, not two.
+	var responseRows int
+	for _, e := range sink.snapshot() {
+		if e.Direction == "response" {
+			responseRows++
+		}
+	}
+	if responseRows != 1 {
+		t.Errorf("response rows = %d, want 1 (double-Close must not double-flush)", responseRows)
+	}
+}
+
+func TestStreamAccumulator_Truncates(t *testing.T) {
+	a := &streamAccumulator{}
+	long := strings.Repeat("a", maxStreamCaptureBytes/2)
+	a.append(long)
+	a.append(long)
+	// Third append exceeds budget — must mark truncated and stop accumulating.
+	a.append(long)
+	if !a.truncated {
+		t.Error("expected truncated=true after over-budget append")
+	}
+	if !strings.Contains(string(a.buf), "[truncated") {
+		t.Error("expected truncation marker in buffer")
+	}
+	// Further appends are no-ops.
+	bufLen := len(a.buf)
+	a.append("more")
+	if len(a.buf) != bufLen {
+		t.Errorf("post-truncation append grew buffer: %d -> %d", bufLen, len(a.buf))
+	}
+}
+
+// Ensure the stub-error type used in CapturesTransportError compiles.
+var _ = errors.New

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -87,6 +87,30 @@ func (s *SessionStore) SetModel(id string, model provider.ModelRef) error {
 	return nil
 }
 
+// SetMetadata upserts a single metadata key on the session. An empty value
+// removes the key so callers can both set and clear flags through one path.
+// Used today by the set_debug_mode command to persist `debug=true` and the
+// orchestrator's per-session debug-context flag reads it on every Run().
+func (s *SessionStore) SetMetadata(id, key, value string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sess, ok := s.sessions[id]
+	if !ok {
+		return fmt.Errorf("session %q not found", id)
+	}
+	if sess.Metadata == nil {
+		sess.Metadata = make(map[string]string)
+	}
+	if value == "" {
+		delete(sess.Metadata, key)
+	} else {
+		sess.Metadata[key] = value
+	}
+	sess.UpdatedAt = time.Now()
+	return nil
+}
+
 // SetSummary updates the session summary and trims messages to the given slice (for summarization).
 func (s *SessionStore) SetSummary(id string, summary string, messages []provider.Message) error {
 	s.mu.Lock()

--- a/internal/state/store/debug_e2e_test.go
+++ b/internal/state/store/debug_e2e_test.go
@@ -1,0 +1,155 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/logger"
+	"github.com/opentalon/opentalon/internal/provider"
+)
+
+// TestEndToEnd_DebugCaptureFlowsThroughEveryLayer wires up the full chain
+// the way main.go does and exercises one request:
+//
+//  1. state-store opens (sqlite) and migration 007 creates ai_debug_events
+//  2. async writer + sessionDebugHandler installed on slog.Default
+//  3. provider.OpenAIProvider gets a sink + resolver
+//  4. ctx is decorated like orchestrator.Run does (session_id, trace_id,
+//     and the session-debug flag from metadata["debug"]=true)
+//  5. provider.Complete runs against an httptest server
+//
+// Expectations:
+//   - request and response rows land in ai_debug_events with the right
+//     session_id and trace_id
+//   - stderr (the captured slog buffer) contains an Info-level "openai
+//     raw http" record with session_debug=true even though the underlying
+//     handler is at LevelInfo (i.e. the handler promotion really fires)
+//   - a request with no session-debug flag in ctx leaves the sink empty
+//
+// This is the only test that proves all five subsystems compose. Each
+// piece has unit tests, but a refactor to any of them could silently
+// break the chain.
+func TestEndToEnd_DebugCaptureFlowsThroughEveryLayer(t *testing.T) {
+	// 1. State store + migration.
+	db := openTestDB(t)
+	debugStore := NewDebugEventStore(db)
+
+	// 2. Async writer.
+	writer := newDebugEventWriterSized(debugStore, 16)
+	writer.Start(context.Background())
+	defer writer.Stop(2 * time.Second)
+
+	// 3. Install the session-debug handler on slog.Default. Capture stderr
+	// into a buffer so we can assert the promotion happens.
+	var logBuf bytes.Buffer
+	prevDefault := slog.Default()
+	defer slog.SetDefault(prevDefault)
+	base := slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slog.SetDefault(slog.New(logger.NewSessionDebugHandler(base)))
+
+	// 4. Mock OpenAI server.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "chatcmpl-e2e",
+			"model":   "gpt-4o",
+			"choices": []map[string]any{{"index": 0, "message": map[string]string{"role": "assistant", "content": "ok"}}},
+		})
+	}))
+	defer server.Close()
+
+	// 5. Sink + resolver wired the same way main.go does.
+	sink := &writerSink{w: writer}
+	resolver := func(ctx context.Context) (string, string, bool) {
+		if !logger.IsSessionDebug(ctx) {
+			return "", "", false
+		}
+		return actor.SessionID(ctx), logger.TraceID(ctx), true
+	}
+	p := provider.NewOpenAIProvider("openai", server.URL, "k", nil,
+		provider.WithOpenAIDebugSink(sink),
+		provider.WithOpenAIDebugResolver(resolver),
+	)
+
+	// --- Path A: session WITHOUT /debug. No capture, no slog promotion. ---
+	logBuf.Reset()
+	plainCtx := actor.WithSessionID(context.Background(), "sess-quiet")
+	plainCtx = logger.WithTraceID(plainCtx, "trace-quiet")
+	if _, err := p.Complete(plainCtx, &provider.CompletionRequest{
+		Model: "gpt-4o", Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("plain Complete: %v", err)
+	}
+	if got := writer.dropped.Load(); got != 0 {
+		t.Errorf("plain path dropped %d events; want 0", got)
+	}
+	if strings.Contains(logBuf.String(), "openai raw http") {
+		t.Errorf("plain path emitted raw http to slog at Info level: %q", logBuf.String())
+	}
+	// Drain anything in flight before the assertion.
+	writer.Stop(2 * time.Second)
+	if n, _ := debugStore.CountForSession(context.Background(), "sess-quiet"); n != 0 {
+		t.Errorf("plain path produced %d rows; want 0", n)
+	}
+
+	// Restart writer for path B.
+	writer = newDebugEventWriterSized(debugStore, 16)
+	writer.Start(context.Background())
+	defer writer.Stop(2 * time.Second)
+	sink.w = writer
+
+	// --- Path B: session WITH /debug active. Full chain populates. ---
+	logBuf.Reset()
+	dbgCtx := actor.WithSessionID(context.Background(), "sess-loud")
+	dbgCtx = logger.WithTraceID(dbgCtx, "trace-loud")
+	dbgCtx = logger.WithSessionDebug(dbgCtx)
+
+	if _, err := p.Complete(dbgCtx, &provider.CompletionRequest{
+		Model: "gpt-4o", Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("debug Complete: %v", err)
+	}
+	writer.Stop(2 * time.Second)
+
+	rows, err := debugStore.CountForSession(context.Background(), "sess-loud")
+	if err != nil {
+		t.Fatalf("CountForSession: %v", err)
+	}
+	if rows != 2 {
+		t.Errorf("/debug path rows = %d, want 2 (request+response)", rows)
+	}
+	if !strings.Contains(logBuf.String(), `"openai raw http"`) {
+		t.Errorf("/debug path did not emit raw http on stderr; got: %q", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), `"session_debug":true`) {
+		t.Errorf("/debug path missing session_debug=true tag; got: %q", logBuf.String())
+	}
+	if !strings.Contains(logBuf.String(), `"level":"INFO"`) {
+		t.Errorf("/debug path slog level was not promoted to INFO; got: %q", logBuf.String())
+	}
+}
+
+// writerSink adapts the in-package DebugEventWriter to provider.DebugEventSink
+// for tests. Production wiring lives in cmd/opentalon/main.go but that's
+// behind the binary; the adapter pattern is so trivial it's worth a tiny
+// duplicate here to keep the e2e test self-contained.
+type writerSink struct{ w *DebugEventWriter }
+
+func (s *writerSink) Submit(_ context.Context, e provider.DebugEvent) {
+	s.w.Submit(DebugEvent{
+		SessionID: e.SessionID,
+		TraceID:   e.TraceID,
+		Direction: e.Direction,
+		Status:    e.Status,
+		URL:       e.URL,
+		Body:      e.Body,
+		Timestamp: e.Timestamp,
+	})
+}

--- a/internal/state/store/debug_events.go
+++ b/internal/state/store/debug_events.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// DebugEvent is one captured LLM-endpoint exchange.
+//
+// Direction is one of "request", "response", "error". Body is JSON text when
+// the captured payload was JSON (typically request and non-streaming response
+// bodies); for streaming responses the orchestrator writes a single
+// accumulated row at end-of-stream. Error rows carry the failure reason in
+// Body and Status=0.
+//
+// URL is informational — debug capture is OpenAI-endpoint-scoped so URL is
+// always the configured OpenAI completions URL; storing it makes audit
+// dashboards self-explanatory and allows pointing the same plumbing at
+// additional providers later without a schema change.
+type DebugEvent struct {
+	SessionID string
+	TraceID   string
+	Direction string // "request" | "response" | "error"
+	Status    int    // HTTP status when known; 0 for request and error rows
+	URL       string
+	Body      string // raw JSON text or, for error rows, "Class: message"
+	Timestamp time.Time
+}
+
+// DebugEventStore persists per-session LLM-endpoint debug events. The table
+// is intentionally append-only (no updates); retention is handled by Prune.
+type DebugEventStore struct {
+	db *DB
+}
+
+// NewDebugEventStore returns a store backed by db. The schema is created by
+// migration 007 and supports both SQLite and PostgreSQL.
+func NewDebugEventStore(db *DB) *DebugEventStore {
+	return &DebugEventStore{db: db}
+}
+
+// Insert appends one event. Caller is expected to fan in writes through the
+// async-writer goroutine (see debug_writer.go) so the LLM hot-path is never
+// blocked on the database.
+func (s *DebugEventStore) Insert(ctx context.Context, e DebugEvent) error {
+	id, err := newDebugEventID()
+	if err != nil {
+		return fmt.Errorf("debug event id: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	ts := e.Timestamp.UTC().Format(time.RFC3339Nano)
+	if e.Timestamp.IsZero() {
+		ts = now
+	}
+	d := s.db.Dialect()
+	_, err = s.db.SQLDB().ExecContext(ctx, d.Rebind(
+		`INSERT INTO ai_debug_events (id, session_id, trace_id, ts, direction, status, url, body, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		id, e.SessionID, e.TraceID, ts, e.Direction, e.Status, e.URL, e.Body, now)
+	if err != nil {
+		return fmt.Errorf("debug event insert: %w", err)
+	}
+	return nil
+}
+
+// Prune deletes rows older than maxAge. Returns the number of rows removed.
+// Safe to call concurrently with Insert; both run on independent connections
+// from the pool.
+func (s *DebugEventStore) Prune(ctx context.Context, maxAge time.Duration) (int64, error) {
+	if maxAge <= 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().Add(-maxAge).UTC().Format(time.RFC3339Nano)
+	d := s.db.Dialect()
+	res, err := s.db.SQLDB().ExecContext(ctx,
+		d.Rebind(`DELETE FROM ai_debug_events WHERE ts < ?`), cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("debug event prune: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// CountForSession returns how many events were captured for a session.
+// Used by the set_debug_mode "status" reply so users can see the table is
+// actually filling.
+func (s *DebugEventStore) CountForSession(ctx context.Context, sessionID string) (int64, error) {
+	var n int64
+	err := s.db.SQLDB().QueryRowContext(ctx,
+		s.db.Dialect().Rebind(`SELECT COUNT(*) FROM ai_debug_events WHERE session_id = ?`),
+		sessionID,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("debug event count: %w", err)
+	}
+	return n, nil
+}
+
+// newDebugEventID generates a 32-char hex id. We don't use bigserial because
+// the schema is portable across SQLite and PostgreSQL — see migration 007.
+func newDebugEventID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/internal/state/store/debug_events_test.go
+++ b/internal/state/store/debug_events_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/config"
+)
+
+func openTestDB(t *testing.T) *DB {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := Open(config.DBConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func TestDebugEventStore_InsertAndCount(t *testing.T) {
+	db := openTestDB(t)
+	store := NewDebugEventStore(db)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		err := store.Insert(ctx, DebugEvent{
+			SessionID: "sess-A",
+			TraceID:   "trace-A",
+			Direction: "request",
+			URL:       "https://example.invalid/v1/chat/completions",
+			Body:      `{"model":"x"}`,
+			Timestamp: time.Now(),
+		})
+		if err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+	// One event for a different session — must not be counted.
+	_ = store.Insert(ctx, DebugEvent{SessionID: "sess-B", Direction: "response", Body: "{}"})
+
+	n, err := store.CountForSession(ctx, "sess-A")
+	if err != nil {
+		t.Fatalf("CountForSession: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("CountForSession(sess-A) = %d, want 3", n)
+	}
+	n, _ = store.CountForSession(ctx, "sess-B")
+	if n != 1 {
+		t.Errorf("CountForSession(sess-B) = %d, want 1", n)
+	}
+	n, _ = store.CountForSession(ctx, "nonexistent")
+	if n != 0 {
+		t.Errorf("CountForSession(nonexistent) = %d, want 0", n)
+	}
+}
+
+func TestDebugEventStore_Prune(t *testing.T) {
+	db := openTestDB(t)
+	store := NewDebugEventStore(db)
+	ctx := context.Background()
+
+	old := time.Now().Add(-48 * time.Hour)
+	fresh := time.Now().Add(-1 * time.Minute)
+
+	// Insert one old, one fresh.
+	if err := store.Insert(ctx, DebugEvent{SessionID: "s", Direction: "request", Body: "{}", Timestamp: old}); err != nil {
+		t.Fatalf("Insert old: %v", err)
+	}
+	if err := store.Insert(ctx, DebugEvent{SessionID: "s", Direction: "response", Body: "{}", Timestamp: fresh}); err != nil {
+		t.Fatalf("Insert fresh: %v", err)
+	}
+
+	// Prune everything older than 24h.
+	deleted, err := store.Prune(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("Prune deleted %d, want 1", deleted)
+	}
+
+	n, _ := store.CountForSession(ctx, "s")
+	if n != 1 {
+		t.Errorf("post-prune count = %d, want 1", n)
+	}
+
+	// Prune with retention=0 is a no-op (caller signals "disabled").
+	deleted, err = store.Prune(ctx, 0)
+	if err != nil {
+		t.Fatalf("Prune(0): %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("Prune(0) deleted %d, want 0 (retention disabled)", deleted)
+	}
+}
+
+func TestDebugEventStore_DefaultsTimestamp(t *testing.T) {
+	db := openTestDB(t)
+	store := NewDebugEventStore(db)
+	ctx := context.Background()
+
+	// Insert without explicit Timestamp — store should fill in now.
+	if err := store.Insert(ctx, DebugEvent{SessionID: "s", Direction: "request", Body: "{}"}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	n, _ := store.CountForSession(ctx, "s")
+	if n != 1 {
+		t.Errorf("count = %d, want 1", n)
+	}
+}

--- a/internal/state/store/debug_retention.go
+++ b/internal/state/store/debug_retention.go
@@ -1,0 +1,56 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RunDebugRetention prunes ai_debug_events rows older than retention on a
+// daily schedule. Runs an immediate prune on start so a freshly-rotated pod
+// catches up rather than waiting up to 24h.
+//
+// retention <= 0 disables pruning entirely — the caller (main.go) maps the
+// explicit DebugConfig.RetentionDisabled flag into this. Treating zero as
+// "disabled" here is intentional API simplicity: callers either pass a
+// positive duration or pass zero. The "0 days means 30 days" UX trick stays
+// at the config layer where users meet it.
+//
+// We don't use pg_cron or pg_partman: the retention policy is a single
+// DELETE-by-timestamp, doable in milliseconds at the volumes this table is
+// designed for, and keeping the logic in process means SQLite deployments
+// (dev / single-node) get the same behavior as production Postgres without
+// extension dependencies.
+//
+// Cancellation: returns when ctx is cancelled. Stop() on the writer is a
+// separate concern handled in main.go.
+func RunDebugRetention(ctx context.Context, store *DebugEventStore, retention time.Duration) {
+	if retention <= 0 {
+		slog.Info("debug retention disabled")
+		return
+	}
+	prune := func() {
+		pruneCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		n, err := store.Prune(pruneCtx, retention)
+		if err != nil {
+			slog.Warn("debug retention prune failed", "error", err)
+			return
+		}
+		if n > 0 {
+			slog.Info("debug retention prune", "rows_deleted", n, "retention", retention)
+		}
+	}
+
+	prune()
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			prune()
+		}
+	}
+}

--- a/internal/state/store/debug_writer.go
+++ b/internal/state/store/debug_writer.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// DebugEventWriter buffers debug events on a bounded channel and drains them
+// through a single background goroutine. The LLM hot-path calls Submit, which
+// is non-blocking: when the channel is full, the event is dropped and a
+// counter is bumped so we can warn periodically without flooding logs.
+//
+// Why a buffer + drop policy: the alternative — synchronous writes from
+// inside the OpenAI request/response path — would couple LLM latency to the
+// state-store's tail latency, and a slow Postgres flush could stall every
+// agent loop. Writes happen at human conversation rate (~ <1 per second
+// per active session), so a small buffer (cap 100) and a single worker keep
+// per-session event order intact while shielding the hot path entirely.
+type DebugEventWriter struct {
+	store    *DebugEventStore
+	ch       chan DebugEvent
+	dropped  atomic.Int64
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// debugWriterBufferSize is intentionally hardcoded. /debug is opt-in per
+// session and the worker drains at ~1k inserts/s on Postgres — 100 is
+// plenty for any realistic concurrent-debug-session load, and exposing a
+// knob nobody will turn is just configuration surface area to maintain.
+const debugWriterBufferSize = 100
+
+// NewDebugEventWriter constructs a writer. The caller must call Start()
+// once and Stop() during shutdown.
+func NewDebugEventWriter(store *DebugEventStore) *DebugEventWriter {
+	return newDebugEventWriterSized(store, debugWriterBufferSize)
+}
+
+// newDebugEventWriterSized is the test-internal constructor that lets
+// drop-policy and flush tests pin a tiny buffer; production code uses
+// NewDebugEventWriter with the constant.
+func newDebugEventWriterSized(store *DebugEventStore, bufferSize int) *DebugEventWriter {
+	if bufferSize <= 0 {
+		bufferSize = debugWriterBufferSize
+	}
+	return &DebugEventWriter{
+		store: store,
+		ch:    make(chan DebugEvent, bufferSize),
+		done:  make(chan struct{}),
+	}
+}
+
+// Start launches the worker goroutine. It returns immediately. The worker
+// runs until Stop() is called, draining any events still in the buffer
+// before exiting. Drop counters are reported every reportEvery batches so
+// dashboards see the pressure without each individual drop generating a
+// log line.
+func (w *DebugEventWriter) Start(ctx context.Context) {
+	go w.run(ctx)
+}
+
+// Submit enqueues e for asynchronous insert. Never blocks — if the buffer is
+// full the event is dropped and the dropped-counter is bumped.
+func (w *DebugEventWriter) Submit(e DebugEvent) {
+	select {
+	case w.ch <- e:
+	default:
+		n := w.dropped.Add(1)
+		// Warn once per power-of-two so the first drop is visible and large
+		// drop bursts do not flood logs.
+		if n == 1 || n&(n-1) == 0 {
+			slog.Warn("debug event buffer full, dropping",
+				"session_id", e.SessionID,
+				"direction", e.Direction,
+				"total_dropped", n,
+			)
+		}
+	}
+}
+
+// Stop flushes the buffer and stops the worker. Safe to call multiple times.
+// Shutdown waits up to flushTimeout for in-flight events to be persisted.
+func (w *DebugEventWriter) Stop(flushTimeout time.Duration) {
+	w.stopOnce.Do(func() {
+		close(w.ch)
+		select {
+		case <-w.done:
+		case <-time.After(flushTimeout):
+			slog.Warn("debug event writer flush timeout exceeded", "timeout", flushTimeout)
+		}
+	})
+}
+
+// Dropped returns the cumulative number of events dropped since process start.
+func (w *DebugEventWriter) Dropped() int64 { return w.dropped.Load() }
+
+func (w *DebugEventWriter) run(ctx context.Context) {
+	defer close(w.done)
+	for e := range w.ch {
+		// Use a short per-insert timeout so a stalled DB doesn't block
+		// shutdown forever. Errors are logged but never returned —
+		// debug capture is best-effort and must never propagate up.
+		insertCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := w.store.Insert(insertCtx, e); err != nil {
+			slog.Warn("debug event insert failed",
+				"session_id", e.SessionID,
+				"direction", e.Direction,
+				"error", err,
+			)
+		}
+		cancel()
+	}
+}

--- a/internal/state/store/debug_writer_test.go
+++ b/internal/state/store/debug_writer_test.go
@@ -1,0 +1,70 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestDebugEventWriter_FlushesAllOnStop is the happy path: events sent
+// during normal operation reach the underlying store before Stop returns.
+func TestDebugEventWriter_FlushesAllOnStop(t *testing.T) {
+	db := openTestDB(t)
+	store := NewDebugEventStore(db)
+	w := newDebugEventWriterSized(store, 10)
+	w.Start(context.Background())
+
+	for i := 0; i < 5; i++ {
+		w.Submit(DebugEvent{SessionID: "sess", Direction: "request", Body: "{}"})
+	}
+	w.Stop(2 * time.Second)
+
+	n, err := store.CountForSession(context.Background(), "sess")
+	if err != nil {
+		t.Fatalf("CountForSession: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("flushed count = %d, want 5", n)
+	}
+	if w.Dropped() != 0 {
+		t.Errorf("Dropped = %d, want 0 (buffer was sized for the load)", w.Dropped())
+	}
+}
+
+// TestDebugEventWriter_DropsOnFullBuffer drives the channel past capacity
+// before the worker can drain it. The drop counter must go up and the
+// per-row count in the store stays bounded by what got through.
+func TestDebugEventWriter_DropsOnFullBuffer(t *testing.T) {
+	db := openTestDB(t)
+	store := NewDebugEventStore(db)
+	// Tiny buffer; do not Start so nothing drains until we submit a flood.
+	w := newDebugEventWriterSized(store, 2)
+
+	// Submit 10 events without a worker — only 2 fit in the buffer; the
+	// other 8 must be dropped.
+	for i := 0; i < 10; i++ {
+		w.Submit(DebugEvent{SessionID: "sess", Direction: "request", Body: "{}"})
+	}
+	if got := w.Dropped(); got != 8 {
+		t.Errorf("Dropped = %d, want 8", got)
+	}
+
+	// Start the worker now and let it drain; Stop should empty the channel.
+	w.Start(context.Background())
+	w.Stop(2 * time.Second)
+	n, _ := store.CountForSession(context.Background(), "sess")
+	if n != 2 {
+		t.Errorf("post-flush count = %d, want 2 (8 were dropped before worker ran)", n)
+	}
+}
+
+// TestDebugEventWriter_StopIsIdempotent ensures multiple Stop calls do not
+// panic on a closed channel.
+func TestDebugEventWriter_StopIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	w := newDebugEventWriterSized(NewDebugEventStore(db), 4)
+	w.Start(context.Background())
+	w.Stop(time.Second)
+	w.Stop(time.Second)
+	w.Stop(time.Second)
+}

--- a/internal/state/store/migrations/007_ai_debug_events.sql
+++ b/internal/state/store/migrations/007_ai_debug_events.sql
@@ -1,0 +1,29 @@
+-- Per-session deep debug capture. Populated only when a session's metadata
+-- carries debug=true (toggled via the set_debug_mode action). Each row holds
+-- one raw HTTP exchange between OpenTalon and the LLM endpoint (request /
+-- response / error), with body kept as JSON text for after-the-fact replay
+-- and diffing against parallel implementations.
+--
+-- Rows are pruned after debug.retention_days (default 30) by a background
+-- worker started in cmd/opentalon. Volume is intentionally bounded by
+-- session-level opt-in — without an active /debug session this table stays
+-- empty.
+--
+-- Schema is portable across SQLite and PostgreSQL: TEXT for ids/timestamps/
+-- bodies, INTEGER for status. Postgres-native shapes (jsonb / GIN / generated
+-- columns) are deliberately avoided so the same migration runs on both
+-- dialects and so debug-data inspection is just `SELECT body FROM ...` —
+-- no jsonb-path queries assumed.
+CREATE TABLE IF NOT EXISTS ai_debug_events (
+  id          TEXT NOT NULL PRIMARY KEY,
+  session_id  TEXT NOT NULL,
+  trace_id    TEXT NOT NULL,
+  ts          TEXT NOT NULL,
+  direction   TEXT NOT NULL,
+  status      INTEGER,
+  url         TEXT,
+  body        TEXT NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_ai_debug_events_session_ts ON ai_debug_events(session_id, ts);
+CREATE INDEX IF NOT EXISTS idx_ai_debug_events_ts ON ai_debug_events(ts);

--- a/internal/state/store/session.go
+++ b/internal/state/store/session.go
@@ -132,6 +132,52 @@ func (s *SessionStore) SetModel(id string, model provider.ModelRef) error {
 	return nil
 }
 
+// SetMetadata upserts a single key in the session's metadata JSON column. An
+// empty value removes the key. The whole map is read, mutated in memory, and
+// written back in one transaction — debug-toggle traffic is rare (one row per
+// /debug command), so the simpler read-modify-write loses nothing here and
+// avoids a JSON-merge UDF that would only work on one dialect.
+func (s *SessionStore) SetMetadata(id, key, value string) error {
+	ctx := context.Background()
+	d := s.db.Dialect()
+
+	tx, cleanup, err := d.BeginExclusive(ctx, s.db.SQLDB())
+	if err != nil {
+		return fmt.Errorf("set metadata begin: %w", err)
+	}
+	defer cleanup()
+	defer func() { _ = tx.Rollback() }()
+
+	var mdJSON string
+	err = tx.QueryRowContext(ctx,
+		d.Rebind(`SELECT COALESCE(metadata,'{}') FROM sessions WHERE id = ?`+d.ForUpdate()),
+		id,
+	).Scan(&mdJSON)
+	if err != nil {
+		return fmt.Errorf("set metadata select: %w", err)
+	}
+	md := map[string]string{}
+	if mdJSON != "" {
+		_ = json.Unmarshal([]byte(mdJSON), &md)
+	}
+	if value == "" {
+		delete(md, key)
+	} else {
+		md[key] = value
+	}
+	updated, err := json.Marshal(md)
+	if err != nil {
+		return fmt.Errorf("set metadata marshal: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := tx.ExecContext(ctx,
+		d.Rebind(`UPDATE sessions SET metadata = ?, updated_at = ? WHERE id = ?`),
+		string(updated), now, id); err != nil {
+		return fmt.Errorf("set metadata update: %w", err)
+	}
+	return tx.Commit()
+}
+
 // SetSummary updates the session summary and replaces messages with the given slice.
 func (s *SessionStore) SetSummary(id string, summary string, messages []provider.Message) error {
 	ctx := context.Background()

--- a/internal/state/store/store_test.go
+++ b/internal/state/store/store_test.go
@@ -25,8 +25,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != 6 {
-		t.Errorf("schema_version = %d, want 6", v)
+	if v != 7 {
+		t.Errorf("schema_version = %d, want 7", v)
 	}
 
 	// Re-open: idempotent, no error
@@ -39,8 +39,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version (second open): %v", err)
 	}
-	if v != 6 {
-		t.Errorf("schema_version after re-open = %d, want 6", v)
+	if v != 7 {
+		t.Errorf("schema_version after re-open = %d, want 7", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

Toggling `/debug` on a session causes every subsequent LLM exchange in that session to be emitted on stderr at INFO and persisted to a new `ai_debug_events` table (default 30 days retention, configurable). Other sessions stay quiet at the configured `LOG_LEVEL` — no global verbosity bump.

Replaces the global `LOG_LEVEL`-gated raw-http logging from #205 with a per-session pathway. One mechanism instead of two.

## How it works

1. `set_debug_mode` action (the LLM-routed `/debug` slash command) sets `session.Metadata["debug"]=true`. Resurrects the previously inert `SetMetadata` path on the session interface.
2. `orchestrator.Run()` reads the flag once per turn and stamps a ctx marker via `logger.WithSessionDebug`.
3. New `sessionDebugHandler` wrapper around `JSONHandler` promotes Debug→Info records carrying that marker (other ctx unaffected).
4. `OpenAIProvider` gains `(DebugEventSink, DebugContextResolver)` options. When both are wired and the resolver returns enabled, raw request/response/error bodies are submitted to the sink. Streaming responses are aggregated inside `oaiResponseStream` so end-of-stream produces one row, not N chunks.
5. Sink is implemented by an async writer (bounded channel cap 100, drop policy, power-of-two warnings) so the LLM hot path never blocks on the database.
6. Daily retention worker prunes rows older than `state.debug.retention_days` (default 30); explicit `state.debug.retention_disabled` for the off-switch.

## Schema

Dialect-portable (TEXT for ids/json/timestamps, B-tree indexes) so SQLite and PostgreSQL deployments share migration 007 without `jsonb` / `GIN` / `GENERATED` postgres-specific features.

## Test coverage

- Unit tests for each component (`sessionDebugHandler`, `DebugEventStore`, `DebugEventWriter` incl. drop policy, `set_debug_mode` action, `oaiResponseStream` capture incl. mid-stream abort + double-Close idempotency)
- **End-to-end test** (`TestEndToEnd_DebugCaptureFlowsThroughEveryLayer`) wires up the full chain like `main.go` does and verifies rows appear in `ai_debug_events` AND stderr emits `session_debug=true` Info-level records — covers the multi-layer wiring path which is the most fragile part.

## Privacy / GDPR note

`ai_debug_events` stores raw request/response bodies (system prompt + user message + tool outputs in plaintext). The 30-day default reflects this. The parallel `messages` table is intentionally uncapped (`state.session.max_idle_days` defaults to 0) — required for downstream Rails-app billing. Two policies, two tables, by design.

The `api-plugin` (`db_access: true` in production) can technically read this table since it gets the same DSN injected. Today it does not enumerate tables, but if a generic SQL endpoint is ever added there, `ai_debug_events` should be on a deny-list.

## Activation in production (after merge)

```yaml
# gitops opentalon-configmap.yaml (separate PR after this lands)
state:
  debug:
    retention_days: 30          # configurable; default 30
    # retention_disabled: true  # explicit off-switch (default false)
  # session.max_idle_days intentionally unset (0 = forever) — required for billing
```

User toggles with `/debug` (or `/debug on`, `/debug off`, `/debug status`). `kubectl logs -f opentalon-0 | jq 'select(.session_debug==true)'` tails captured traffic for the active sessions.

## Test plan

- [ ] `go test ./...` passes (31 packages, 0 failures)
- [ ] `golangci-lint run ./...` clean (verified locally)
- [ ] Manual: enable `/debug` on a session, send a message, verify a row appears in `ai_debug_events` and a `session_debug=true` record on stderr
- [ ] Manual: with debug off (default), verify no rows are written and no extra stderr noise
- [ ] Manual: `/debug status` shows captured row count when enabled
- [ ] Manual: SQLite path (no `db.driver: postgres`) still builds and runs without persistence (slog-only debug mode)

## Follow-ups

- gitops PR: add `state.debug.retention_days: 30` to the configmap, flip `log.level: debug → info` (no longer needed globally), drop the dead `log.file:` key.