### PR TITLE
fix: rollback session history on confirmation rejection

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -765,6 +765,12 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		defer timing.log(log)
 	}
 
+	// Snapshot session state before this Run so we can rollback on rejection.
+	var msgCountAtStart int
+	if sess != nil {
+		msgCountAtStart = len(sess.Messages)
+	}
+
 	// Block A: Check for pending pipeline confirmation.
 	if timing != nil {
 		timing.begin("confirmation_check")
@@ -877,9 +883,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// LLM summarizes the result for the user.
 			toolCallConfirmed = true
 		} else {
-			// Don't record the cancellation in session history — if the LLM
-			// sees a prior rejection it avoids re-calling the write tool and
-			// either narrates or fabricates results instead.
+			// Rollback session to before this Run — remove the user message
+			// and any tool calls/results that were added during the
+			// confirmation attempt. Without this, the LLM sees prior tool
+			// results and narrates instead of re-calling the tool.
+			if s, _ := sessions.Get(sessionID); s != nil && msgCountAtStart < len(s.Messages) {
+				_ = sessions.SetSummary(sessionID, s.Summary, s.Messages[:msgCountAtStart])
+			}
 			return &RunResult{
 				Response: "OK, action cancelled.",
 				Metadata: map[string]string{


### PR DESCRIPTION
## Summary
- On confirmation rejection, rollback session history to before the Run started
- Removes the user message and all tool calls/results from the rejected attempt
- This prevents the LLM from seeing prior tool results and narrating instead of re-calling the tool

## How it works
- Snapshot message count at Run() start
- On rejection, use `SetSummary` to restore messages to pre-Run state
- Next request starts fresh — the LLM has no memory of the rejected attempt

## Test plan
- [x] `go build ./...` passes
- [x] orchestrator tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)