### PR TITLE
fix: trailing system instruction to stop repeating prior answers

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2397,6 +2397,16 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 		})
 	}
 
+	// Only inject the "don't repeat" reminder when there's actual prior
+	// conversation (at least one assistant reply). On the first turn there's
+	// nothing to repeat.
+	if len(sess.Messages) > 2 {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
+		})
+	}
+
 	if o.contextWindow > 0 {
 		messages = trimToContextWindow(ctx, messages, o.contextWindow)
 	}
@@ -2425,6 +2435,19 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 		messages = append(messages, provider.Message{
 			Role:    provider.RoleSystem,
 			Content: "[IMPORTANT — output format reminder] " + hint,
+		})
+	}
+
+	// Trailing instruction placed close to the generation point where
+	// the model is most likely to follow it. The same instruction in the
+	// preamble (far away) gets buried under 50-100k tokens.
+	// Only inject the "don't repeat" reminder when there's actual prior
+	// conversation (at least one assistant reply). On the first turn there's
+	// nothing to repeat.
+	if len(sess.Messages) > 2 {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
 		})
 	}
 


### PR DESCRIPTION
## Summary
- The preamble "don't repeat" instruction was buried 50-100k tokens away from the generation point — the model ignored it
- Added a trailing system message placed RIGHT AFTER the conversation history, immediately before the model generates
- Only injected when there are prior messages (>2 messages in session), not on first turn

## Why this works
LLMs follow instructions near the end of the context more reliably than instructions at the beginning. The trailing `[IMPORTANT] Answer ONLY the user's last message` is the last thing the model sees before generating.

## Test plan
- [x] All tests pass (including `TestGuardSanitizesLastMessage`)
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)