### PR TITLE
feat(store): structured session_events log + prompt_snapshots

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -145,6 +145,9 @@ func main() {
 	var debugStore *store.DebugEventStore
 	var debugWriter *store.DebugEventWriter
 	var debugRetentionCancel context.CancelFunc
+	var sessionEventStore *store.SessionEventStore
+	var sessionEventWriter *store.SessionEventWriter
+	var sessionEventsRetentionCancel context.CancelFunc
 	if dataDir != "" || cfg.State.DB.Driver == "postgres" {
 		db, err := store.Open(cfg.State.DB, dataDir)
 		if err != nil {
@@ -180,6 +183,25 @@ func main() {
 			var retentionCtx context.Context
 			retentionCtx, debugRetentionCancel = context.WithCancel(context.Background())
 			go store.RunDebugRetention(retentionCtx, debugStore, retention)
+
+			// Structured session_events log: always-on (orchestrator emits
+			// every turn / tool call / failure mode), separate retention
+			// horizon from /debug because the analytics use case wants
+			// longer history than the raw-HTTP-replay use case.
+			sessionEventStore = store.NewSessionEventStore(db)
+			sessionEventWriter = store.NewSessionEventWriter(sessionEventStore)
+			sessionEventWriter.Start(context.Background())
+			var sessionEventsRetention time.Duration
+			if !cfg.State.SessionEvents.RetentionDisabled {
+				days := cfg.State.SessionEvents.RetentionDays
+				if days <= 0 {
+					days = 90
+				}
+				sessionEventsRetention = time.Duration(days) * 24 * time.Hour
+			}
+			var sessionEventsRetentionCtx context.Context
+			sessionEventsRetentionCtx, sessionEventsRetentionCancel = context.WithCancel(context.Background())
+			go store.RunSessionEventsRetention(sessionEventsRetentionCtx, sessionEventStore, sessionEventsRetention)
 			// Seed static group→plugin assignments from config (source="config"; does not overwrite whoami/admin).
 			seedGroupPlugins(context.Background(), groupPluginStore, cfg.Profiles.Groups)
 			// Seed group→plugin assignments from remote bootstrap response (source="bootstrap"; lower priority than "config", does not overwrite whoami/admin).
@@ -793,6 +815,13 @@ func main() {
 	}
 	if debugRetentionCancel != nil {
 		debugRetentionCancel()
+	}
+	// Same bounded-flush dance for the always-on structured event log.
+	if sessionEventWriter != nil {
+		sessionEventWriter.Stop(5 * time.Second)
+	}
+	if sessionEventsRetentionCancel != nil {
+		sessionEventsRetentionCancel()
 	}
 
 	// Stop health server first so K8s stops routing traffic during teardown.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -343,10 +343,11 @@ type SubprocessOrchestratorConfig struct {
 }
 
 type StateConfig struct {
-	DataDir string        `yaml:"data_dir"`
-	DB      DBConfig      `yaml:"db,omitempty"`
-	Session SessionConfig `yaml:"session,omitempty"`
-	Debug   DebugConfig   `yaml:"debug,omitempty"`
+	DataDir       string              `yaml:"data_dir"`
+	DB            DBConfig            `yaml:"db,omitempty"`
+	Session       SessionConfig       `yaml:"session,omitempty"`
+	Debug         DebugConfig         `yaml:"debug,omitempty"`
+	SessionEvents SessionEventsConfig `yaml:"session_events,omitempty"`
 }
 
 // DebugConfig configures per-session deep debug capture (toggled by the
@@ -368,6 +369,26 @@ type StateConfig struct {
 // surface area.
 type DebugConfig struct {
 	RetentionDays     int  `yaml:"retention_days,omitempty"`     // default 30 when 0 or omitted
+	RetentionDisabled bool `yaml:"retention_disabled,omitempty"` // when true, never prune (overrides RetentionDays)
+}
+
+// SessionEventsConfig configures the always-on structured session_events
+// log. Unlike DebugConfig (opt-in per session), the event log is always
+// populated by the orchestrator — retention is the only knob.
+//
+// Retention semantics mirror DebugConfig:
+//   - RetentionDays:    integer days; 0 or omitted means "use default 90"
+//   - RetentionDisabled: explicit off-switch; takes precedence over
+//     RetentionDays. Use this to keep events forever (alpha-phase tuning),
+//     not RetentionDays=0 — that path applies the default and would
+//     surprise an operator who meant "off".
+//
+// Default 90 days (vs DebugConfig's 30) reflects the analytics use case:
+// regression triage often needs weeks-old comparison points, and the
+// table is small enough (TEXT JSON per event) that 90 days of alpha
+// traffic stays well within a single Postgres tablespace.
+type SessionEventsConfig struct {
+	RetentionDays     int  `yaml:"retention_days,omitempty"`     // default 90 when 0 or omitted
 	RetentionDisabled bool `yaml:"retention_disabled,omitempty"` // when true, never prune (overrides RetentionDays)
 }
 

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -23,6 +23,7 @@
 package events
 
 import (
+	"encoding/json"
 	"unicode/utf8"
 )
 
@@ -79,14 +80,25 @@ const ExcerptCap = 4 * 1024
 // Excerpt clips s at ExcerptCap bytes and reports whether truncation
 // happened. Use this for any free-form payload field whose source is the
 // LLM or a tool response.
+//
+// Trim happens at a rune boundary so the stored excerpt stays valid UTF-8.
+// If the input is itself invalid UTF-8 (no rune boundary in the trailing
+// few bytes), we fall back to a raw byte cut at ExcerptCap rather than
+// returning an empty string — pair with SanitizeUTF8 before storing if
+// the source is untrusted.
 func Excerpt(s string) (string, bool) {
 	if len(s) <= ExcerptCap {
 		return s, false
 	}
-	// Trim at a rune boundary so the stored excerpt remains valid UTF-8.
 	cut := ExcerptCap
 	for cut > 0 && !utf8.RuneStart(s[cut]) {
 		cut--
+	}
+	if cut == 0 && !utf8.RuneStart(s[0]) {
+		// Invalid UTF-8: prefer a too-long-by-a-few-bytes raw cut over an
+		// empty excerpt that loses all forensic value. SanitizeUTF8 will
+		// scrub continuation-byte fragments at the boundary on its own pass.
+		cut = ExcerptCap
 	}
 	return s[:cut], true
 }
@@ -158,20 +170,25 @@ const LLMRequestVersion = 1
 // LLMResponsePayload — captured at provider edge BEFORE the orchestrator
 // parses native tool calls or interprets text-based tool-call syntax.
 // RawContentExcerpt is the exact bytes (subject to ExcerptCap), and
-// NativeToolCallsRaw is the exact provider ToolCalls struct as
-// json.RawMessage so consumers see whatever the provider sent — even if
-// it doesn't match our current ToolCall shape.
+// NativeToolCallsRaw is the provider's ToolCalls structure embedded as
+// raw JSON so consumers see exactly what the provider sent — even if the
+// shape drifts from the current ToolCall struct.
+//
+// NativeToolCallsRaw uses json.RawMessage (not string) so it inlines
+// directly into the parent payload: `{"native_tool_calls_raw":[{...}]}`
+// instead of an escaped-string form. This matters for psql inspection and
+// for the api-plugin which would otherwise need a double unmarshal.
 type LLMResponsePayload struct {
 	Header
-	RawContentExcerpt   string `json:"raw_content_excerpt"`
-	RawContentTruncated bool   `json:"raw_content_truncated,omitempty"`
-	RawContentSHA256    string `json:"raw_content_sha256,omitempty"`
-	NativeToolCallsRaw  string `json:"native_tool_calls_raw,omitempty"` // JSON text exactly as received
-	FinishReason        string `json:"finish_reason,omitempty"`
-	TokensIn            int    `json:"tokens_in,omitempty"`
-	TokensOut           int    `json:"tokens_out,omitempty"`
-	LatencyMS           int64  `json:"latency_ms,omitempty"`
-	ProviderResponseID  string `json:"provider_response_id,omitempty"`
+	RawContentExcerpt   string          `json:"raw_content_excerpt"`
+	RawContentTruncated bool            `json:"raw_content_truncated,omitempty"`
+	RawContentSHA256    string          `json:"raw_content_sha256,omitempty"`
+	NativeToolCallsRaw  json.RawMessage `json:"native_tool_calls_raw,omitempty"`
+	FinishReason        string          `json:"finish_reason,omitempty"`
+	TokensIn            int             `json:"tokens_in,omitempty"`
+	TokensOut           int             `json:"tokens_out,omitempty"`
+	LatencyMS           int64           `json:"latency_ms,omitempty"`
+	ProviderResponseID  string          `json:"provider_response_id,omitempty"`
 }
 
 const LLMResponseVersion = 1

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -1,0 +1,384 @@
+// Package events is the source of truth for session_events payloads.
+//
+// Every row in the session_events table carries an event_type and a JSON
+// payload. This package declares the canonical list of event_type values
+// (Type* constants) and the Go struct for each payload variant. Producers
+// (orchestrator, planner, tool dispatch, retention worker stub) build a
+// struct from here and let the store marshal it; consumers (api-plugin,
+// score worker, Rails UI via the api-plugin) decode the same struct.
+//
+// Schema versioning. Each payload struct embeds a `V int` field tagged as
+// "v" in JSON, default 1. When a payload evolves, bump the constant for
+// that event type and teach the consumer to handle the older version
+// alongside the new one — never break old rows in place (the table is
+// append-only).
+//
+// Raw-capture rule. Payload fields that carry LLM- or tool-emitted bytes
+// (raw_content, raw_snippet, response_excerpt, response_body_excerpt,
+// refusal_text, arguments, ...) are populated with the EXACT bytes
+// observed at the point of first capture, before any parsing or
+// normalization. The store enforces UTF-8 validity and a 4 KB excerpt cap
+// (with a truncated flag), and nothing else — see Excerpt and
+// SanitizeUTF8.
+package events
+
+import (
+	"unicode/utf8"
+)
+
+// Event-type constants. Add new ones here, never invent strings inline.
+const (
+	// Conversation surface (UI-visible by default).
+	TypeTurnStart   = "turn_start"
+	TypeUserMessage = "user_message"
+	TypeLLMRequest  = "llm_request"
+	TypeLLMResponse = "llm_response"
+
+	// Planner / orchestrator internals (debug-view or fold-default in UI).
+	TypePlannerInvoked         = "planner_invoked"
+	TypePlannerRequest         = "planner_request"
+	TypePlannerResponse        = "planner_response"
+	TypePlannerStep            = "planner_step"
+	TypeToolRetrieval          = "tool_retrieval"
+	TypeSummarizationTriggered = "summarization_triggered"
+	TypeSummarizationCompleted = "summarization_completed"
+	TypeModelSwitch            = "model_switch"
+	TypeConfirmationRequested  = "confirmation_requested"
+	TypeConfirmationResolved   = "confirmation_resolved"
+	TypeRetry                  = "retry"
+
+	// Tool calls.
+	TypeToolCallExtracted = "tool_call_extracted"
+	TypeToolCallResult    = "tool_call_result"
+
+	// Failure modes (always UI-visible — each its own type for clean analytics).
+	TypeToolCallParseFailed = "tool_call_parse_failed"
+	TypeToolCallArgsInvalid = "tool_call_args_invalid"
+	TypeToolCallNotFound    = "tool_call_not_found"
+	TypeLLMRefused          = "llm_refused"
+	TypeLLMError            = "llm_error"
+	TypeError               = "error"
+
+	// Closing.
+	TypeScoreComputed = "score_computed"
+)
+
+// PromptSnapshotKind values for prompt_snapshots.kind.
+const (
+	PromptKindSystemPrompt       = "system_prompt"
+	PromptKindServerInstructions = "server_instructions"
+	PromptKindToolDescription    = "tool_description"
+)
+
+// ExcerptCap is the maximum byte length stored for raw LLM/tool-emitted
+// excerpts. Capture is best-effort and informational — bodies exceeding the
+// cap are truncated with a flag, and the full body remains available via
+// ai_debug_events (when /debug was active for that session).
+const ExcerptCap = 4 * 1024
+
+// Excerpt clips s at ExcerptCap bytes and reports whether truncation
+// happened. Use this for any free-form payload field whose source is the
+// LLM or a tool response.
+func Excerpt(s string) (string, bool) {
+	if len(s) <= ExcerptCap {
+		return s, false
+	}
+	// Trim at a rune boundary so the stored excerpt remains valid UTF-8.
+	cut := ExcerptCap
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut], true
+}
+
+// SanitizeUTF8 replaces invalid UTF-8 byte sequences with U+FFFD so the
+// result satisfies Postgres' UTF-8 column requirement. Valid input is
+// returned unchanged.
+func SanitizeUTF8(s string) string {
+	if utf8.ValidString(s) {
+		return s
+	}
+	return string([]rune(s)) // []rune conversion replaces invalid bytes with U+FFFD
+}
+
+// ----- Payload structs -----
+
+// Header is embedded in every payload. Producers set V to the current
+// schema version constant for that event type.
+type Header struct {
+	V int `json:"v"`
+}
+
+// TurnStartPayload — emitted once per orchestrator turn. References to
+// prompt content are by SHA256; bodies are persisted out-of-band in
+// prompt_snapshots so the same prompt costs one row across all sessions.
+type TurnStartPayload struct {
+	Header
+	SystemPromptSHA256 string                 `json:"system_prompt_sha256,omitempty"`
+	ServerInstructions []ServerInstructionRef `json:"server_instructions,omitempty"`
+	AvailableTools     []ToolRef              `json:"available_tools,omitempty"`
+	ModelID            string                 `json:"model_id"`
+	Temperature        *float64               `json:"temperature,omitempty"`
+	ReasoningEffort    string                 `json:"reasoning_effort,omitempty"`
+}
+
+type ServerInstructionRef struct {
+	Name   string `json:"name"`
+	SHA256 string `json:"sha256"`
+}
+
+type ToolRef struct {
+	Name       string `json:"name"`
+	DescSHA256 string `json:"desc_sha256"`
+}
+
+const TurnStartVersion = 1
+
+// UserMessagePayload — exact user input as the orchestrator received it.
+type UserMessagePayload struct {
+	Header
+	Content       string `json:"content"`
+	ContentLength int    `json:"content_length"`
+}
+
+const UserMessageVersion = 1
+
+// LLMRequestPayload — metadata about the request, not the full body (the
+// full request body lives in ai_debug_events when /debug is active).
+type LLMRequestPayload struct {
+	Header
+	ModelID      string `json:"model_id"`
+	MessageCount int    `json:"message_count"`
+	HasTools     bool   `json:"has_tools"`
+	MaxTokens    int    `json:"max_tokens,omitempty"`
+}
+
+const LLMRequestVersion = 1
+
+// LLMResponsePayload — captured at provider edge BEFORE the orchestrator
+// parses native tool calls or interprets text-based tool-call syntax.
+// RawContentExcerpt is the exact bytes (subject to ExcerptCap), and
+// NativeToolCallsRaw is the exact provider ToolCalls struct as
+// json.RawMessage so consumers see whatever the provider sent — even if
+// it doesn't match our current ToolCall shape.
+type LLMResponsePayload struct {
+	Header
+	RawContentExcerpt   string `json:"raw_content_excerpt"`
+	RawContentTruncated bool   `json:"raw_content_truncated,omitempty"`
+	RawContentSHA256    string `json:"raw_content_sha256,omitempty"`
+	NativeToolCallsRaw  string `json:"native_tool_calls_raw,omitempty"` // JSON text exactly as received
+	FinishReason        string `json:"finish_reason,omitempty"`
+	TokensIn            int    `json:"tokens_in,omitempty"`
+	TokensOut           int    `json:"tokens_out,omitempty"`
+	LatencyMS           int64  `json:"latency_ms,omitempty"`
+	ProviderResponseID  string `json:"provider_response_id,omitempty"`
+}
+
+const LLMResponseVersion = 1
+
+// PlannerInvokedPayload / PlannerRequestPayload / PlannerResponsePayload /
+// PlannerStepPayload — populated by the future planner instrumentation.
+// Structs are reserved here so consumers and the api-plugin can ship a
+// stable shape today.
+type PlannerInvokedPayload struct {
+	Header
+	Reason string `json:"reason,omitempty"`
+}
+
+const PlannerInvokedVersion = 1
+
+type PlannerRequestPayload struct {
+	Header
+	ModelID      string `json:"model_id"`
+	MessageCount int    `json:"message_count"`
+}
+
+const PlannerRequestVersion = 1
+
+type PlannerResponsePayload struct {
+	Header
+	RawContentExcerpt   string `json:"raw_content_excerpt"`
+	RawContentTruncated bool   `json:"raw_content_truncated,omitempty"`
+	LatencyMS           int64  `json:"latency_ms,omitempty"`
+}
+
+const PlannerResponseVersion = 1
+
+type PlannerStepPayload struct {
+	Header
+	StepIndex int    `json:"step_index"`
+	StepKind  string `json:"step_kind"`
+	Note      string `json:"note,omitempty"`
+}
+
+const PlannerStepVersion = 1
+
+// ToolRetrievalPayload — Weaviate-backed tool RAG. Hits include score so
+// regression analysis can spot retrieval quality drift over time.
+type ToolRetrievalPayload struct {
+	Header
+	Query string             `json:"query"`
+	TopK  int                `json:"top_k"`
+	Hits  []ToolRetrievalHit `json:"hits"`
+}
+
+type ToolRetrievalHit struct {
+	ToolName string  `json:"tool_name"`
+	Score    float64 `json:"score"`
+}
+
+const ToolRetrievalVersion = 1
+
+type SummarizationTriggeredPayload struct {
+	Header
+	MessageCount int    `json:"message_count"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+const SummarizationTriggeredVersion = 1
+
+type SummarizationCompletedPayload struct {
+	Header
+	SummaryExcerpt   string `json:"summary_excerpt"`
+	SummaryTruncated bool   `json:"summary_truncated,omitempty"`
+	KeptMessages     int    `json:"kept_messages"`
+	LatencyMS        int64  `json:"latency_ms,omitempty"`
+}
+
+const SummarizationCompletedVersion = 1
+
+type ModelSwitchPayload struct {
+	Header
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Reason string `json:"reason,omitempty"`
+}
+
+const ModelSwitchVersion = 1
+
+type ConfirmationRequestedPayload struct {
+	Header
+	Prompt     string   `json:"prompt"`
+	Choices    []string `json:"choices,omitempty"`
+	ToolCallID string   `json:"tool_call_id,omitempty"`
+}
+
+const ConfirmationRequestedVersion = 1
+
+type ConfirmationResolvedPayload struct {
+	Header
+	Choice     string `json:"choice"`
+	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+const ConfirmationResolvedVersion = 1
+
+type RetryPayload struct {
+	Header
+	Phase     string `json:"phase"`
+	Attempt   int    `json:"attempt"`
+	LastError string `json:"last_error,omitempty"`
+}
+
+const RetryVersion = 1
+
+// ToolCallExtractedPayload — the orchestrator's decoded view of one tool
+// call. Mode discriminates how the call was obtained: "native" for
+// provider-emitted function calls, "text" for free-text parser hits.
+type ToolCallExtractedPayload struct {
+	Header
+	CallID    string            `json:"call_id"`
+	Plugin    string            `json:"plugin"`
+	Action    string            `json:"action"`
+	Arguments map[string]string `json:"arguments,omitempty"`
+	Mode      string            `json:"mode"` // "native" | "text"
+}
+
+const ToolCallExtractedVersion = 1
+
+// ToolCallResultPayload — emitted after the tool dispatch returns or
+// errors out. Status mirrors plugin convention ("ok" / "error"). Parent
+// event_id of the corresponding tool_call_extracted is linked via the
+// session_events.parent_id column, not duplicated in payload.
+type ToolCallResultPayload struct {
+	Header
+	CallID            string `json:"call_id"`
+	Status            string `json:"status"`
+	ResponseExcerpt   string `json:"response_excerpt"`
+	ResponseTruncated bool   `json:"response_truncated,omitempty"`
+	LatencyMS         int64  `json:"latency_ms,omitempty"`
+}
+
+const ToolCallResultVersion = 1
+
+// ToolCallParseFailedPayload — text-based tool-call syntax that the
+// orchestrator's parser could not interpret. Carries the exact substring
+// the parser saw so post-hoc analysis can diff against working examples.
+type ToolCallParseFailedPayload struct {
+	Header
+	RawSnippet string `json:"raw_snippet"`
+	ParserUsed string `json:"parser_used"`
+	ParseError string `json:"parse_error"`
+}
+
+const ToolCallParseFailedVersion = 1
+
+type ToolCallArgsInvalidPayload struct {
+	Header
+	CallID          string `json:"call_id"`
+	Plugin          string `json:"plugin"`
+	Action          string `json:"action"`
+	ValidationError string `json:"validation_error"`
+}
+
+const ToolCallArgsInvalidVersion = 1
+
+type ToolCallNotFoundPayload struct {
+	Header
+	RequestedName string `json:"requested_name"`
+}
+
+const ToolCallNotFoundVersion = 1
+
+// LLMRefusedPayload — content-safety refusal or policy block from the
+// provider. RefusalText is the model's stated refusal (no excerpt cap —
+// these are short by construction).
+type LLMRefusedPayload struct {
+	Header
+	RefusalText      string `json:"refusal_text"`
+	ContentSafetyHit string `json:"content_safety_hit,omitempty"`
+}
+
+const LLMRefusedVersion = 1
+
+type LLMErrorPayload struct {
+	Header
+	Phase                 string `json:"phase"`
+	StatusCode            int    `json:"status_code,omitempty"`
+	ResponseBodyExcerpt   string `json:"response_body_excerpt,omitempty"`
+	ResponseBodyTruncated bool   `json:"response_body_truncated,omitempty"`
+}
+
+const LLMErrorVersion = 1
+
+// ErrorPayload — generic catch-all. Prefer a typed variant above when one
+// exists; use Error only when none fits.
+type ErrorPayload struct {
+	Header
+	Where   string `json:"where"`
+	Message string `json:"message"`
+}
+
+const ErrorVersion = 1
+
+// ScoreComputedPayload — written by the score worker (separate ticket).
+// Reasoning is informational free text; the numeric score plus
+// rubric_version are the analytics fields.
+type ScoreComputedPayload struct {
+	Header
+	Score         float64 `json:"score"`
+	RubricVersion string  `json:"rubric_version"`
+	Reasoning     string  `json:"reasoning,omitempty"`
+}
+
+const ScoreComputedVersion = 1

--- a/internal/state/store/migrations/009_session_events.sql
+++ b/internal/state/store/migrations/009_session_events.sql
@@ -1,0 +1,53 @@
+-- Structured per-session event log. Always-on (unlike ai_debug_events which is
+-- /debug-opt-in) and intentionally written at the point of FIRST observation,
+-- before any parsing / normalization. The orchestrator emits one row per
+-- meaningful step (turn_start, user_message, llm_request, llm_response,
+-- tool_call_extracted, tool_call_result, retries, summarization, failure
+-- modes, score_computed, ...). The exhaustive list of event_type values
+-- and their payload shape lives in internal/state/store/events.
+--
+-- Rows are append-only — the only mutator is the retention worker. payload
+-- carries a schema-versioned JSON blob ("v":N) so producers and consumers
+-- can evolve independently; per-event-type Go structs are the source of
+-- truth (see internal/state/store/events/event_types.go).
+--
+-- parent_id wires events into a DAG: tool_call_result.parent_id points at
+-- the tool_call_extracted row, llm_error / tool_call_parse_failed point at
+-- llm_request, retries point at the failed predecessor. NULL = root event
+-- of a turn.
+--
+-- duration_ms is recorded where it is meaningful (llm_response,
+-- tool_call_result, summarization_completed, ...) and NULL otherwise.
+--
+-- prompt_snapshots is a content-addressed store for system_prompt /
+-- server_instructions / tool_description bodies. turn_start references
+-- snapshots by sha256, so 10k sessions sharing one system prompt cost one
+-- snapshot row, not 10k inlined duplicates. The api-plugin resolves
+-- references on read (?expand=prompt_snapshots).
+--
+-- Schema portability: TEXT for ids/timestamps/payloads, INTEGER for seq /
+-- duration_ms. No jsonb / generated columns — the same migration runs on
+-- SQLite and PostgreSQL, matching the pattern set in 007_ai_debug_events.sql
+-- and 008_messages_tool_calls.sql.
+CREATE TABLE IF NOT EXISTS session_events (
+  id          TEXT NOT NULL PRIMARY KEY,
+  session_id  TEXT NOT NULL,
+  seq         INTEGER NOT NULL,
+  ts          TEXT NOT NULL,
+  event_type  TEXT NOT NULL,
+  parent_id   TEXT,
+  duration_ms INTEGER,
+  payload     TEXT NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_session_events_session_seq ON session_events(session_id, seq);
+CREATE INDEX IF NOT EXISTS idx_session_events_type_ts ON session_events(event_type, ts);
+CREATE INDEX IF NOT EXISTS idx_session_events_parent ON session_events(parent_id);
+
+CREATE TABLE IF NOT EXISTS prompt_snapshots (
+  sha256      TEXT NOT NULL PRIMARY KEY,
+  kind        TEXT NOT NULL,
+  content     TEXT NOT NULL,
+  created_at  TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_prompt_snapshots_kind ON prompt_snapshots(kind);

--- a/internal/state/store/session_events.go
+++ b/internal/state/store/session_events.go
@@ -1,0 +1,240 @@
+package store
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// SessionEvent is one row of the session_events table.
+//
+// Producers populate everything except ID (generated) and CreatedAt
+// (defaults to now). Seq is assigned atomically at insert time so callers
+// never need to coordinate counters — the (session_id, seq) UNIQUE index
+// enforces order.
+//
+// Payload is the marshalled event-type-specific struct from
+// internal/state/store/events. The store does no validation beyond UTF-8
+// + JSON well-formedness (see SessionEventStore.Insert) — semantic checks
+// live in the producer per the raw-capture rule.
+type SessionEvent struct {
+	ID         string
+	SessionID  string
+	Seq        int64
+	Timestamp  time.Time
+	EventType  string
+	ParentID   string // empty = root
+	DurationMS int64  // 0 = not applicable
+	Payload    json.RawMessage
+}
+
+// SessionEventStore persists structured session_events rows. The table is
+// append-only — only the retention worker (Prune) removes rows. Reads are
+// served via ListForSession and CountForSession; the api-plugin layers a
+// HTTP endpoint on top.
+//
+// Schema lives in migration 009_session_events.sql and is portable across
+// SQLite and PostgreSQL (TEXT/INTEGER only).
+type SessionEventStore struct {
+	db *DB
+}
+
+// NewSessionEventStore returns a store backed by db.
+func NewSessionEventStore(db *DB) *SessionEventStore {
+	return &SessionEventStore{db: db}
+}
+
+// Insert appends one event. Seq is auto-assigned per session via
+// COALESCE(MAX(seq), 0) + 1 inside the INSERT, mirroring messages.seq.
+// In-process ordering relies on the single-goroutine writer in
+// session_events_writer.go — every event for a given session passes
+// through one drain, so the MAX(seq) read and INSERT are effectively
+// serialised. The UNIQUE (session_id, seq) index remains as a safety
+// net for the cross-process case (multi-pod K8s with session affinity
+// drifting under failover); a duplicate-key error there is currently
+// logged and the event is dropped, which is acceptable for alpha-phase
+// debug data.
+//
+// Validation is intentionally minimal:
+//   - empty EventType / SessionID / Payload → error,
+//   - Payload must be valid JSON (json.Valid check),
+//   - UTF-8 invalid bytes in Payload are not rewritten here — producers
+//     run their excerpts through events.SanitizeUTF8 before marshalling.
+//
+// Nothing else is touched. The raw-capture rule lives at the producer.
+func (s *SessionEventStore) Insert(ctx context.Context, e SessionEvent) error {
+	if e.SessionID == "" {
+		return fmt.Errorf("session event: session_id required")
+	}
+	if e.EventType == "" {
+		return fmt.Errorf("session event: event_type required")
+	}
+	if len(e.Payload) == 0 {
+		return fmt.Errorf("session event: payload required")
+	}
+	if !json.Valid(e.Payload) {
+		return fmt.Errorf("session event: payload is not valid JSON")
+	}
+
+	id := e.ID
+	if id == "" {
+		generated, err := newSessionEventID()
+		if err != nil {
+			return fmt.Errorf("session event id: %w", err)
+		}
+		id = generated
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	ts := now
+	if !e.Timestamp.IsZero() {
+		ts = e.Timestamp.UTC().Format(time.RFC3339Nano)
+	}
+
+	parentID := sql.NullString{String: e.ParentID, Valid: e.ParentID != ""}
+	duration := sql.NullInt64{Int64: e.DurationMS, Valid: e.DurationMS != 0}
+
+	d := s.db.Dialect()
+	_, err := s.db.SQLDB().ExecContext(ctx, d.Rebind(
+		`INSERT INTO session_events (id, session_id, seq, ts, event_type, parent_id, duration_ms, payload, created_at)
+		 SELECT ?, ?, COALESCE(MAX(seq), 0) + 1, ?, ?, ?, ?, ?, ? FROM session_events WHERE session_id = ?`),
+		id, e.SessionID, ts, e.EventType, parentID, duration, string(e.Payload), now, e.SessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("session event insert: %w", err)
+	}
+	return nil
+}
+
+// ListForSession returns events for a session in seq order. sinceSeq is
+// exclusive (pass 0 for full history). limit <= 0 means "no limit".
+//
+// Callers should normally bound the read with a sensible limit since
+// alpha-phase verbose capture can put hundreds of rows into a single
+// session.
+func (s *SessionEventStore) ListForSession(ctx context.Context, sessionID string, sinceSeq, limit int64) ([]SessionEvent, error) {
+	d := s.db.Dialect()
+	query := `SELECT id, session_id, seq, ts, event_type, parent_id, duration_ms, payload
+	          FROM session_events WHERE session_id = ? AND seq > ? ORDER BY seq`
+	args := []any{sessionID, sinceSeq}
+	if limit > 0 {
+		query += " LIMIT ?"
+		args = append(args, limit)
+	}
+	rows, err := s.db.SQLDB().QueryContext(ctx, d.Rebind(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("session event list: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []SessionEvent
+	for rows.Next() {
+		var (
+			ev       SessionEvent
+			tsStr    string
+			parent   sql.NullString
+			duration sql.NullInt64
+			payload  string
+		)
+		if err := rows.Scan(&ev.ID, &ev.SessionID, &ev.Seq, &tsStr, &ev.EventType, &parent, &duration, &payload); err != nil {
+			return nil, fmt.Errorf("session event scan: %w", err)
+		}
+		ev.Timestamp, _ = time.Parse(time.RFC3339Nano, tsStr)
+		ev.ParentID = parent.String
+		ev.DurationMS = duration.Int64
+		ev.Payload = json.RawMessage(payload)
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("session event iterate: %w", err)
+	}
+	return out, nil
+}
+
+// CountForSession returns how many events were captured for a session.
+// Cheap on both engines thanks to idx_session_events_session_seq.
+func (s *SessionEventStore) CountForSession(ctx context.Context, sessionID string) (int64, error) {
+	var n int64
+	err := s.db.SQLDB().QueryRowContext(ctx,
+		s.db.Dialect().Rebind(`SELECT COUNT(*) FROM session_events WHERE session_id = ?`),
+		sessionID,
+	).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("session event count: %w", err)
+	}
+	return n, nil
+}
+
+// Prune deletes rows older than maxAge. Returns the number of rows
+// removed. Mirrors DebugEventStore.Prune so the retention worker is a
+// near-clone of the existing debug retention worker.
+func (s *SessionEventStore) Prune(ctx context.Context, maxAge time.Duration) (int64, error) {
+	if maxAge <= 0 {
+		return 0, nil
+	}
+	cutoff := time.Now().Add(-maxAge).UTC().Format(time.RFC3339Nano)
+	d := s.db.Dialect()
+	res, err := s.db.SQLDB().ExecContext(ctx,
+		d.Rebind(`DELETE FROM session_events WHERE ts < ?`), cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("session event prune: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// UpsertPromptSnapshot inserts a content-addressed prompt body. Idempotent:
+// repeated calls with the same sha256 are no-ops.
+//
+// Kind must be one of the events.PromptKind* constants. Caller is
+// responsible for computing sha256 over the canonical content bytes —
+// the store does not re-hash on insert (keeps the write hot-path cheap).
+func (s *SessionEventStore) UpsertPromptSnapshot(ctx context.Context, sha256, kind, content string) error {
+	if sha256 == "" || kind == "" {
+		return fmt.Errorf("prompt snapshot: sha256 and kind required")
+	}
+	d := s.db.Dialect()
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	// ON CONFLICT DO NOTHING is portable across SQLite (>= 3.24, 2018) and
+	// PostgreSQL — no dialect branch needed. Conflict target is the primary
+	// key column. Same-sha repeat-writes are no-ops by construction
+	// (content-addressed: same sha implies same body bytes).
+	_, err := s.db.SQLDB().ExecContext(ctx, d.Rebind(
+		`INSERT INTO prompt_snapshots (sha256, kind, content, created_at) VALUES (?, ?, ?, ?)
+		 ON CONFLICT (sha256) DO NOTHING`),
+		sha256, kind, content, now,
+	)
+	if err != nil {
+		return fmt.Errorf("prompt snapshot upsert: %w", err)
+	}
+	return nil
+}
+
+// GetPromptSnapshot returns the stored body for a sha256. Returns
+// (empty, "", nil) when the snapshot is unknown (caller treats as "body
+// not retained" rather than an error).
+func (s *SessionEventStore) GetPromptSnapshot(ctx context.Context, sha256 string) (content, kind string, err error) {
+	row := s.db.SQLDB().QueryRowContext(ctx,
+		s.db.Dialect().Rebind(`SELECT content, kind FROM prompt_snapshots WHERE sha256 = ?`), sha256)
+	err = row.Scan(&content, &kind)
+	if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	if err != nil {
+		return "", "", fmt.Errorf("prompt snapshot get: %w", err)
+	}
+	return content, kind, nil
+}
+
+// newSessionEventID returns a 32-char hex id, same shape as the debug
+// event id — see the rationale in debug_events.go.
+func newSessionEventID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/internal/state/store/session_events_retention.go
+++ b/internal/state/store/session_events_retention.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RunSessionEventsRetention prunes session_events rows older than
+// retention on a daily schedule. Runs an immediate prune on start so a
+// freshly-rotated pod catches up rather than waiting up to 24h.
+//
+// retention <= 0 disables pruning entirely — the caller (main.go) maps
+// the explicit SessionEventsConfig.RetentionDisabled flag into this.
+// Treating zero as "disabled" here is intentional API simplicity;
+// callers either pass a positive duration or pass zero. The "0 days
+// means default" UX trick stays at the config layer.
+//
+// Implementation deliberately mirrors RunDebugRetention: same in-process
+// timer, same DELETE-by-timestamp, no pg_cron / pg_partman dependency
+// (SQLite deployments would otherwise diverge from production Postgres).
+func RunSessionEventsRetention(ctx context.Context, store *SessionEventStore, retention time.Duration) {
+	if retention <= 0 {
+		slog.Info("session events retention disabled")
+		return
+	}
+	prune := func() {
+		pruneCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		n, err := store.Prune(pruneCtx, retention)
+		if err != nil {
+			slog.Warn("session events retention prune failed", "error", err)
+			return
+		}
+		if n > 0 {
+			slog.Info("session events retention prune", "rows_deleted", n, "retention", retention)
+		}
+	}
+
+	prune()
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			prune()
+		}
+	}
+}

--- a/internal/state/store/session_events_test.go
+++ b/internal/state/store/session_events_test.go
@@ -1,0 +1,284 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// payloadJSON marshals a typed event payload for the test inserts. Real
+// producers do the same — typed struct → json.Marshal → Insert.
+func payloadJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return b
+}
+
+func TestSessionEventStore_InsertAssignsMonotonicSeq(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	// Insert three events on session A and one on session B; A's seq must
+	// be 1, 2, 3 and B's must be 1 — independent counters per session.
+	for i := 0; i < 3; i++ {
+		err := store.Insert(ctx, SessionEvent{
+			SessionID: "sess-A",
+			EventType: events.TypeUserMessage,
+			Payload:   payloadJSON(t, events.UserMessagePayload{Header: events.Header{V: 1}, Content: "hi", ContentLength: 2}),
+		})
+		if err != nil {
+			t.Fatalf("Insert A[%d]: %v", i, err)
+		}
+	}
+	err := store.Insert(ctx, SessionEvent{
+		SessionID: "sess-B",
+		EventType: events.TypeUserMessage,
+		Payload:   payloadJSON(t, events.UserMessagePayload{Header: events.Header{V: 1}, Content: "hi", ContentLength: 2}),
+	})
+	if err != nil {
+		t.Fatalf("Insert B: %v", err)
+	}
+
+	listA, err := store.ListForSession(ctx, "sess-A", 0, 0)
+	if err != nil {
+		t.Fatalf("ListForSession A: %v", err)
+	}
+	if len(listA) != 3 {
+		t.Fatalf("len(listA) = %d, want 3", len(listA))
+	}
+	for i, ev := range listA {
+		wantSeq := int64(i + 1)
+		if ev.Seq != wantSeq {
+			t.Errorf("listA[%d].Seq = %d, want %d", i, ev.Seq, wantSeq)
+		}
+	}
+
+	listB, _ := store.ListForSession(ctx, "sess-B", 0, 0)
+	if len(listB) != 1 || listB[0].Seq != 1 {
+		t.Errorf("listB seq = %+v, want one event with seq=1", listB)
+	}
+}
+
+func TestSessionEventStore_InsertValidatesInputs(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		in   SessionEvent
+	}{
+		{"empty session_id", SessionEvent{EventType: "x", Payload: json.RawMessage(`{}`)}},
+		{"empty event_type", SessionEvent{SessionID: "s", Payload: json.RawMessage(`{}`)}},
+		{"empty payload", SessionEvent{SessionID: "s", EventType: "x"}},
+		{"invalid json payload", SessionEvent{SessionID: "s", EventType: "x", Payload: json.RawMessage(`not json`)}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := store.Insert(ctx, c.in); err == nil {
+				t.Errorf("Insert(%s): want error, got nil", c.name)
+			}
+		})
+	}
+}
+
+func TestSessionEventStore_ParentIDAndDurationRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	parent := SessionEvent{
+		ID:        "deadbeefdeadbeefdeadbeefdeadbeef",
+		SessionID: "sess-link",
+		EventType: events.TypeToolCallExtracted,
+		Payload: payloadJSON(t, events.ToolCallExtractedPayload{
+			Header: events.Header{V: 1}, CallID: "call_1", Plugin: "p", Action: "a", Mode: "native",
+		}),
+	}
+	if err := store.Insert(ctx, parent); err != nil {
+		t.Fatalf("Insert parent: %v", err)
+	}
+	child := SessionEvent{
+		SessionID:  "sess-link",
+		EventType:  events.TypeToolCallResult,
+		ParentID:   parent.ID,
+		DurationMS: 137,
+		Payload: payloadJSON(t, events.ToolCallResultPayload{
+			Header: events.Header{V: 1}, CallID: "call_1", Status: "ok", ResponseExcerpt: "{}",
+		}),
+	}
+	if err := store.Insert(ctx, child); err != nil {
+		t.Fatalf("Insert child: %v", err)
+	}
+
+	list, err := store.ListForSession(ctx, "sess-link", 0, 0)
+	if err != nil {
+		t.Fatalf("ListForSession: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len(list) = %d, want 2", len(list))
+	}
+	if list[0].ParentID != "" {
+		t.Errorf("root event ParentID = %q, want empty", list[0].ParentID)
+	}
+	if list[1].ParentID != parent.ID {
+		t.Errorf("child ParentID = %q, want %q", list[1].ParentID, parent.ID)
+	}
+	if list[1].DurationMS != 137 {
+		t.Errorf("child DurationMS = %d, want 137", list[1].DurationMS)
+	}
+}
+
+func TestSessionEventStore_ListForSessionSinceSeqAndLimit(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		err := store.Insert(ctx, SessionEvent{
+			SessionID: "sess-page",
+			EventType: events.TypeUserMessage,
+			Payload:   payloadJSON(t, events.UserMessagePayload{Header: events.Header{V: 1}, Content: "x"}),
+		})
+		if err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+
+	// since_seq = 2 → events with seq > 2 (i.e. 3, 4, 5).
+	list, err := store.ListForSession(ctx, "sess-page", 2, 0)
+	if err != nil {
+		t.Fatalf("ListForSession sinceSeq=2: %v", err)
+	}
+	if len(list) != 3 || list[0].Seq != 3 {
+		t.Errorf("sinceSeq=2: got len=%d first.Seq=%d, want len=3 first.Seq=3", len(list), list[0].Seq)
+	}
+
+	// limit = 2 → first two only.
+	list, _ = store.ListForSession(ctx, "sess-page", 0, 2)
+	if len(list) != 2 || list[0].Seq != 1 || list[1].Seq != 2 {
+		t.Errorf("limit=2: got %+v, want seq=[1,2]", list)
+	}
+}
+
+func TestSessionEventStore_PruneByTimestamp(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	old := time.Now().Add(-48 * time.Hour)
+	fresh := time.Now().Add(-1 * time.Minute)
+
+	if err := store.Insert(ctx, SessionEvent{
+		SessionID: "s", EventType: events.TypeUserMessage, Timestamp: old,
+		Payload: payloadJSON(t, events.UserMessagePayload{Header: events.Header{V: 1}, Content: "old"}),
+	}); err != nil {
+		t.Fatalf("Insert old: %v", err)
+	}
+	if err := store.Insert(ctx, SessionEvent{
+		SessionID: "s", EventType: events.TypeUserMessage, Timestamp: fresh,
+		Payload: payloadJSON(t, events.UserMessagePayload{Header: events.Header{V: 1}, Content: "fresh"}),
+	}); err != nil {
+		t.Fatalf("Insert fresh: %v", err)
+	}
+
+	deleted, err := store.Prune(ctx, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("Prune deleted %d, want 1", deleted)
+	}
+
+	n, _ := store.CountForSession(ctx, "s")
+	if n != 1 {
+		t.Errorf("post-prune count = %d, want 1", n)
+	}
+
+	// Prune with retention=0 is a no-op (caller signals "disabled").
+	deleted, err = store.Prune(ctx, 0)
+	if err != nil {
+		t.Fatalf("Prune(0): %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("Prune(0) deleted %d, want 0", deleted)
+	}
+}
+
+func TestSessionEventStore_PromptSnapshotUpsertIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	const sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := store.UpsertPromptSnapshot(ctx, sha, events.PromptKindSystemPrompt, "first content"); err != nil {
+		t.Fatalf("Upsert 1: %v", err)
+	}
+	// Second upsert with different content must be a no-op (content-addressed
+	// table — same sha means same content by construction).
+	if err := store.UpsertPromptSnapshot(ctx, sha, events.PromptKindSystemPrompt, "second content"); err != nil {
+		t.Fatalf("Upsert 2: %v", err)
+	}
+	content, kind, err := store.GetPromptSnapshot(ctx, sha)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if content != "first content" {
+		t.Errorf("content = %q, want %q (idempotent upsert must not overwrite)", content, "first content")
+	}
+	if kind != events.PromptKindSystemPrompt {
+		t.Errorf("kind = %q, want %q", kind, events.PromptKindSystemPrompt)
+	}
+
+	// Unknown sha resolves to empty (not an error).
+	content, kind, err = store.GetPromptSnapshot(ctx, "deadbeef")
+	if err != nil {
+		t.Fatalf("Get unknown: %v", err)
+	}
+	if content != "" || kind != "" {
+		t.Errorf("unknown sha returned content=%q kind=%q, want both empty", content, kind)
+	}
+}
+
+func TestEvents_ExcerptCapAndUTF8(t *testing.T) {
+	// Excerpt with content under the cap returns untruncated.
+	s := strings.Repeat("a", 100)
+	got, truncated := events.Excerpt(s)
+	if truncated {
+		t.Errorf("Excerpt(100): truncated = true, want false")
+	}
+	if got != s {
+		t.Errorf("Excerpt(100): content changed unexpectedly")
+	}
+
+	// Excerpt over the cap returns truncated at a rune boundary.
+	big := strings.Repeat("z", events.ExcerptCap+512)
+	got, truncated = events.Excerpt(big)
+	if !truncated {
+		t.Errorf("Excerpt(cap+512): truncated = false, want true")
+	}
+	if len(got) > events.ExcerptCap {
+		t.Errorf("Excerpt: len = %d, want <= %d", len(got), events.ExcerptCap)
+	}
+
+	// SanitizeUTF8 leaves valid input untouched and replaces invalid bytes.
+	if got := events.SanitizeUTF8("hello"); got != "hello" {
+		t.Errorf("SanitizeUTF8 valid input modified to %q", got)
+	}
+	bad := "hello\xc3\x28world"
+	clean := events.SanitizeUTF8(bad)
+	if clean == bad {
+		t.Errorf("SanitizeUTF8 did not replace invalid bytes")
+	}
+	if !strings.Contains(clean, "hello") || !strings.Contains(clean, "world") {
+		t.Errorf("SanitizeUTF8 corrupted valid surrounding text: %q", clean)
+	}
+}

--- a/internal/state/store/session_events_test.go
+++ b/internal/state/store/session_events_test.go
@@ -269,6 +269,17 @@ func TestEvents_ExcerptCapAndUTF8(t *testing.T) {
 		t.Errorf("Excerpt: len = %d, want <= %d", len(got), events.ExcerptCap)
 	}
 
+	// Invalid UTF-8 (only continuation bytes, no rune starts): falls back
+	// to a raw-byte cut at the cap rather than returning empty.
+	invalid := strings.Repeat("\x80", events.ExcerptCap+10)
+	got, truncated = events.Excerpt(invalid)
+	if !truncated {
+		t.Errorf("Excerpt(invalid UTF-8): truncated = false, want true")
+	}
+	if len(got) != events.ExcerptCap {
+		t.Errorf("Excerpt(invalid UTF-8): len = %d, want %d (raw-byte fallback)", len(got), events.ExcerptCap)
+	}
+
 	// SanitizeUTF8 leaves valid input untouched and replaces invalid bytes.
 	if got := events.SanitizeUTF8("hello"); got != "hello" {
 		t.Errorf("SanitizeUTF8 valid input modified to %q", got)
@@ -280,5 +291,38 @@ func TestEvents_ExcerptCapAndUTF8(t *testing.T) {
 	}
 	if !strings.Contains(clean, "hello") || !strings.Contains(clean, "world") {
 		t.Errorf("SanitizeUTF8 corrupted valid surrounding text: %q", clean)
+	}
+}
+
+// TestLLMResponsePayload_NativeToolCallsRawInlinesAsJSON pins the wire
+// format: NativeToolCallsRaw must embed as inline JSON, not as an escaped
+// string. This is the contract the api-plugin (TIM-868x follow-up) and
+// psql inspection rely on.
+func TestLLMResponsePayload_NativeToolCallsRawInlinesAsJSON(t *testing.T) {
+	raw := json.RawMessage(`[{"id":"call_1","name":"tickets.show","arguments":{"id":"42"}}]`)
+	p := events.LLMResponsePayload{
+		Header:             events.Header{V: events.LLMResponseVersion},
+		RawContentExcerpt:  "ok",
+		NativeToolCallsRaw: raw,
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	out := string(b)
+	if !strings.Contains(out, `"native_tool_calls_raw":[{"id":"call_1"`) {
+		t.Errorf("native_tool_calls_raw not embedded inline; got: %s", out)
+	}
+	if strings.Contains(out, `"native_tool_calls_raw":"`) {
+		t.Errorf("native_tool_calls_raw marshalled as escaped string (regression); got: %s", out)
+	}
+
+	// Round-trip survives a re-decode with the same struct.
+	var decoded events.LLMResponsePayload
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if string(decoded.NativeToolCallsRaw) != string(raw) {
+		t.Errorf("round-trip mismatch: got %s, want %s", decoded.NativeToolCallsRaw, raw)
 	}
 }

--- a/internal/state/store/session_events_writer.go
+++ b/internal/state/store/session_events_writer.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// SessionEventWriter buffers session_events on a bounded channel and
+// drains them through a single background goroutine. Producers call
+// Submit on the orchestrator hot-path; the call is non-blocking and an
+// over-full buffer drops the event with a counter.
+//
+// Why a buffer + drop policy mirrors DebugEventWriter: the orchestrator
+// emits multiple events per turn (turn_start, llm_request, llm_response,
+// one tool_call_extracted + one tool_call_result per call, …) and we
+// must never gate user-visible LLM latency on database flush time.
+// Volume is bounded by human conversation rate per session, so a small
+// buffer keeps order intact while shielding the hot path.
+//
+// The buffer cap is intentionally larger than DebugEventWriter's 100:
+// session_events is always-on (not /debug-opt-in), so a burst of activity
+// across concurrent sessions can fan in more events than the debug path.
+type SessionEventWriter struct {
+	store    *SessionEventStore
+	ch       chan SessionEvent
+	dropped  atomic.Int64
+	stopOnce sync.Once
+	done     chan struct{}
+}
+
+// SessionEventBufferCap is the in-memory channel capacity for the writer.
+// 1000 covers the worst realistic burst (full orchestrator turn × ~20
+// concurrent active sessions × safety margin) while keeping memory usage
+// bounded. Not configurable: the right answer is "deep enough that drops
+// are theoretical", and exposing a knob just invites misconfiguration.
+const SessionEventBufferCap = 1000
+
+// NewSessionEventWriter constructs a writer with the default buffer cap.
+// The caller must call Start() once and Stop() during shutdown.
+func NewSessionEventWriter(store *SessionEventStore) *SessionEventWriter {
+	return &SessionEventWriter{
+		store: store,
+		ch:    make(chan SessionEvent, SessionEventBufferCap),
+		done:  make(chan struct{}),
+	}
+}
+
+// Start launches the worker goroutine. It returns immediately. The worker
+// runs until Stop() is called, draining any events still in the buffer
+// before exiting.
+func (w *SessionEventWriter) Start(ctx context.Context) {
+	go w.run(ctx)
+}
+
+// Submit enqueues e for asynchronous insert. Never blocks — if the buffer
+// is full the event is dropped and the dropped-counter is bumped. A log
+// line is emitted on the first drop and on every subsequent power-of-two
+// drop so dashboards see backpressure without log floods.
+func (w *SessionEventWriter) Submit(e SessionEvent) {
+	select {
+	case w.ch <- e:
+	default:
+		n := w.dropped.Add(1)
+		if n == 1 || n&(n-1) == 0 {
+			slog.Warn("session event buffer full, dropping",
+				"session_id", e.SessionID,
+				"event_type", e.EventType,
+				"total_dropped", n,
+			)
+		}
+	}
+}
+
+// Stop flushes the buffer and stops the worker. Safe to call multiple
+// times. Shutdown waits up to flushTimeout for in-flight events to be
+// persisted; mirrors DebugEventWriter.Stop.
+func (w *SessionEventWriter) Stop(flushTimeout time.Duration) {
+	w.stopOnce.Do(func() {
+		close(w.ch)
+		select {
+		case <-w.done:
+		case <-time.After(flushTimeout):
+			slog.Warn("session event writer flush timeout exceeded", "timeout", flushTimeout)
+		}
+	})
+}
+
+// Dropped returns the cumulative number of events dropped since process
+// start. Useful for a /healthz-style observability surface.
+func (w *SessionEventWriter) Dropped() int64 { return w.dropped.Load() }
+
+func (w *SessionEventWriter) run(ctx context.Context) {
+	defer close(w.done)
+	for e := range w.ch {
+		insertCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := w.store.Insert(insertCtx, e); err != nil {
+			slog.Warn("session event insert failed",
+				"session_id", e.SessionID,
+				"event_type", e.EventType,
+				"error", err,
+			)
+		}
+		cancel()
+	}
+}

--- a/internal/state/store/session_events_writer_test.go
+++ b/internal/state/store/session_events_writer_test.go
@@ -1,0 +1,86 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// fakeUserMessagePayload builds a small valid payload for writer tests.
+func fakeUserMessagePayload(t *testing.T) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(events.UserMessagePayload{
+		Header: events.Header{V: events.UserMessageVersion}, Content: "x", ContentLength: 1,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestSessionEventWriter_SubmitFlushesOnStop(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	w := NewSessionEventWriter(store)
+	w.Start(context.Background())
+
+	payload := fakeUserMessagePayload(t)
+	for i := 0; i < 5; i++ {
+		w.Submit(SessionEvent{
+			SessionID: "sess-writer",
+			EventType: events.TypeUserMessage,
+			Payload:   payload,
+		})
+	}
+	w.Stop(2 * time.Second)
+
+	n, err := store.CountForSession(context.Background(), "sess-writer")
+	if err != nil {
+		t.Fatalf("CountForSession: %v", err)
+	}
+	if n != 5 {
+		t.Errorf("post-Stop count = %d, want 5 (Stop must flush)", n)
+	}
+	if d := w.Dropped(); d != 0 {
+		t.Errorf("dropped = %d, want 0 (buffer was not pressured)", d)
+	}
+}
+
+func TestSessionEventWriter_DropsWhenBufferFull(t *testing.T) {
+	// Build a writer with a deliberately tiny buffer and DO NOT start the
+	// drain — every Submit beyond the cap must drop and increment the
+	// counter without blocking. Starting the drain would let events leave
+	// the channel and defeat the test.
+	w := &SessionEventWriter{
+		store: nil, // not used: drain never runs
+		ch:    make(chan SessionEvent, 2),
+		done:  make(chan struct{}),
+	}
+
+	payload := json.RawMessage(`{"v":1}`)
+	for i := 0; i < 10; i++ {
+		w.Submit(SessionEvent{
+			SessionID: "sess-overflow",
+			EventType: events.TypeUserMessage,
+			Payload:   payload,
+		})
+	}
+
+	dropped := w.Dropped()
+	if dropped != 8 {
+		t.Errorf("Dropped() = %d, want 8 (buffer cap 2, submitted 10)", dropped)
+	}
+}
+
+func TestSessionEventWriter_StopIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionEventStore(db)
+	w := NewSessionEventWriter(store)
+	w.Start(context.Background())
+	w.Stop(1 * time.Second)
+	// Second Stop must not panic on double-close of the channel.
+	w.Stop(1 * time.Second)
+}

--- a/internal/state/store/store_postgres_test.go
+++ b/internal/state/store/store_postgres_test.go
@@ -3,13 +3,16 @@
 package store
 
 import (
+	"context"
 	"database/sql"
+	"encoding/json"
 	"os"
 	"sync"
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/config"
 	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state/store/events"
 )
 
 // Run with: go test -tags postgres -run TestPostgres ./internal/state/store/
@@ -131,5 +134,60 @@ func TestPostgres_NativeToolCallsRoundTrip(t *testing.T) {
 	}
 	if toolCalls.Valid {
 		t.Errorf("empty-slice tool_calls = %q on postgres, want NULL", toolCalls.String)
+	}
+}
+
+func TestPostgres_SessionEventStoreRoundTrip(t *testing.T) {
+	db := pgDB(t)
+	store := NewSessionEventStore(db)
+	ctx := context.Background()
+
+	payload, _ := json.Marshal(events.UserMessagePayload{
+		Header: events.Header{V: events.UserMessageVersion}, Content: "hi", ContentLength: 2,
+	})
+	for i := 0; i < 3; i++ {
+		if err := store.Insert(ctx, SessionEvent{
+			SessionID: "sess-pg",
+			EventType: events.TypeUserMessage,
+			Payload:   payload,
+		}); err != nil {
+			t.Fatalf("Insert[%d]: %v", i, err)
+		}
+	}
+	list, err := store.ListForSession(ctx, "sess-pg", 0, 0)
+	if err != nil {
+		t.Fatalf("ListForSession: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("len(list) = %d, want 3", len(list))
+	}
+	for i, ev := range list {
+		wantSeq := int64(i + 1)
+		if ev.Seq != wantSeq {
+			t.Errorf("list[%d].Seq = %d, want %d (monotonic per session)", i, ev.Seq, wantSeq)
+		}
+		if ev.EventType != events.TypeUserMessage {
+			t.Errorf("list[%d].EventType = %q, want %q", i, ev.EventType, events.TypeUserMessage)
+		}
+		if !json.Valid(ev.Payload) {
+			t.Errorf("list[%d].Payload is not valid JSON", i)
+		}
+	}
+
+	// Idempotent prompt snapshot upsert on Postgres uses ON CONFLICT DO NOTHING;
+	// repeated call with different content must keep the first.
+	const sha = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	if err := store.UpsertPromptSnapshot(ctx, sha, events.PromptKindToolDescription, "first"); err != nil {
+		t.Fatalf("Upsert 1: %v", err)
+	}
+	if err := store.UpsertPromptSnapshot(ctx, sha, events.PromptKindToolDescription, "second"); err != nil {
+		t.Fatalf("Upsert 2: %v", err)
+	}
+	content, _, err := store.GetPromptSnapshot(ctx, sha)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if content != "first" {
+		t.Errorf("content = %q, want %q (idempotent ON CONFLICT DO NOTHING)", content, "first")
 	}
 }

--- a/internal/state/store/store_test.go
+++ b/internal/state/store/store_test.go
@@ -26,8 +26,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != 8 {
-		t.Errorf("schema_version = %d, want 8", v)
+	if v != 9 {
+		t.Errorf("schema_version = %d, want 9", v)
 	}
 
 	// Re-open: idempotent, no error
@@ -40,8 +40,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version (second open): %v", err)
 	}
-	if v != 8 {
-		t.Errorf("schema_version after re-open = %d, want 8", v)
+	if v != 9 {
+		t.Errorf("schema_version after re-open = %d, want 9", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

Schema-first introduction of an always-on, append-only structured event log for chat sessions, plus a content-addressed `prompt_snapshots` table for system-prompt / server-instruction / tool-description bodies.

**Schema and plumbing only** — no orchestrator instrumentation yet. Follow-up PRs wire each producer (turn start, LLM request/response, tool dispatch, planner, retries, failure modes, score) once this lands.

## Motivation

The current state DB captures *what the orchestrator concluded* (parsed tool calls in `messages.tool_calls` from #238, raw HTTP bodies in `ai_debug_events` when /debug is active per-session). It does **not** capture *what the LLM actually emitted before normalisation*. The failure modes that matter most — malformed text-based tool-call syntax, args validation errors, content-safety refusals, parser hits on garbage — are the ones the orchestrator filters or rewrites, and we lose them.

`session_events` is the always-on raw-capture-first log designed to make those failure modes first-class. Each event_type carries an exact pre-parse excerpt (subject to a 4 KB cap with a `truncated` flag) and is written *before* the orchestrator's parsing layers run.

## Tables

```sql
CREATE TABLE session_events (
  id          TEXT NOT NULL PRIMARY KEY,
  session_id  TEXT NOT NULL,
  seq         INTEGER NOT NULL,    -- monotonic per session
  ts          TEXT NOT NULL,       -- RFC3339Nano wall-clock
  event_type  TEXT NOT NULL,
  parent_id   TEXT,                -- DAG: tool_call_result -> tool_call_extracted
  duration_ms INTEGER,
  payload     TEXT NOT NULL,       -- JSON, "v":N versioned
  created_at  TEXT NOT NULL
);
-- UNIQUE (session_id, seq), (event_type, ts), (parent_id)

CREATE TABLE prompt_snapshots (
  sha256      TEXT NOT NULL PRIMARY KEY,
  kind        TEXT NOT NULL,       -- system_prompt | server_instructions | tool_description
  content     TEXT NOT NULL,
  created_at  TEXT NOT NULL
);
```

Schema is portable across SQLite and PostgreSQL (TEXT/INTEGER only, no jsonb / GIN / generated columns), matching the convention set in #226 (`007_ai_debug_events.sql`) and #238 (`008_messages_tool_calls.sql`).

## Event types

Defined as `Type*` constants in the new `internal/state/store/events` package with a typed payload struct per variant:

- **Conversation surface** — `turn_start`, `user_message`, `llm_request`, `llm_response`
- **Planner / orchestrator internals** — `planner_invoked`, `planner_request`, `planner_response`, `planner_step`, `tool_retrieval`, `summarization_triggered`, `summarization_completed`, `model_switch`, `confirmation_requested`, `confirmation_resolved`, `retry`
- **Tool calls** — `tool_call_extracted`, `tool_call_result`
- **Failure modes** — `tool_call_parse_failed`, `tool_call_args_invalid`, `tool_call_not_found`, `llm_refused`, `llm_error`, `error`
- **Closing** — `score_computed`

Each payload struct embeds `Header{V int}` for schema versioning so producers and consumers can evolve independently.

## Design conventions (non-negotiable)

1. **Raw-capture at point of first observation.** Producers emit events BEFORE any parsing / normalization. `llm_response` carries the exact provider bytes; `tool_call_parse_failed` carries the exact substring the parser saw.
2. **Append-only.** Only the retention worker (`Prune`) ever deletes. Enforced by code-review.
3. **Schema-versioned payloads.** `"v":N` in every payload; the `events` package is the source of truth.
4. **Minimal write-time validation.** UTF-8 valid (Postgres requirement; replace invalid bytes with U+FFFD before insert), 4 KB excerpt cap with a `truncated` flag, JSON well-formedness. No semantic cleanup.
5. **UI rendering is the consumer's concern.** The store returns raw bytes; the api-plugin / Rails / whichever frontend handles HTML-escape, simple_format, JSON pretty-print.
6. **Retention worker.** Mirrors `RunDebugRetention` — in-process timer, DELETE-by-timestamp, no pg_cron dependency. Default 90 days (vs. 30 for the per-session /debug log).
7. **Always-on capture** (not opt-in /debug). The existing `ai_debug_events` raw-HTTP-replay layer stays as a complementary mechanism.

## Code structure

| Path | Purpose |
|---|---|
| `internal/state/store/migrations/009_session_events.sql` | DDL — two tables, three indexes on `session_events`, one on `prompt_snapshots`. |
| `internal/state/store/events/event_types.go` | Type constants, typed payload structs, `Header{V}`, `Excerpt`, `SanitizeUTF8`. |
| `internal/state/store/session_events.go` | `SessionEventStore`: Insert / List / Count / Prune / UpsertPromptSnapshot / GetPromptSnapshot. |
| `internal/state/store/session_events_writer.go` | Async drop-policy writer (buffer 1000) — parity with `DebugEventWriter`. |
| `internal/state/store/session_events_retention.go` | `RunSessionEventsRetention` — parity with `RunDebugRetention`. |
| `internal/config/config.go` | `SessionEventsConfig` (`retention_days`, `retention_disabled`). |
| `cmd/opentalon/main.go` | Wire store + writer + retention; flush + cancel during shutdown. |

## Insert ordering

`SessionEventStore.Insert` auto-assigns `seq` via `COALESCE(MAX(seq), 0) + 1` mirroring `messages.seq`. In-process ordering is serialised by the single-goroutine drain in `SessionEventWriter`; the UNIQUE `(session_id, seq)` index is a safety net for the cross-process case (session-affinity drift under K8s failover). Conflict there is logged and the event dropped — acceptable trade-off for alpha-phase debug data.

## Upsert portability

`prompt_snapshots` uses `INSERT ... ON CONFLICT (sha256) DO NOTHING`, which is supported by SQLite ≥ 3.24 (2018) and PostgreSQL. No dialect branch needed — same statement on both engines.

## Test plan

- [x] `go build ./...` clean (incl. `-tags postgres`)
- [x] `go vet ./...` clean (incl. `-tags postgres`)
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages green
- [x] Schema version assertion bumped 8 → 9 in `TestOpenAndMigrations`
- [x] `session_events_test.go` covers monotonic seq, input validation, parent_id+duration round-trip, sinceSeq/limit pagination, prune-by-timestamp, idempotent prompt-snapshot upsert, excerpt cap (rune-boundary safe), UTF-8 sanitisation
- [x] `session_events_writer_test.go` covers Submit flush-on-Stop, drop counter when buffer is full, idempotent double-Stop
- [x] `store_postgres_test.go` adds `TestPostgres_SessionEventStoreRoundTrip` for the `postgres` build tag