### PR TITLE
fix: record pipeline results in native tool format for session history

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1909,8 +1909,24 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 		tr := ToolResult{CallID: tc.ID, Content: es.Content, Error: es.Error}
 		toolCalls = append(toolCalls, tc)
 		toolResults = append(toolResults, tr)
-		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: formatToolCallMessage(tc)})
-		_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: o.guard.WrapContent(tr)})
+		if o.supportsNativeTools() {
+			_ = o.sessions.AddMessage(sessionID, provider.Message{
+				Role: provider.RoleAssistant,
+				ToolCalls: []provider.ToolCall{{
+					ID:        tc.ID,
+					Name:      tc.Plugin + "." + tc.Action,
+					Arguments: tc.Args,
+				}},
+			})
+			_ = o.sessions.AddMessage(sessionID, provider.Message{
+				Role:       provider.RoleTool,
+				Content:    nativeToolContent(tr),
+				ToolCallID: tc.ID,
+			})
+		} else {
+			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: formatToolCallMessage(tc)})
+			_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: o.guard.WrapContent(tr)})
+		}
 	}
 	_ = o.sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: execResult.Summary})
 


### PR DESCRIPTION
## Summary

Multi-step pipeline results were always recorded in text-based format (`[tool_call]` + `[plugin_output]`), even when native tool calling is active. The LLM on the next turn couldn't connect follow-up messages to pipeline results because native-mode models don't understand text-based tool call blocks in session history.

Single-step pipelines already had this fix (line 923) — this applies the same pattern to multi-step `executePipeline()`.

**Before:** "Rename item to Test 1234" → pipeline executes → "Delete the test" → LLM asks "which test?" (lost context)

**After:** Pipeline results are recorded as `role:assistant` with `tool_calls` + `role:tool` with `tool_call_id` — the model sees them as real tool interactions and can reference the item from the previous turn.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint` clean
- [x] `go test -race ./internal/orchestrator/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)