### PR TITLE
feat(store): persist native tool calls in messages table

### DIFF
--- a/internal/state/store/migrations/008_messages_tool_calls.sql
+++ b/internal/state/store/migrations/008_messages_tool_calls.sql
@@ -1,0 +1,15 @@
+-- Persist native tool-call structured data alongside the existing message
+-- (role, content) pair. When the orchestrator routes a message through a
+-- provider that supports native function calling, the assistant turn carries
+-- ToolCalls (one or more name+args pairs) and the role=tool reply carries
+-- ToolCallID. Without persistence both vanish at AddMessage time and any
+-- after-the-fact session analysis is reduced to parsing free-text content --
+-- which only works for the legacy text-based tool-calling path. Messages
+-- written via the text-based path leave both columns NULL.
+--
+-- Schema portability: TEXT-only (tool_calls holds a JSON-encoded array,
+-- mirroring messages.content; tool_call_id is a short opaque id from the
+-- provider). No jsonb / generated columns -- the same migration runs on
+-- SQLite and PostgreSQL. See top-of-file comment in 007_ai_debug_events.sql.
+ALTER TABLE messages ADD COLUMN tool_calls TEXT;
+ALTER TABLE messages ADD COLUMN tool_call_id TEXT;

--- a/internal/state/store/session.go
+++ b/internal/state/store/session.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -9,6 +10,20 @@ import (
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/state"
 )
+
+// toolCallsAsNullString marshals a non-empty ToolCalls slice into JSON; an
+// empty slice persists as SQL NULL (not "[]") so consumers can cheaply filter
+// for rows that carry structured tool-call data.
+func toolCallsAsNullString(calls []provider.ToolCall) (sql.NullString, error) {
+	if len(calls) == 0 {
+		return sql.NullString{}, nil
+	}
+	b, err := json.Marshal(calls)
+	if err != nil {
+		return sql.NullString{}, fmt.Errorf("marshal tool_calls: %w", err)
+	}
+	return sql.NullString{String: string(b), Valid: true}, nil
+}
 
 // SessionStore is the database-backed session store.
 type SessionStore struct {
@@ -91,6 +106,12 @@ func (s *SessionStore) AddMessage(id string, msg provider.Message) error {
 	d := s.db.Dialect()
 	now := time.Now().UTC().Format(time.RFC3339)
 
+	toolCallsJSON, err := toolCallsAsNullString(msg.ToolCalls)
+	if err != nil {
+		return err
+	}
+	toolCallID := sql.NullString{String: msg.ToolCallID, Valid: msg.ToolCallID != ""}
+
 	tx, err := s.db.SQLDB().BeginTx(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("add message begin: %w", err)
@@ -100,9 +121,9 @@ func (s *SessionStore) AddMessage(id string, msg provider.Message) error {
 	// Atomically assign next seq in a single statement to avoid race conditions
 	// between concurrent AddMessage calls.
 	if _, err := tx.ExecContext(ctx,
-		d.Rebind(`INSERT INTO messages (session_id, seq, role, content, created_at)
-		SELECT ?, COALESCE(MAX(seq), 0) + 1, ?, ?, ? FROM messages WHERE session_id = ?`),
-		id, string(msg.Role), msg.Content, now, id); err != nil {
+		d.Rebind(`INSERT INTO messages (session_id, seq, role, content, tool_calls, tool_call_id, created_at)
+		SELECT ?, COALESCE(MAX(seq), 0) + 1, ?, ?, ?, ?, ? FROM messages WHERE session_id = ?`),
+		id, string(msg.Role), msg.Content, toolCallsJSON, toolCallID, now, id); err != nil {
 		return fmt.Errorf("add message insert: %w", err)
 	}
 
@@ -198,9 +219,14 @@ func (s *SessionStore) SetSummary(id string, summary string, messages []provider
 
 	// Insert the kept messages with fresh seq numbers.
 	for i, msg := range messages {
+		toolCallsJSON, err := toolCallsAsNullString(msg.ToolCalls)
+		if err != nil {
+			return err
+		}
+		toolCallID := sql.NullString{String: msg.ToolCallID, Valid: msg.ToolCallID != ""}
 		if _, err := tx.ExecContext(ctx,
-			d.Rebind(`INSERT INTO messages (session_id, seq, role, content, created_at) VALUES (?, ?, ?, ?, ?)`),
-			id, i+1, string(msg.Role), msg.Content, now); err != nil {
+			d.Rebind(`INSERT INTO messages (session_id, seq, role, content, tool_calls, tool_call_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			id, i+1, string(msg.Role), msg.Content, toolCallsJSON, toolCallID, now); err != nil {
 			return fmt.Errorf("set summary insert: %w", err)
 		}
 	}
@@ -257,7 +283,7 @@ func (s *SessionStore) PruneIdleSessions() error {
 // loadMessages reads all messages for a session from the messages table, ordered by seq.
 func (s *SessionStore) loadMessages(sessionID string) ([]provider.Message, error) {
 	rows, err := s.db.SQLDB().Query(
-		s.db.Dialect().Rebind(`SELECT role, content FROM messages WHERE session_id = ? ORDER BY seq`),
+		s.db.Dialect().Rebind(`SELECT role, content, tool_calls, tool_call_id FROM messages WHERE session_id = ? ORDER BY seq`),
 		sessionID)
 	if err != nil {
 		return nil, fmt.Errorf("load messages: %w", err)
@@ -267,13 +293,21 @@ func (s *SessionStore) loadMessages(sessionID string) ([]provider.Message, error
 	var messages []provider.Message
 	for rows.Next() {
 		var role, content string
-		if err := rows.Scan(&role, &content); err != nil {
+		var toolCallsJSON, toolCallID sql.NullString
+		if err := rows.Scan(&role, &content, &toolCallsJSON, &toolCallID); err != nil {
 			return nil, fmt.Errorf("load messages scan: %w", err)
 		}
-		messages = append(messages, provider.Message{
-			Role:    provider.Role(role),
-			Content: content,
-		})
+		msg := provider.Message{
+			Role:       provider.Role(role),
+			Content:    content,
+			ToolCallID: toolCallID.String, // zero value "" when NULL — safe
+		}
+		if toolCallsJSON.Valid {
+			if err := json.Unmarshal([]byte(toolCallsJSON.String), &msg.ToolCalls); err != nil {
+				return nil, fmt.Errorf("load messages unmarshal tool_calls: %w", err)
+			}
+		}
+		messages = append(messages, msg)
 	}
 	if messages == nil {
 		messages = []provider.Message{}

--- a/internal/state/store/store_postgres_test.go
+++ b/internal/state/store/store_postgres_test.go
@@ -3,6 +3,7 @@
 package store
 
 import (
+	"database/sql"
 	"os"
 	"sync"
 	"testing"
@@ -77,5 +78,58 @@ func TestPostgres_AddMessageConcurrent(t *testing.T) {
 	}
 	if len(sess.Messages) != n {
 		t.Errorf("got %d messages, want %d", len(sess.Messages), n)
+	}
+}
+
+func TestPostgres_NativeToolCallsRoundTrip(t *testing.T) {
+	db := pgDB(t)
+	store := NewSessionStore(db, 0, 0)
+	store.Create("tool-call-test", "", "")
+
+	calls := []provider.ToolCall{{
+		ID: "call_pg_1", Name: "tickets.show", Arguments: map[string]string{"id": "42"},
+	}}
+	if err := store.AddMessage("tool-call-test", provider.Message{
+		Role: provider.RoleAssistant, ToolCalls: calls,
+	}); err != nil {
+		t.Fatalf("AddMessage assistant: %v", err)
+	}
+	if err := store.AddMessage("tool-call-test", provider.Message{
+		Role: provider.RoleTool, Content: `{"status":"open"}`, ToolCallID: "call_pg_1",
+	}); err != nil {
+		t.Fatalf("AddMessage tool: %v", err)
+	}
+
+	sess, err := store.Get("tool-call-test")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(sess.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(sess.Messages))
+	}
+	if got := sess.Messages[0].ToolCalls; len(got) != 1 || got[0].ID != "call_pg_1" {
+		t.Errorf("assistant ToolCalls mismatch on postgres: %+v", got)
+	}
+	if sess.Messages[1].ToolCallID != "call_pg_1" {
+		t.Errorf("tool ToolCallID mismatch on postgres: %q", sess.Messages[1].ToolCallID)
+	}
+
+	// Empty slice must persist as NULL on Postgres as well (no "[]" sentinel).
+	store.Create("empty-tool-calls", "", "")
+	if err := store.AddMessage("empty-tool-calls", provider.Message{
+		Role: provider.RoleAssistant, Content: "no tools", ToolCalls: []provider.ToolCall{},
+	}); err != nil {
+		t.Fatalf("AddMessage empty: %v", err)
+	}
+	var toolCalls sql.NullString
+	err = db.SQLDB().QueryRow(
+		db.Dialect().Rebind(`SELECT tool_calls FROM messages WHERE session_id = ? AND seq = ?`),
+		"empty-tool-calls", 1,
+	).Scan(&toolCalls)
+	if err != nil {
+		t.Fatalf("read empty row: %v", err)
+	}
+	if toolCalls.Valid {
+		t.Errorf("empty-slice tool_calls = %q on postgres, want NULL", toolCalls.String)
 	}
 }

--- a/internal/state/store/store_test.go
+++ b/internal/state/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -25,8 +26,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != 7 {
-		t.Errorf("schema_version = %d, want 7", v)
+	if v != 8 {
+		t.Errorf("schema_version = %d, want 8", v)
 	}
 
 	// Re-open: idempotent, no error
@@ -39,8 +40,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version (second open): %v", err)
 	}
-	if v != 7 {
-		t.Errorf("schema_version after re-open = %d, want 7", v)
+	if v != 8 {
+		t.Errorf("schema_version after re-open = %d, want 8", v)
 	}
 }
 
@@ -175,6 +176,165 @@ func TestSessionStore_SetSummaryRoundTrip(t *testing.T) {
 	}
 	if len(sess.Messages) != 2 {
 		t.Errorf("len(Messages) = %d, want 2", len(sess.Messages))
+	}
+}
+
+func TestSessionStore_NativeToolCallsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(config.DBConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sessStore := NewSessionStore(db, 0, 0)
+	sessStore.Create("s1", "", "")
+
+	// Plain user turn — neither column should be populated.
+	if err := sessStore.AddMessage("s1", provider.Message{
+		Role: provider.RoleUser, Content: "find ticket 42",
+	}); err != nil {
+		t.Fatalf("AddMessage user: %v", err)
+	}
+
+	// Assistant turn with a native tool call.
+	assistantCalls := []provider.ToolCall{{
+		ID:        "call_abc123",
+		Name:      "tickets.show",
+		Arguments: map[string]string{"id": "42"},
+	}}
+	if err := sessStore.AddMessage("s1", provider.Message{
+		Role: provider.RoleAssistant, ToolCalls: assistantCalls,
+	}); err != nil {
+		t.Fatalf("AddMessage assistant tool call: %v", err)
+	}
+
+	// Tool reply referencing that call.
+	if err := sessStore.AddMessage("s1", provider.Message{
+		Role: provider.RoleTool, Content: `{"status":"open"}`, ToolCallID: "call_abc123",
+	}); err != nil {
+		t.Fatalf("AddMessage tool reply: %v", err)
+	}
+
+	sess, err := sessStore.Get("s1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(sess.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(sess.Messages))
+	}
+	if got := sess.Messages[1].ToolCalls; len(got) != 1 || got[0].ID != "call_abc123" ||
+		got[0].Name != "tickets.show" || got[0].Arguments["id"] != "42" {
+		t.Errorf("assistant ToolCalls round-trip mismatch: %+v", got)
+	}
+	if sess.Messages[2].ToolCallID != "call_abc123" {
+		t.Errorf("tool reply ToolCallID = %q, want %q", sess.Messages[2].ToolCallID, "call_abc123")
+	}
+	if sess.Messages[2].Content != `{"status":"open"}` {
+		t.Errorf("tool reply Content = %q", sess.Messages[2].Content)
+	}
+
+	// Direct SQL check: the user turn must have NULL in both new columns
+	// (text-based path stays untouched, no "[]" sentinel).
+	var toolCalls, toolCallID sql.NullString
+	err = db.SQLDB().QueryRow(
+		db.Dialect().Rebind(`SELECT tool_calls, tool_call_id FROM messages WHERE session_id = ? AND seq = ?`),
+		"s1", 1,
+	).Scan(&toolCalls, &toolCallID)
+	if err != nil {
+		t.Fatalf("read user row: %v", err)
+	}
+	if toolCalls.Valid {
+		t.Errorf("user-turn tool_calls = %q, want NULL", toolCalls.String)
+	}
+	if toolCallID.Valid {
+		t.Errorf("user-turn tool_call_id = %q, want NULL", toolCallID.String)
+	}
+
+	// The assistant turn carries tool_calls but not tool_call_id.
+	err = db.SQLDB().QueryRow(
+		db.Dialect().Rebind(`SELECT tool_calls, tool_call_id FROM messages WHERE session_id = ? AND seq = ?`),
+		"s1", 2,
+	).Scan(&toolCalls, &toolCallID)
+	if err != nil {
+		t.Fatalf("read assistant row: %v", err)
+	}
+	if !toolCalls.Valid {
+		t.Error("assistant-turn tool_calls = NULL, want JSON")
+	}
+	if toolCallID.Valid {
+		t.Errorf("assistant-turn tool_call_id = %q, want NULL", toolCallID.String)
+	}
+}
+
+func TestSessionStore_EmptyToolCallsSlicePersistsAsNull(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(config.DBConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sessStore := NewSessionStore(db, 0, 0)
+	sessStore.Create("s1", "", "")
+
+	// Explicit empty (not nil) slice — must still write NULL, not "[]",
+	// so consumers can filter for rows with structured tool data via IS NOT NULL.
+	if err := sessStore.AddMessage("s1", provider.Message{
+		Role: provider.RoleAssistant, Content: "no tools here", ToolCalls: []provider.ToolCall{},
+	}); err != nil {
+		t.Fatalf("AddMessage: %v", err)
+	}
+
+	var toolCalls sql.NullString
+	err = db.SQLDB().QueryRow(
+		db.Dialect().Rebind(`SELECT tool_calls FROM messages WHERE session_id = ? AND seq = ?`),
+		"s1", 1,
+	).Scan(&toolCalls)
+	if err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if toolCalls.Valid {
+		t.Errorf("empty-slice tool_calls = %q, want NULL", toolCalls.String)
+	}
+}
+
+func TestSessionStore_SetSummaryPreservesToolCalls(t *testing.T) {
+	dir := t.TempDir()
+	db, err := Open(config.DBConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	sessStore := NewSessionStore(db, 0, 0)
+	sessStore.Create("s1", "", "")
+
+	calls := []provider.ToolCall{{
+		ID: "call_x", Name: "items.list", Arguments: map[string]string{"q": "drone"},
+	}}
+	err = sessStore.SetSummary("s1", "summary", []provider.Message{
+		{Role: provider.RoleUser, Content: "find a drone"},
+		{Role: provider.RoleAssistant, ToolCalls: calls},
+		{Role: provider.RoleTool, Content: `{"items":[]}`, ToolCallID: "call_x"},
+	})
+	if err != nil {
+		t.Fatalf("SetSummary: %v", err)
+	}
+
+	sess, err := sessStore.Get("s1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(sess.Messages) != 3 {
+		t.Fatalf("len(Messages) = %d, want 3", len(sess.Messages))
+	}
+	if got := sess.Messages[1].ToolCalls; len(got) != 1 || got[0].Name != "items.list" ||
+		got[0].Arguments["q"] != "drone" {
+		t.Errorf("ToolCalls after SetSummary mismatch: %+v", got)
+	}
+	if sess.Messages[2].ToolCallID != "call_x" {
+		t.Errorf("ToolCallID after SetSummary = %q", sess.Messages[2].ToolCallID)
 	}
 }
 


### PR DESCRIPTION
## Why

The state store drops `provider.Message.ToolCalls` and `ToolCallID` at `AddMessage` time. After a session ends, the only structured record of which tools the LLM actually invoked lives in `ai_debug_events` — and that table only fills up for sessions that explicitly opted in via `/debug`. Without persistence on `messages`, any after-the-fact session analysis (which tool was called, with what args, in what order) has to fall back to parsing the free-text content column, which only works for the legacy text-based tool-calling path.

## What changed

- Migration `008_messages_tool_calls.sql`: adds two nullable `TEXT` columns to `messages` — `tool_calls` (JSON-encoded `[]ToolCall`) and `tool_call_id` (provider's opaque id for the matching reply).
- `internal/state/store/session.go`:
  - `AddMessage`, `SetSummary`, `loadMessages` carry the new columns end-to-end.
  - `toolCallsAsNullString` helper enforces the invariant that **an empty `ToolCalls` slice persists as SQL NULL, not `"[]"`** — so a consumer can write `WHERE tool_calls IS NOT NULL` to filter rows that carry structured tool data.
  - Marshal happens before `tx.Begin()` so we don't open a transaction just to roll it back on a marshal error.
- Tests: SQLite round-trip + direct-SQL NULL assertions, `SetSummary` preservation, and Postgres-tagged variants for the round-trip and the empty-slice-NULL invariant.

## Schema portability

`TEXT` only, no `jsonb` / GIN / generated columns, no Postgres-specific syntax. Same migration runs on SQLite and PostgreSQL — consistent with the convention spelled out at the top of `007_ai_debug_events.sql`.

## Backward compatibility

- Wire format of `provider.Message` is unchanged.
- All existing rows have `tool_calls = NULL` and `tool_call_id = NULL` after the migration runs — `loadMessages` returns those as the Go zero value (`nil` slice, empty string), so existing sessions deserialize identically.
- The text-based tool-calling path (where calls are embedded in `content`) writes nothing new — its rows stay NULL in both new columns.
- No backfill of historical messages.

## Testing

- `go test ./...` — full suite green (SQLite path, default tags).
- `go test -tags postgres ./internal/state/store/...` — two new Postgres-tagged tests cover the same round-trip + empty-slice-NULL invariant on PostgreSQL.
- `gofmt -l`, `go vet ./...`, `golangci-lint run ./internal/state/store/...` — all clean.