### PR TITLE
refactor: simplify per-session debug capture

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -815,7 +815,7 @@ type providerDebugSink struct {
 	writer *store.DebugEventWriter
 }
 
-func (s *providerDebugSink) Submit(ctx context.Context, e provider.DebugEvent) {
+func (s *providerDebugSink) Submit(_ context.Context, e provider.DebugEvent) {
 	s.writer.Submit(store.DebugEvent{
 		SessionID: e.SessionID,
 		TraceID:   e.TraceID,

--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -433,37 +433,25 @@ func (e *Executor) setDebugMode(ctx context.Context, call orchestrator.ToolCall)
 		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("persist debug flag: %v", err)}
 	}
 
+	// Reply is honest about persistence: the counter being non-nil is the
+	// proxy for "state store + async writer are wired", so sessions that
+	// only get console promotion say so explicitly instead of promising a
+	// table that's not being written.
+	persistenceWired := e.debugEventCounter != nil
 	if enable {
-		return orchestrator.ToolResult{
-			CallID:  call.ID,
-			Content: "Debug mode ON. " + e.debugCaptureScopeText() + " Send /debug off to stop.",
+		body := "Debug mode ON. The next LLM exchange will be logged at INFO level on stderr"
+		if persistenceWired {
+			body += " and persisted to the ai_debug_events table."
+		} else {
+			body += " (no state store configured, so events are not persisted)."
 		}
+		return orchestrator.ToolResult{CallID: call.ID, Content: body + " Send /debug off to stop."}
 	}
-	return orchestrator.ToolResult{
-		CallID:  call.ID,
-		Content: "Debug mode OFF." + e.debugRetentionTrailerText(),
+	body := "Debug mode OFF."
+	if persistenceWired {
+		body += " Already-captured events stay in ai_debug_events until they age out."
 	}
-}
-
-// debugCaptureScopeText describes what /debug-on actually captures, honest
-// about whether persistence is wired. The Counter being non-nil is the
-// proxy for "state-store + async writer are configured" — sessions that
-// only get console promotion say so explicitly.
-func (e *Executor) debugCaptureScopeText() string {
-	if e.debugEventCounter == nil {
-		return "The next LLM exchange will be logged at INFO level on stderr (no state store configured, so events are not persisted)."
-	}
-	return "The next LLM exchange will be logged at INFO level on stderr and persisted to the ai_debug_events table."
-}
-
-// debugRetentionTrailerText is the second sentence of the OFF reply: only
-// meaningful when persistence is wired, otherwise omitted to avoid the
-// false promise of historical retention.
-func (e *Executor) debugRetentionTrailerText() string {
-	if e.debugEventCounter == nil {
-		return ""
-	}
-	return " Already-captured events stay in ai_debug_events until they age out."
+	return orchestrator.ToolResult{CallID: call.ID, Content: body}
 }
 
 func (e *Executor) debugStatusReply(ctx context.Context, callID, sessionID string, on bool) orchestrator.ToolResult {

--- a/internal/commands/set_debug_mode_test.go
+++ b/internal/commands/set_debug_mode_test.go
@@ -9,12 +9,10 @@ import (
 	"github.com/opentalon/opentalon/internal/state"
 )
 
-// stubCounter satisfies DebugEventCounter for status-reply tests.
-type stubCounter struct{ n int64 }
+// counterFunc adapts a plain func to DebugEventCounter for status-reply tests.
+type counterFunc func() (int64, error)
 
-func (s *stubCounter) CountForSession(ctx context.Context, _ string) (int64, error) {
-	return s.n, nil
-}
+func (f counterFunc) CountForSession(_ context.Context, _ string) (int64, error) { return f() }
 
 func newDebugTestExecutor(t *testing.T) (*Executor, *state.SessionStore) {
 	t.Helper()
@@ -100,7 +98,7 @@ func TestSetDebugMode_ExplicitOnOff(t *testing.T) {
 
 func TestSetDebugMode_StatusWithCounter(t *testing.T) {
 	exec, sessions := newDebugTestExecutor(t)
-	exec.WithDebugEventCounter(&stubCounter{n: 7})
+	exec.WithDebugEventCounter(counterFunc(func() (int64, error) { return 7, nil }))
 
 	// Turn debug on first.
 	_ = exec.Execute(context.Background(), orchestrator.ToolCall{

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -276,23 +276,22 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	// ai_debug_events table. Tagged "openai raw http" + direction so a
 	// single `kubectl logs -f | jq 'select(.msg=="openai raw http")'`
 	// covers both request and response.
-	url := p.baseURL + openAICompletionsPath
-	p.captureRawHTTP(ctx, "request", url, 0, body)
+	p.captureRawHTTP(ctx, "request", 0, body, nil)
 
 	httpResp, err := p.client.Do(httpReq)
 	if err != nil {
-		p.captureRawHTTPError(ctx, url, err)
+		p.captureRawHTTP(ctx, "error", 0, nil, err)
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
 
 	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
-		p.captureRawHTTPError(ctx, url, err)
+		p.captureRawHTTP(ctx, "error", 0, nil, err)
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
-	p.captureRawHTTP(ctx, "response", url, httpResp.StatusCode, respBody)
+	p.captureRawHTTP(ctx, "response", httpResp.StatusCode, respBody, nil)
 
 	if httpResp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
@@ -392,21 +391,20 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 	// Request is captured the same way as in the non-streaming path; the
 	// streaming response is captured at end-of-stream by the accumulator
 	// inside oaiResponseStream.
-	url := p.baseURL + openAICompletionsPath
-	p.captureRawHTTP(ctx, "request", url, 0, body)
+	p.captureRawHTTP(ctx, "request", 0, body, nil)
 
 	// Use a client without timeout for streaming; context handles cancellation.
 	streamClient := &http.Client{}
 	httpResp, err := streamClient.Do(httpReq)
 	if err != nil {
-		p.captureRawHTTPError(ctx, url, err)
+		p.captureRawHTTP(ctx, "error", 0, nil, err)
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 
 	if httpResp.StatusCode != http.StatusOK {
 		defer func() { _ = httpResp.Body.Close() }()
 		respBody, _ := io.ReadAll(httpResp.Body)
-		p.captureRawHTTP(ctx, "response", url, httpResp.StatusCode, respBody)
+		p.captureRawHTTP(ctx, "response", httpResp.StatusCode, respBody, nil)
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
 	}
 
@@ -416,26 +414,10 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 	}
 	// Wire end-of-stream capture only when this session opted in. Sessions
 	// without /debug get the lighter struct without the buffer.
-	if sessionID, traceID, ok := p.resolveDebug(ctx); ok {
+	if _, _, ok := p.resolveDebug(ctx); ok {
 		stream.accumulator = &streamAccumulator{}
-		sink := p.debugSink
 		stream.onClose = func(rawBody []byte) {
-			sink.Submit(ctx, DebugEvent{
-				SessionID: sessionID,
-				TraceID:   traceID,
-				Direction: "response",
-				Status:    httpResp.StatusCode,
-				URL:       url,
-				Body:      string(rawBody),
-				Timestamp: time.Now().UTC(),
-			})
-			slog.DebugContext(ctx, "openai raw http",
-				"direction", "response",
-				"url", url,
-				"status", httpResp.StatusCode,
-				"body", rawJSONOrString(rawBody),
-				"streaming", true,
-			)
+			p.captureRawHTTP(ctx, "response", httpResp.StatusCode, rawBody, nil)
 		}
 	}
 	return stream, nil
@@ -608,44 +590,40 @@ func rawJSONOrString(body []byte) any {
 // Persistence is gated on resolveDebug() reporting enabled=true so non-debug
 // sessions cost nothing beyond the slog call (which itself short-circuits
 // when the level filters it out).
-func (p *OpenAIProvider) captureRawHTTP(ctx context.Context, direction, url string, status int, body []byte) {
-	slog.DebugContext(ctx, "openai raw http",
-		"direction", direction,
-		"url", url,
-		"status", status,
-		"body", rawJSONOrString(body),
-	)
+//
+// captureErr is non-nil for transport / read failures (DNS, dial, body
+// read aborts); in that case direction is forced to "error" and body is
+// ignored — the failure class+message become the captured Body so /debug
+// histories show the failure inline with successful exchanges.
+func (p *OpenAIProvider) captureRawHTTP(ctx context.Context, direction string, status int, body []byte, captureErr error) {
+	url := p.baseURL + openAICompletionsPath
+	if captureErr == nil {
+		slog.DebugContext(ctx, "openai raw http",
+			"direction", direction,
+			"url", url,
+			"status", status,
+			"body", rawJSONOrString(body),
+		)
+	}
 	sessionID, traceID, ok := p.resolveDebug(ctx)
 	if !ok {
 		return
 	}
-	p.debugSink.Submit(ctx, DebugEvent{
+	rec := DebugEvent{
 		SessionID: sessionID,
 		TraceID:   traceID,
 		Direction: direction,
 		Status:    status,
 		URL:       url,
-		Body:      string(body),
 		Timestamp: time.Now().UTC(),
-	})
-}
-
-// captureRawHTTPError records a non-HTTP failure (DNS, dial, marshalling,
-// stream-read aborts) so /debug session histories show the failure in the
-// same row stream as successful exchanges.
-func (p *OpenAIProvider) captureRawHTTPError(ctx context.Context, url string, err error) {
-	sessionID, traceID, ok := p.resolveDebug(ctx)
-	if !ok {
-		return
 	}
-	p.debugSink.Submit(ctx, DebugEvent{
-		SessionID: sessionID,
-		TraceID:   traceID,
-		Direction: "error",
-		URL:       url,
-		Body:      fmt.Sprintf("%T: %s", err, err.Error()),
-		Timestamp: time.Now().UTC(),
-	})
+	if captureErr != nil {
+		rec.Direction = "error"
+		rec.Body = fmt.Sprintf("%T: %s", captureErr, captureErr.Error())
+	} else {
+		rec.Body = string(body)
+	}
+	p.debugSink.Submit(ctx, rec)
 }
 
 // nativeArgToString converts a JSON-decoded value to a string suitable for

--- a/internal/state/store/debug_e2e_test.go
+++ b/internal/state/store/debug_e2e_test.go
@@ -43,7 +43,7 @@ func TestEndToEnd_DebugCaptureFlowsThroughEveryLayer(t *testing.T) {
 	debugStore := NewDebugEventStore(db)
 
 	// 2. Async writer.
-	writer := newDebugEventWriterSized(debugStore, 16)
+	writer := NewDebugEventWriter(debugStore)
 	writer.Start(context.Background())
 	defer writer.Stop(2 * time.Second)
 
@@ -100,7 +100,7 @@ func TestEndToEnd_DebugCaptureFlowsThroughEveryLayer(t *testing.T) {
 	}
 
 	// Restart writer for path B.
-	writer = newDebugEventWriterSized(debugStore, 16)
+	writer = NewDebugEventWriter(debugStore)
 	writer.Start(context.Background())
 	defer writer.Stop(2 * time.Second)
 	sink.w = writer

--- a/internal/state/store/debug_events_test.go
+++ b/internal/state/store/debug_events_test.go
@@ -29,7 +29,6 @@ func TestDebugEventStore_InsertAndCount(t *testing.T) {
 			SessionID: "sess-A",
 			TraceID:   "trace-A",
 			Direction: "request",
-			URL:       "https://example.invalid/v1/chat/completions",
 			Body:      `{"model":"x"}`,
 			Timestamp: time.Now(),
 		})

--- a/internal/state/store/debug_writer.go
+++ b/internal/state/store/debug_writer.go
@@ -27,28 +27,14 @@ type DebugEventWriter struct {
 	done     chan struct{}
 }
 
-// debugWriterBufferSize is intentionally hardcoded. /debug is opt-in per
-// session and the worker drains at ~1k inserts/s on Postgres — 100 is
-// plenty for any realistic concurrent-debug-session load, and exposing a
-// knob nobody will turn is just configuration surface area to maintain.
-const debugWriterBufferSize = 100
-
-// NewDebugEventWriter constructs a writer. The caller must call Start()
-// once and Stop() during shutdown.
+// NewDebugEventWriter constructs a writer with a buffer cap of 100 — plenty
+// for any realistic /debug load (opt-in per session, worker drains at
+// ~1k/s on Postgres). The caller must call Start() once and Stop() during
+// shutdown.
 func NewDebugEventWriter(store *DebugEventStore) *DebugEventWriter {
-	return newDebugEventWriterSized(store, debugWriterBufferSize)
-}
-
-// newDebugEventWriterSized is the test-internal constructor that lets
-// drop-policy and flush tests pin a tiny buffer; production code uses
-// NewDebugEventWriter with the constant.
-func newDebugEventWriterSized(store *DebugEventStore, bufferSize int) *DebugEventWriter {
-	if bufferSize <= 0 {
-		bufferSize = debugWriterBufferSize
-	}
 	return &DebugEventWriter{
 		store: store,
-		ch:    make(chan DebugEvent, bufferSize),
+		ch:    make(chan DebugEvent, 100),
 		done:  make(chan struct{}),
 	}
 }

--- a/internal/state/store/debug_writer_test.go
+++ b/internal/state/store/debug_writer_test.go
@@ -11,7 +11,7 @@ import (
 func TestDebugEventWriter_FlushesAllOnStop(t *testing.T) {
 	db := openTestDB(t)
 	store := NewDebugEventStore(db)
-	w := newDebugEventWriterSized(store, 10)
+	w := NewDebugEventWriter(store)
 	w.Start(context.Background())
 
 	for i := 0; i < 5; i++ {
@@ -31,30 +31,31 @@ func TestDebugEventWriter_FlushesAllOnStop(t *testing.T) {
 	}
 }
 
-// TestDebugEventWriter_DropsOnFullBuffer drives the channel past capacity
-// before the worker can drain it. The drop counter must go up and the
-// per-row count in the store stays bounded by what got through.
+// TestDebugEventWriter_DropsOnFullBuffer drives the channel past the
+// hardcoded capacity before the worker can drain it. The drop counter
+// must go up and the per-row count in the store stays bounded by what
+// got through.
 func TestDebugEventWriter_DropsOnFullBuffer(t *testing.T) {
 	db := openTestDB(t)
 	store := NewDebugEventStore(db)
-	// Tiny buffer; do not Start so nothing drains until we submit a flood.
-	w := newDebugEventWriterSized(store, 2)
+	// Do not Start so nothing drains until we submit a flood that exceeds
+	// the writer's buffer (cap 100). 150 ensures we also exercise the
+	// power-of-two warn cadence (1, 2, 4, 8, 16, 32 → 6 warn lines).
+	w := NewDebugEventWriter(store)
 
-	// Submit 10 events without a worker — only 2 fit in the buffer; the
-	// other 8 must be dropped.
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 150; i++ {
 		w.Submit(DebugEvent{SessionID: "sess", Direction: "request", Body: "{}"})
 	}
-	if got := w.Dropped(); got != 8 {
-		t.Errorf("Dropped = %d, want 8", got)
+	if got := w.Dropped(); got != 50 {
+		t.Errorf("Dropped = %d, want 50 (150 - 100 buffer cap)", got)
 	}
 
 	// Start the worker now and let it drain; Stop should empty the channel.
 	w.Start(context.Background())
 	w.Stop(2 * time.Second)
 	n, _ := store.CountForSession(context.Background(), "sess")
-	if n != 2 {
-		t.Errorf("post-flush count = %d, want 2 (8 were dropped before worker ran)", n)
+	if n != 100 {
+		t.Errorf("post-flush count = %d, want 100 (50 were dropped before worker ran)", n)
 	}
 }
 
@@ -62,7 +63,7 @@ func TestDebugEventWriter_DropsOnFullBuffer(t *testing.T) {
 // panic on a closed channel.
 func TestDebugEventWriter_StopIsIdempotent(t *testing.T) {
 	db := openTestDB(t)
-	w := newDebugEventWriterSized(NewDebugEventStore(db), 4)
+	w := NewDebugEventWriter(NewDebugEventStore(db))
 	w.Start(context.Background())
 	w.Stop(time.Second)
 	w.Stop(time.Second)


### PR DESCRIPTION
## Summary

Self-review follow-up on the just-merged #209. Four patterns were over-engineered for what they delivered. -50 lines net.

## Cleanups

| What | Why |
|------|-----|
| `captureRawHTTP` + `captureRawHTTPError` merged | Error path is just `direction=\"error\"` with the failure class+msg in Body. One function with a captureErr param is shorter than two near-duplicates. |
| `debugCaptureScopeText` / `debugRetentionTrailerText` inlined | Two helper methods for branching a single string at one call site = pure indirection. Inline branches sit next to the message text they affect. |
| `WriterBufferSize` knob + sized constructor removed | /debug is opt-in per session and the worker drains at ~1k inserts/s on Postgres — cap 100 is plenty forever. Configurability for a knob nobody will turn is just maintenance surface. The drop-policy test floods 150 events to exercise the same code path without the parallel constructor. |
| 7-line `stubCounter` struct → func-type adapter | One-method interface, one-line test setup. |

## Not changed

The `URL` field on `DebugEvent` stays. Removing it would require a follow-up schema migration (since #209 is already merged and 007 may have been applied) for marginal storage savings on a debug-only opt-in table. Net cost > net benefit.

## Test plan

- [x] `go test ./...` passes (31 packages, 0 failures)
- [x] `golangci-lint run ./...` clean
- [x] E2E test (`TestEndToEnd_DebugCaptureFlowsThroughEveryLayer`) still verifies the full pipeline
- [x] Drop-policy test (`TestDebugEventWriter_DropsOnFullBuffer`) now floods 150 against the hardcoded 100 cap