### PR TITLE
chore: postgres test cleanup + document state retention knobs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -239,6 +239,18 @@ state:
   #   max_messages_after_summary: 6  # keep this many messages after summarization
   #   summarize_prompt: "Summarize the following conversation in a short paragraph."  # any language
   #   summarize_update_prompt: "Update the given conversation summary with the following new exchange. Keep the result to a short paragraph."
+  # Per-session deep debug capture: raw LLM-endpoint request/response bodies
+  # captured only while a session has metadata[debug]=true (toggled via the
+  # set_debug_mode action). The table stays empty otherwise.
+  # debug:
+  #   retention_days: 30         # days to keep ai_debug_events rows (default 30)
+  #   retention_disabled: false  # set true to keep rows forever; overrides retention_days
+  # Structured session_events log: always-on per-turn analytics trail
+  # (turn_start, llm_response, tool_call_extracted, parse failures, ...).
+  # See internal/state/store/events for the full payload schema.
+  # session_events:
+  #   retention_days: 90         # days to keep session_events rows (default 90)
+  #   retention_disabled: false  # set true to keep rows forever; overrides retention_days
 
 # Scheduler: periodic jobs and user-triggered reminders.
 # The built-in scheduler tool lets the LLM create/list/delete jobs and set

--- a/internal/state/store/store_postgres_test.go
+++ b/internal/state/store/store_postgres_test.go
@@ -29,8 +29,21 @@ func pgDB(t *testing.T) *DB {
 		t.Fatalf("Open postgres: %v", err)
 	}
 	t.Cleanup(func() {
-		// Drop tables so each test starts clean.
-		db.SQLDB().Exec("DROP TABLE IF EXISTS sessions, memories, schema_version")
+		// Drop every table the migrations create so each test starts clean.
+		// Order matters only insofar as schema_version is re-created by the
+		// next Open(); dropping it ensures a fresh migration replay. Keep
+		// this list in sync with internal/state/store/migrations/*.sql.
+		db.SQLDB().Exec(`DROP TABLE IF EXISTS
+			session_events,
+			prompt_snapshots,
+			ai_debug_events,
+			messages,
+			profile_usage,
+			group_plugins,
+			entities,
+			sessions,
+			memories,
+			schema_version`)
 		db.Close()
 	})
 	return db


### PR DESCRIPTION
## Summary

Two small follow-ups noticed during review of #239:

- **Postgres test cleanup**: `pgDB()` in `store_postgres_test.go` only dropped 3 of the 10 tables the migrations create (`sessions, memories, schema_version`), so re-running the `postgres`-tagged test suite without manually wiping the database accumulated rows and tripped length assertions on the second run (e.g. `TestPostgres_NativeToolCallsRoundTrip` from #238, `TestPostgres_SessionEventStoreRoundTrip` from #239). Now lists every table the migrations create — kept in sync with `migrations/*.sql` via a maintainer-pointing comment.
- **Document retention knobs**: `config.example.yaml` documented `state.session` and `state.db` but not the two retention sub-blocks. Adding inline-default comments for `state.debug` (per-session raw-HTTP capture) and `state.session_events` (always-on structured log) lets operators size storage without reading the Go config docstrings.

No behavioural changes. Defaults unchanged. Tests still pass.

## Test plan

- [x] `go build ./...` clean (incl. `-tags postgres`)
- [x] `go vet ./...` clean (incl. `-tags postgres`)
- [x] `gofmt -l` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages green
- [x] Manual sanity check that the postgres-tagged tests now compile and the new DROP list matches the file inventory in `internal/state/store/migrations/`