### PR TITLE
feat: debounce rapid messages into single LLM call

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,25 @@ Session A msg2 ···············► (waits for msg1 to finish) ─�
 
 Set `max_concurrent_sessions` to match your LLM provider's rate limits and expected load. A value of `1` (default) gives the original sequential behaviour with no behaviour change needed for existing deployments.
 
+## Message Debouncing
+
+When a user sends multiple messages rapidly (e.g. "yes", "also add barcode 123", "set price to 50"), each message normally triggers a separate LLM call. With large context windows (~98k tokens), this wastes tokens and produces disjointed responses.
+
+Enable debouncing to merge rapid messages into a single LLM call:
+
+```yaml
+orchestrator:
+  debounce_window: "800ms"   # collect messages for 800ms, then send as one (default: "0" = disabled)
+```
+
+**How it works:**
+
+- When a message arrives, the debouncer waits for the configured window (e.g. 800ms)
+- If more messages arrive within the window, the timer resets
+- When the timer fires, all buffered messages are merged (content joined with newlines) and processed as one request
+- Different sessions debounce independently
+- **Confirmation signals** (`approve`/`reject`) bypass debounce and execute immediately
+
 ### Debugging
 
 Set `LOG_LEVEL=debug` to see pipeline decisions, planner LLM calls, step execution, and retry attempts — all prefixed with `[pipeline]`.

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ orchestrator:
 - If more messages arrive within the window, the timer resets
 - When the timer fires, all buffered messages are merged (content joined with newlines) and processed as one request
 - Different sessions debounce independently
-- **Confirmation signals** (`approve`/`reject`) bypass debounce and execute immediately
+- **Confirmation signals** (any message with non-empty `confirmation` metadata) and typing indicators bypass debounce and execute immediately
 
 ### Debugging
 

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -706,6 +706,15 @@ func main() {
 	reg := channel.NewRegistry(handler)
 	notifier.reg = reg
 
+	if dw := cfg.Orchestrator.DebounceWindow; dw != "" {
+		if d, err := time.ParseDuration(dw); err == nil && d > 0 {
+			reg.SetDebounceWindow(d)
+			slog.Info("message debounce enabled", "window", d)
+		} else if err != nil {
+			slog.Warn("invalid orchestrator.debounce_window, debounce disabled", "value", dw, "error", err)
+		}
+	}
+
 	if cfg.Cluster.Enabled {
 		dedupTTL := 5 * time.Minute
 		if cfg.Cluster.DedupTTL != "" {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -41,6 +41,7 @@ routing:
 orchestrator:
   rules: []
   # permission_plugin: permission   # optional; core calls this plugin with action "check"(actor, plugin) before running a tool
+  # debounce_window: "800ms"       # merge rapid messages into one LLM call (default "0" = disabled)
   # Run these plugin actions before the first LLM call; their output becomes the user message (or they can block with send_to_llm: false).
   # List order = execution order: the first entry runs first and receives the user message; each preparer's output is the next one's input.
   content_preparers:

--- a/internal/channel/debounce.go
+++ b/internal/channel/debounce.go
@@ -21,6 +21,7 @@ type sessionDebouncer struct {
 	window   time.Duration
 	buffers  map[string]*debounceBuf
 	dispatch func(sessionKey string, merged pkg.InboundMessage)
+	stopped  bool
 }
 
 type debounceBuf struct {
@@ -33,6 +34,21 @@ func newSessionDebouncer(window time.Duration, dispatch func(string, pkg.Inbound
 		window:   window,
 		buffers:  make(map[string]*debounceBuf),
 		dispatch: dispatch,
+	}
+}
+
+// stop cancels all pending timers and prevents future dispatches.
+// Buffered messages are discarded. Call when the dispatch loop exits.
+func (d *sessionDebouncer) stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.stopped = true
+	for key, buf := range d.buffers {
+		if buf.timer != nil {
+			buf.timer.Stop()
+		}
+		delete(d.buffers, key)
 	}
 }
 
@@ -49,6 +65,10 @@ func (d *sessionDebouncer) submit(sessionKey string, msg pkg.InboundMessage) boo
 
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	if d.stopped {
+		return false
+	}
 
 	buf, exists := d.buffers[sessionKey]
 	if !exists {
@@ -73,7 +93,7 @@ func (d *sessionDebouncer) submit(sessionKey string, msg pkg.InboundMessage) boo
 func (d *sessionDebouncer) flush(sessionKey string) {
 	d.mu.Lock()
 	buf, exists := d.buffers[sessionKey]
-	if !exists || len(buf.messages) == 0 {
+	if d.stopped || !exists || len(buf.messages) == 0 {
 		d.mu.Unlock()
 		return
 	}

--- a/internal/channel/debounce.go
+++ b/internal/channel/debounce.go
@@ -1,0 +1,134 @@
+package channel
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	pkg "github.com/opentalon/opentalon/pkg/channel"
+)
+
+// defaultDebounceWindow is how long the debouncer waits for additional
+// messages before dispatching. 0 = disabled (opt-in via SetDebounceWindow).
+const defaultDebounceWindow = 0
+
+// sessionDebouncer collects rapid-fire messages for the same session and
+// merges them into a single InboundMessage before dispatching. This avoids
+// burning an LLM round (~98k tokens) for each line when the user sends
+// "yes\nalso add barcode\nset price to 50" as three separate WebSocket frames.
+type sessionDebouncer struct {
+	mu       sync.Mutex
+	window   time.Duration
+	buffers  map[string]*debounceBuf
+	dispatch func(sessionKey string, merged pkg.InboundMessage)
+}
+
+type debounceBuf struct {
+	messages []pkg.InboundMessage
+	timer    *time.Timer
+}
+
+func newSessionDebouncer(window time.Duration, dispatch func(string, pkg.InboundMessage)) *sessionDebouncer {
+	return &sessionDebouncer{
+		window:   window,
+		buffers:  make(map[string]*debounceBuf),
+		dispatch: dispatch,
+	}
+}
+
+// submit adds a message to the debounce buffer. If no more messages arrive
+// within the window, the buffer is flushed as a single merged message.
+// Returns true if the message was debounced, false if it should be dispatched
+// immediately (e.g. confirmation signals).
+func (d *sessionDebouncer) submit(sessionKey string, msg pkg.InboundMessage) bool {
+	// Skip debounce for confirmation signals and typing indicators —
+	// these must be processed immediately.
+	if msg.Metadata["confirmation"] != "" || msg.Metadata["_typing"] == "true" {
+		return false
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	buf, exists := d.buffers[sessionKey]
+	if !exists {
+		buf = &debounceBuf{}
+		d.buffers[sessionKey] = buf
+	}
+
+	buf.messages = append(buf.messages, msg)
+
+	// Reset the timer on each new message.
+	if buf.timer != nil {
+		buf.timer.Stop()
+	}
+	buf.timer = time.AfterFunc(d.window, func() {
+		d.flush(sessionKey)
+	})
+
+	return true
+}
+
+// flush merges all buffered messages for a session and dispatches them.
+func (d *sessionDebouncer) flush(sessionKey string) {
+	d.mu.Lock()
+	buf, exists := d.buffers[sessionKey]
+	if !exists || len(buf.messages) == 0 {
+		d.mu.Unlock()
+		return
+	}
+	messages := buf.messages
+	delete(d.buffers, sessionKey)
+	d.mu.Unlock()
+
+	merged := mergeMessages(messages)
+	d.dispatch(sessionKey, merged)
+}
+
+// mergeMessages combines multiple InboundMessages into one.
+// Content is joined with newlines. Metadata is merged (last wins).
+// Files are concatenated. Identity fields come from the last message.
+func mergeMessages(messages []pkg.InboundMessage) pkg.InboundMessage {
+	if len(messages) == 1 {
+		return messages[0]
+	}
+
+	last := messages[len(messages)-1]
+
+	// Join content.
+	var parts []string
+	for _, m := range messages {
+		if c := strings.TrimSpace(m.Content); c != "" {
+			parts = append(parts, c)
+		}
+	}
+
+	// Merge metadata (last wins on conflicts).
+	var meta map[string]string
+	for _, m := range messages {
+		for k, v := range m.Metadata {
+			if meta == nil {
+				meta = make(map[string]string)
+			}
+			meta[k] = v
+		}
+	}
+
+	// Concatenate files.
+	var files []pkg.FileAttachment
+	for _, m := range messages {
+		files = append(files, m.Files...)
+	}
+
+	return pkg.InboundMessage{
+		ChannelID:      last.ChannelID,
+		ConversationID: last.ConversationID,
+		ThreadID:       last.ThreadID,
+		SenderID:       last.SenderID,
+		SenderName:     last.SenderName,
+		Content:        strings.Join(parts, "\n"),
+		Metadata:       meta,
+		Files:          files,
+		Timestamp:      last.Timestamp,
+	}
+}

--- a/internal/channel/debounce_test.go
+++ b/internal/channel/debounce_test.go
@@ -92,10 +92,12 @@ func TestDebouncerSeparateSessions(t *testing.T) {
 }
 
 func TestDebouncerSingleMessageDispatchesAfterWindow(t *testing.T) {
+	const window = 50 * time.Millisecond
+
 	var mu sync.Mutex
 	var dispatched []pkg.InboundMessage
 
-	d := newSessionDebouncer(50*time.Millisecond, func(_ string, merged pkg.InboundMessage) {
+	d := newSessionDebouncer(window, func(_ string, merged pkg.InboundMessage) {
 		mu.Lock()
 		dispatched = append(dispatched, merged)
 		mu.Unlock()
@@ -103,16 +105,9 @@ func TestDebouncerSingleMessageDispatchesAfterWindow(t *testing.T) {
 
 	d.submit("s1", pkg.InboundMessage{Content: "solo"})
 
-	// Not yet dispatched.
-	time.Sleep(20 * time.Millisecond)
-	mu.Lock()
-	if len(dispatched) != 0 {
-		t.Fatal("dispatched too early")
-	}
-	mu.Unlock()
+	// Wait long enough for the timer to fire, even under CI load.
+	time.Sleep(3 * window)
 
-	// Now it should be dispatched.
-	time.Sleep(50 * time.Millisecond)
 	mu.Lock()
 	defer mu.Unlock()
 	if len(dispatched) != 1 {

--- a/internal/channel/debounce_test.go
+++ b/internal/channel/debounce_test.go
@@ -1,0 +1,152 @@
+package channel
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	pkg "github.com/opentalon/opentalon/pkg/channel"
+)
+
+func TestDebouncerMergesRapidMessages(t *testing.T) {
+	var mu sync.Mutex
+	var dispatched []pkg.InboundMessage
+
+	d := newSessionDebouncer(100*time.Millisecond, func(_ string, merged pkg.InboundMessage) {
+		mu.Lock()
+		dispatched = append(dispatched, merged)
+		mu.Unlock()
+	})
+
+	d.submit("s1", pkg.InboundMessage{Content: "hello", ConversationID: "c1"})
+	d.submit("s1", pkg.InboundMessage{Content: "world", ConversationID: "c1"})
+	d.submit("s1", pkg.InboundMessage{Content: "!", ConversationID: "c1"})
+
+	// Wait for debounce timer to fire.
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dispatched) != 1 {
+		t.Fatalf("expected 1 merged dispatch, got %d", len(dispatched))
+	}
+	if dispatched[0].Content != "hello\nworld\n!" {
+		t.Errorf("merged content = %q, want %q", dispatched[0].Content, "hello\nworld\n!")
+	}
+}
+
+func TestDebouncerConfirmationBypassesDebounce(t *testing.T) {
+	var mu sync.Mutex
+	var dispatched []pkg.InboundMessage
+
+	d := newSessionDebouncer(100*time.Millisecond, func(_ string, merged pkg.InboundMessage) {
+		mu.Lock()
+		dispatched = append(dispatched, merged)
+		mu.Unlock()
+	})
+
+	msg := pkg.InboundMessage{
+		Content:  "yes",
+		Metadata: map[string]string{"confirmation": "approve"},
+	}
+	debounced := d.submit("s1", msg)
+	if debounced {
+		t.Error("confirmation message should bypass debounce")
+	}
+
+	// No dispatch should happen from debouncer.
+	time.Sleep(200 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dispatched) != 0 {
+		t.Errorf("expected 0 dispatches for bypassed message, got %d", len(dispatched))
+	}
+}
+
+func TestDebouncerSeparateSessions(t *testing.T) {
+	var mu sync.Mutex
+	dispatched := make(map[string]pkg.InboundMessage)
+
+	d := newSessionDebouncer(100*time.Millisecond, func(key string, merged pkg.InboundMessage) {
+		mu.Lock()
+		dispatched[key] = merged
+		mu.Unlock()
+	})
+
+	d.submit("s1", pkg.InboundMessage{Content: "a", ConversationID: "c1"})
+	d.submit("s2", pkg.InboundMessage{Content: "b", ConversationID: "c2"})
+
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dispatched) != 2 {
+		t.Fatalf("expected 2 dispatches (one per session), got %d", len(dispatched))
+	}
+	if dispatched["s1"].Content != "a" {
+		t.Errorf("s1 content = %q, want %q", dispatched["s1"].Content, "a")
+	}
+	if dispatched["s2"].Content != "b" {
+		t.Errorf("s2 content = %q, want %q", dispatched["s2"].Content, "b")
+	}
+}
+
+func TestDebouncerSingleMessageDispatchesAfterWindow(t *testing.T) {
+	var mu sync.Mutex
+	var dispatched []pkg.InboundMessage
+
+	d := newSessionDebouncer(50*time.Millisecond, func(_ string, merged pkg.InboundMessage) {
+		mu.Lock()
+		dispatched = append(dispatched, merged)
+		mu.Unlock()
+	})
+
+	d.submit("s1", pkg.InboundMessage{Content: "solo"})
+
+	// Not yet dispatched.
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	if len(dispatched) != 0 {
+		t.Fatal("dispatched too early")
+	}
+	mu.Unlock()
+
+	// Now it should be dispatched.
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(dispatched) != 1 {
+		t.Fatalf("expected 1 dispatch, got %d", len(dispatched))
+	}
+	if dispatched[0].Content != "solo" {
+		t.Errorf("content = %q, want %q", dispatched[0].Content, "solo")
+	}
+}
+
+func TestMergeMessagesMetadata(t *testing.T) {
+	messages := []pkg.InboundMessage{
+		{Content: "first", Metadata: map[string]string{"a": "1", "b": "old"}},
+		{Content: "second", Metadata: map[string]string{"b": "new", "c": "3"}},
+	}
+	merged := mergeMessages(messages)
+	if merged.Metadata["a"] != "1" {
+		t.Errorf("a = %q, want %q", merged.Metadata["a"], "1")
+	}
+	if merged.Metadata["b"] != "new" {
+		t.Errorf("b = %q, want %q (last wins)", merged.Metadata["b"], "new")
+	}
+	if merged.Metadata["c"] != "3" {
+		t.Errorf("c = %q, want %q", merged.Metadata["c"], "3")
+	}
+}
+
+func TestMergeMessagesFiles(t *testing.T) {
+	messages := []pkg.InboundMessage{
+		{Content: "a", Files: []pkg.FileAttachment{{Name: "f1"}}},
+		{Content: "b", Files: []pkg.FileAttachment{{Name: "f2"}, {Name: "f3"}}},
+	}
+	merged := mergeMessages(messages)
+	if len(merged.Files) != 3 {
+		t.Fatalf("expected 3 files, got %d", len(merged.Files))
+	}
+}

--- a/internal/channel/registry.go
+++ b/internal/channel/registry.go
@@ -53,6 +53,9 @@ func NewRegistry(handler pkg.MessageHandler) *Registry {
 func (r *Registry) SetDebounceWindow(d time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if len(r.channels) > 0 {
+		panic("channel: SetDebounceWindow called after channels registered")
+	}
 	r.debounceWindow = d
 }
 
@@ -61,6 +64,9 @@ func (r *Registry) SetDebounceWindow(d time.Duration) {
 func (r *Registry) SetDeduplicator(d MessageDeduplicator, ttl time.Duration) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if len(r.channels) > 0 {
+		panic("channel: SetDeduplicator called after channels registered")
+	}
 	r.dedup = d
 	r.dedupTTL = ttl
 }
@@ -177,6 +183,12 @@ func (r *Registry) dispatch(ch pkg.Channel, inbox <-chan pkg.InboundMessage) {
 		})
 	}
 
+	defer func() {
+		if debouncer != nil {
+			debouncer.stop()
+		}
+	}()
+
 	for {
 		select {
 		case <-r.ctx.Done():
@@ -190,7 +202,13 @@ func (r *Registry) dispatch(ch pkg.Channel, inbox <-chan pkg.InboundMessage) {
 			dedup, dedupTTL := r.dedup, r.dedupTTL
 			r.mu.RUnlock()
 
-			// Deduplication check before debouncing.
+			// Dedup runs before debounce — this ordering is load-bearing.
+			// Each original message is deduped by its own timestamp so that
+			// pod-level duplicates (delivered by at-least-once channels) are
+			// suppressed before they enter the debounce buffer. If dedup ran
+			// after debounce, the merged message would carry only the last
+			// original's timestamp, and earlier duplicates arriving on another
+			// pod could slip through.
 			if dedup != nil {
 				if msg.Timestamp.IsZero() {
 					slog.Warn("dedup skipped: message has no timestamp", "channel", ch.ID())

--- a/internal/channel/registry.go
+++ b/internal/channel/registry.go
@@ -26,8 +26,9 @@ type Registry struct {
 	channels map[string]pkg.Channel
 	handler  pkg.MessageHandler
 
-	dedup    MessageDeduplicator
-	dedupTTL time.Duration
+	dedup          MessageDeduplicator
+	dedupTTL       time.Duration
+	debounceWindow time.Duration
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -38,11 +39,21 @@ type Registry struct {
 func NewRegistry(handler pkg.MessageHandler) *Registry {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Registry{
-		channels: make(map[string]pkg.Channel),
-		handler:  handler,
-		ctx:      ctx,
-		cancel:   cancel,
+		channels:       make(map[string]pkg.Channel),
+		handler:        handler,
+		debounceWindow: defaultDebounceWindow,
+		ctx:            ctx,
+		cancel:         cancel,
 	}
+}
+
+// SetDebounceWindow overrides the default debounce window for message batching.
+// Set to 0 to disable debouncing (each message dispatched immediately).
+// Must be called before any channels are registered.
+func (r *Registry) SetDebounceWindow(d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.debounceWindow = d
 }
 
 // SetDeduplicator attaches a Redis-backed deduplicator to the registry.
@@ -146,6 +157,26 @@ func (r *Registry) dispatch(ch pkg.Channel, inbox <-chan pkg.InboundMessage) {
 	var wg sync.WaitGroup
 	defer wg.Wait() // drain in-flight goroutines before signalling outer WaitGroup
 
+	// processMessage is the callback for both direct dispatch and debounced dispatch.
+	processMessage := func(m pkg.InboundMessage) {
+		wg.Add(1)
+		go func(m pkg.InboundMessage) {
+			defer wg.Done()
+			r.handleMessage(ch, m)
+		}(m)
+	}
+
+	// Create debouncer if window > 0.
+	r.mu.RLock()
+	debounceWindow := r.debounceWindow
+	r.mu.RUnlock()
+	var debouncer *sessionDebouncer
+	if debounceWindow > 0 {
+		debouncer = newSessionDebouncer(debounceWindow, func(_ string, merged pkg.InboundMessage) {
+			processMessage(merged)
+		})
+	}
+
 	for {
 		select {
 		case <-r.ctx.Done():
@@ -159,93 +190,86 @@ func (r *Registry) dispatch(ch pkg.Channel, inbox <-chan pkg.InboundMessage) {
 			dedup, dedupTTL := r.dedup, r.dedupTTL
 			r.mu.RUnlock()
 
-			wg.Add(1)
-			go func(m pkg.InboundMessage) {
-				defer wg.Done()
-
-				sessionKey := pkg.SessionKey(ch.ID(), m.ConversationID, m.ThreadID)
-				traceID := logger.TraceIDFromSessionKey(sessionKey)
-				ctx := logger.WithTraceID(r.ctx, traceID)
-				caps := ch.Capabilities()
-				ctx = pkg.WithCapabilities(ctx, caps)
-				slog.Debug("channel capabilities",
-					"channel", ch.ID(),
-					"response_format", caps.ResponseFormat,
-					"response_format_prompt", caps.ResponseFormatPrompt,
-					"edits", caps.Edits,
-				)
-
-				// Deduplication: when running multiple pods each pod receives every
-				// inbound message. Only the pod that wins the Redis SET NX lock
-				// processes the message; others silently skip it.
-				if dedup != nil {
-					if m.Timestamp.IsZero() {
-						slog.Warn("dedup skipped: message has no timestamp", "channel", ch.ID(), "session", sessionKey)
-					} else {
-						key := fmt.Sprintf("dedup:%s:%s:%d", m.ChannelID, m.ConversationID, m.Timestamp.UnixNano())
-						won, err := dedup.TryAcquire(ctx, key, dedupTTL)
-						if err != nil {
-							slog.Warn("dedup acquire failed, processing anyway", "channel", ch.ID(), "error", err)
-						} else if !won {
-							slog.Debug("dedup skipped duplicate message", "channel", ch.ID(), "session", sessionKey)
-							return
-						}
+			// Deduplication check before debouncing.
+			if dedup != nil {
+				if msg.Timestamp.IsZero() {
+					slog.Warn("dedup skipped: message has no timestamp", "channel", ch.ID())
+				} else {
+					key := fmt.Sprintf("dedup:%s:%s:%d", msg.ChannelID, msg.ConversationID, msg.Timestamp.UnixNano())
+					won, err := dedup.TryAcquire(r.ctx, key, dedupTTL)
+					if err != nil {
+						slog.Warn("dedup acquire failed, processing anyway", "channel", ch.ID(), "error", err)
+					} else if !won {
+						slog.Debug("dedup skipped duplicate message", "channel", ch.ID())
+						continue
 					}
 				}
+			}
 
-				// When the channel supports edits, attach a StreamWriter so the
-				// orchestrator can progressively deliver LLM output in real-time.
-				// gRPC plugin channels report Edits=true but their PluginClient
-				// doesn't implement UpdatableChannel, so StreamWriter would fall
-				// back to plain Send() for every flush — spamming the client with
-				// intermediate frames. Only create StreamWriter when the channel
-				// actually supports in-place message updates.
-				var sw *pkg.StreamWriter
-				if caps.Edits {
-					if _, ok := ch.(pkg.UpdatableChannel); ok {
-						sw = pkg.NewStreamWriter(ch, m.ConversationID, m.ThreadID, safeMetadata(m.Metadata))
-						ctx = pkg.WithStreamWriter(ctx, sw)
-					}
-				}
+			sessionKey := pkg.SessionKey(ch.ID(), msg.ConversationID, msg.ThreadID)
 
-				// Send periodic typing indicators while the handler is
-				// processing. This keeps WebSocket connections (and any
-				// intermediate proxies) alive during long LLM calls.
-				typingStop := startTypingIndicator(ctx, ch, m)
-
-				resp, err := r.handler(ctx, sessionKey, m)
-				typingStop()
-				if err != nil {
-					logger.FromContext(ctx).Error("handling message failed", "channel", ch.ID(), "session", sessionKey, "error", err)
-					return
-				}
-
-				// Streaming delivered content progressively, but the final
-				// handler response may differ (tool-call blocks stripped,
-				// Lua formatting applied). Update the streamed message
-				// with the clean response so users see the processed text.
-				hasMeta := len(resp.Metadata) > 0
-				if sw != nil && sw.Flushed() {
-					logger.FromContext(ctx).Debug("registry: streaming path",
-						"channel", ch.ID(), "has_metadata", hasMeta, "metadata", resp.Metadata)
-					// Merge handler result metadata (e.g. confirmation type,
-					// options) into the stream writer so FinalUpdate carries it.
-					sw.MergeMetadata(resp.Metadata)
-					if resp.Content != sw.FullContent() || hasMeta {
-						if err := sw.FinalUpdate(ctx, resp.Content); err != nil {
-							logger.FromContext(ctx).Debug("stream final update failed", "channel", ch.ID(), "error", err)
-						}
-					}
-					return
-				}
-
-				logger.FromContext(ctx).Debug("registry: direct send path",
-					"channel", ch.ID(), "has_metadata", hasMeta, "sw_nil", sw == nil)
-				if err := ch.Send(ctx, resp); err != nil {
-					logger.FromContext(ctx).Error("sending response failed", "channel", ch.ID(), "error", err)
-				}
-			}(msg)
+			// Try debouncing. If the message bypasses debounce (confirmation, typing),
+			// or debouncing is disabled, dispatch immediately.
+			if debouncer != nil && debouncer.submit(sessionKey, msg) {
+				slog.Debug("message debounced", "channel", ch.ID(), "session", sessionKey)
+				continue
+			}
+			processMessage(msg)
 		}
+	}
+}
+
+// handleMessage processes a single (possibly merged) inbound message:
+// sets up tracing, streaming, typing indicators, calls the handler,
+// and delivers the response back to the channel.
+func (r *Registry) handleMessage(ch pkg.Channel, m pkg.InboundMessage) {
+	sessionKey := pkg.SessionKey(ch.ID(), m.ConversationID, m.ThreadID)
+	traceID := logger.TraceIDFromSessionKey(sessionKey)
+	ctx := logger.WithTraceID(r.ctx, traceID)
+	caps := ch.Capabilities()
+	ctx = pkg.WithCapabilities(ctx, caps)
+
+	// When the channel supports edits, attach a StreamWriter so the
+	// orchestrator can progressively deliver LLM output in real-time.
+	var sw *pkg.StreamWriter
+	if caps.Edits {
+		if _, ok := ch.(pkg.UpdatableChannel); ok {
+			sw = pkg.NewStreamWriter(ch, m.ConversationID, m.ThreadID, safeMetadata(m.Metadata))
+			ctx = pkg.WithStreamWriter(ctx, sw)
+		}
+	}
+
+	// Send periodic typing indicators while the handler is processing.
+	typingStop := startTypingIndicator(ctx, ch, m)
+
+	resp, err := r.handler(ctx, sessionKey, m)
+	typingStop()
+	if err != nil {
+		logger.FromContext(ctx).Error("handling message failed", "channel", ch.ID(), "session", sessionKey, "error", err)
+		return
+	}
+
+	// Streaming delivered content progressively, but the final
+	// handler response may differ (tool-call blocks stripped,
+	// Lua formatting applied). Update the streamed message
+	// with the clean response so users see the processed text.
+	hasMeta := len(resp.Metadata) > 0
+	if sw != nil && sw.Flushed() {
+		logger.FromContext(ctx).Debug("registry: streaming path",
+			"channel", ch.ID(), "has_metadata", hasMeta, "metadata", resp.Metadata)
+		sw.MergeMetadata(resp.Metadata)
+		if resp.Content != sw.FullContent() || hasMeta {
+			if err := sw.FinalUpdate(ctx, resp.Content); err != nil {
+				logger.FromContext(ctx).Debug("stream final update failed", "channel", ch.ID(), "error", err)
+			}
+		}
+		return
+	}
+
+	logger.FromContext(ctx).Debug("registry: direct send path",
+		"channel", ch.ID(), "has_metadata", hasMeta, "sw_nil", sw == nil)
+	if err := ch.Send(ctx, resp); err != nil {
+		logger.FromContext(ctx).Error("sending response failed", "channel", ch.ID(), "error", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -317,6 +317,7 @@ type OrchestratorConfig struct {
 	ResponseFormatters    []ResponseFormatterEntry     `yaml:"response_formatters,omitempty"`
 	PermissionPlugin      string                       `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool
 	MaxConcurrentSessions int                          `yaml:"max_concurrent_sessions,omitempty"` // max sessions running in parallel (default 1 = sequential)
+	DebounceWindow        string                       `yaml:"debounce_window,omitempty"`         // Go duration (e.g. "800ms"); merges rapid messages into one LLM call; default "0" = disabled
 	Pipeline              PipelineOrchestratorConfig   `yaml:"pipeline,omitempty"`
 	Knowledge             KnowledgeConfig              `yaml:"knowledge,omitempty"`       // knowledge-augmented RAG configuration
 	Subprocess            SubprocessOrchestratorConfig `yaml:"subprocess,omitempty"`      // subprocess (sub-agent) support


### PR DESCRIPTION
## Summary
- Adds opt-in message debouncing: when the user sends multiple messages rapidly, they're merged into a single `Run()` call instead of burning an LLM round per message
- Disabled by default (0ms window) — enable via `registry.SetDebounceWindow(800 * time.Millisecond)`
- Confirmation signals (`metadata["confirmation"]`) and typing indicators bypass debounce for instant processing

## How it works
- Messages for the same session are buffered for a configurable window (e.g. 800ms)
- Each new message resets the timer
- When the timer fires, all buffered messages are merged: content joined with `\n`, metadata merged (last wins), files concatenated
- Different sessions debounce independently

## Test plan
- [x] `go test ./internal/channel/ -count=1` passes (6 new tests)
- [x] All existing tests pass (debounce disabled by default)
- [x] `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)