### PR TITLE
fix: enrich RAG search with assistant context for follow-ups

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -939,15 +939,27 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// session history so RAG semantic search matches the full intent, not
 	// just a bare follow-up like "Item" (which would miss "create-item").
 	if !toolCallSeeded {
-		// Enrich the search query with the previous user message so RAG
-		// catches follow-ups like "delete it" after "create item Bla1".
-		// The enriched text is passed as a separate `search_text` arg to
-		// preparers — it's used for RAG search only, while the main
-		// content (the actual user message) flows through to the LLM.
+		// Enrich the search query with recent conversation context so RAG
+		// catches follow-ups like "both" after "Which one would you like
+		// to delete?". Include both the last user message and last assistant
+		// response — the assistant's question often carries the intent that
+		// a bare follow-up ("both", "yes", "the first one") needs for
+		// semantic search to find the right tools.
 		searchText := content
 		if sess, _ := sessions.Get(sessionID); sess != nil {
+			var parts []string
 			if prev := lastUserMessage(sess.Messages); prev != "" && prev != content {
-				searchText = prev + " " + content
+				parts = append(parts, prev)
+			}
+			if asst := lastAssistantMessage(sess.Messages); asst != "" {
+				// Truncate long assistant responses to keep the search query focused.
+				if len(asst) > 200 {
+					asst = asst[:200]
+				}
+				parts = append(parts, asst)
+			}
+			if len(parts) > 0 {
+				searchText = strings.Join(parts, " ") + " " + content
 			}
 		}
 		var relevantTools []string
@@ -3643,6 +3655,15 @@ func lastUserMessage(messages []provider.Message) string {
 			if text != "" {
 				return text
 			}
+		}
+	}
+	return ""
+}
+
+func lastAssistantMessage(messages []provider.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == provider.RoleAssistant && messages[i].Content != "" {
+			return messages[i].Content
 		}
 	}
 	return ""


### PR DESCRIPTION
## Summary
When the user says "both" after the LLM asked "Which one would you like to delete? 2076712 or 2076713?", the RAG search only saw `search_text="both"` — no context about deletion. It returned wrong tools (`update-category`, `create-item`).

**Fix:** Enrich `search_text` with both:
- Last user message ("delete it") 
- Last assistant message ("Which one would you like to delete?", truncated to 200 chars)

Now `search_text` = `"delete it Which one would you like me to delete?... both"` → RAG finds `delete-item`.

## Test plan
- [x] All tests pass
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)