### PR TITLE
fix: restore confirmation message in session for context continuity

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1643,9 +1643,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 						}
 						confirmMsg += "\nWould you like me to proceed?"
 					}
-					// Don't record the confirmation message in session history —
-					// if the user rejects and asks again, the LLM sees the prior
-					// confirmation + rejection and avoids re-calling the tool.
+					// Store the confirmation message so the session has context
+					// for the next turn (approval or follow-up questions). On
+					// rejection, the rollback (msgCountAtStart) removes it.
+					_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: confirmMsg})
 					return &RunResult{
 						Response: confirmMsg,
 						Metadata: map[string]string{


### PR DESCRIPTION
## Summary
After creating a twin via confirmation, "delete it" lost context — the LLM didn't know what "it" referred to because the confirmation message was not stored in session history.

**What changed:**
- Confirmation message is now stored in session again (`sessions.AddMessage`)
- On **approval**: message stays → LLM has full context for follow-up ("delete it")
- On **rejection**: rollback (`msgCountAtStart`) removes it → LLM starts fresh, no avoidance

## Test plan
- [x] All tests pass
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)