### PR TITLE
fix: keep 5 messages after summarization instead of 2

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -531,7 +531,7 @@ func main() {
 		PermissionPluginName:    permPluginName,
 		RuntimePromptPath:       runtimePromptPath,
 		SummarizeAfterMessages:  defaultInt(cfg.State.Session.SummarizeAfter, 5),
-		MaxMessagesAfterSummary: defaultInt(cfg.State.Session.MaxMessagesAfterSummary, 2),
+		MaxMessagesAfterSummary: defaultInt(cfg.State.Session.MaxMessagesAfterSummary, 5),
 		SummarizePrompt:         cfg.State.Session.SummarizePrompt,
 		SummarizeUpdatePrompt:   cfg.State.Session.SummarizeUpdatePrompt,
 		PipelineEnabled:         cfg.Orchestrator.Pipeline.Enabled,


### PR DESCRIPTION
## Summary
Changes `max_messages_after_summary` default from 2 to 5. Keeps ~2.5 conversation turns after summarization — enough for follow-up references ("delete it", "both") while still preventing context bloat.

## Test plan
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)