### PR TITLE
fix: flaky health test — wait for server to accept connections

### DIFF
--- a/internal/health/health_test.go
+++ b/internal/health/health_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"testing"
+	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -27,6 +28,16 @@ func startTestServer(t *testing.T) (*Server, healthpb.HealthClient) {
 	go func() {
 		_ = srv.ListenAndServe()
 	}()
+
+	// Wait for the server to be accepting connections before creating the client.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond); err == nil {
+			_ = c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {


### PR DESCRIPTION
## Summary
- `TestLivenessServingOnStart` fails intermittently in CI — the gRPC health server hasn't bound the port yet when the test client connects
- Added a TCP dial loop (up to 2s) in `startTestServer` to wait for the server to accept connections before returning the client
- Verified with 5x `-count=5` runs locally, no flakes

## Test plan
- [x] `go test ./internal/health/ -count=5` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)