### PR TITLE
feat: producer-side instrumentation for session_events log

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/opentalon/opentalon/internal/scheduler"
 	"github.com/opentalon/opentalon/internal/state"
 	"github.com/opentalon/opentalon/internal/state/store"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
 	"github.com/opentalon/opentalon/internal/synclock"
 	"github.com/opentalon/opentalon/internal/version"
 	chanpkg "github.com/opentalon/opentalon/pkg/channel"
@@ -227,6 +228,17 @@ func main() {
 			return actor.SessionID(ctx), logger.TraceID(ctx), true
 		}
 	}
+
+	// Build the structured session-event sink. Unlike debugSink (opt-in
+	// via /debug), this one is always-on whenever the state store is
+	// available — the producer side will be wired up subsystem by
+	// subsystem in subsequent PRs. For the first introduction of the
+	// adapter we keep it unused; later constructors take it as an arg.
+	var sessionSink emit.Sink = emit.NoOpSink{}
+	if sessionEventWriter != nil {
+		sessionSink = &sessionSinkAdapter{writer: sessionEventWriter}
+	}
+	_ = sessionSink // wired into subsystems in follow-up PRs (phase 1+)
 
 	// Build LLM provider and default model from config. The (sink,resolver)
 	// pair feeds per-session /debug capture; either nil disables capture.
@@ -864,6 +876,25 @@ func (s *providerDebugSink) Submit(_ context.Context, e provider.DebugEvent) {
 		URL:       e.URL,
 		Body:      e.Body,
 		Timestamp: e.Timestamp,
+	})
+}
+
+// sessionSinkAdapter adapts the state-store async session-event writer
+// to the emit.Sink interface. Stays in main.go for the same dependency-
+// direction reason as providerDebugSink: the emit package cannot import
+// store without inviting an import cycle through provider, so this
+// composition layer is the natural home for the conversion.
+type sessionSinkAdapter struct {
+	writer *store.SessionEventWriter
+}
+
+func (s *sessionSinkAdapter) Emit(_ context.Context, e emit.Event) {
+	s.writer.Submit(store.SessionEvent{
+		SessionID:  e.SessionID,
+		EventType:  e.EventType,
+		ParentID:   e.ParentID,
+		DurationMS: e.DurationMS,
+		Payload:    e.Payload,
 	})
 }
 

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -231,18 +231,18 @@ func main() {
 
 	// Build the structured session-event sink. Unlike debugSink (opt-in
 	// via /debug), this one is always-on whenever the state store is
-	// available — the producer side will be wired up subsystem by
-	// subsystem in subsequent PRs. For the first introduction of the
-	// adapter we keep it unused; later constructors take it as an arg.
+	// available. Wired into the LLM provider via buildProvider; future
+	// PRs route it into the orchestrator subsystems too.
 	var sessionSink emit.Sink = emit.NoOpSink{}
 	if sessionEventWriter != nil {
 		sessionSink = &sessionSinkAdapter{writer: sessionEventWriter}
 	}
-	_ = sessionSink // wired into subsystems in follow-up PRs (phase 1+)
 
-	// Build LLM provider and default model from config. The (sink,resolver)
-	// pair feeds per-session /debug capture; either nil disables capture.
-	prov, defaultModel, err := buildProvider(cfg, debugSink, debugResolver)
+	// Build LLM provider and default model from config. The debug sink
+	// + resolver pair feeds per-session /debug capture (either nil
+	// disables it); sessionSink captures the structured event stream
+	// for every LLM call.
+	prov, defaultModel, err := buildProvider(cfg, debugSink, debugResolver, sessionSink)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error building provider: %v\n", err)
 		os.Exit(1) //nolint:gocritic // matches the other main()-level fatal paths; the deferred db.Close is best-effort, the OS reclaims handles on exit
@@ -1174,7 +1174,7 @@ func runClean(configPath, category string) {
 }
 
 // buildProvider returns a provider and the default model ID from config.
-func buildProvider(cfg *config.Config, debugSink provider.DebugEventSink, debugResolve provider.DebugContextResolver) (provider.Provider, string, error) {
+func buildProvider(cfg *config.Config, debugSink provider.DebugEventSink, debugResolve provider.DebugContextResolver, eventSink emit.Sink) (provider.Provider, string, error) {
 	providerID := ""
 	modelID := ""
 
@@ -1244,6 +1244,7 @@ func buildProvider(cfg *config.Config, debugSink provider.DebugEventSink, debugR
 		Models:       models,
 		DebugSink:    debugSink,
 		DebugResolve: debugResolve,
+		EventSink:    eventSink,
 	}
 	prov, err := provider.FromConfig(provCfg)
 	if err != nil {

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -578,6 +578,8 @@ func main() {
 		GroupPluginLookup:       groupPluginStore,
 		UsageRecorder:           usageRecorder,
 		PluginCallObserver:      pluginObserver,
+		EventSink:               sessionSink,       // async-buffered via SessionEventWriter
+		PromptSnapshotStore:     sessionEventStore, // direct/sync store; intentionally not async-buffered so a consumer reading a turn_start event can resolve its sha256 references without racing the writer. nil when state DB is not configured
 		SyncActionsPlugin:       cfg.Orchestrator.Knowledge.SyncPlugin,
 		SyncActionsAction:       cfg.Orchestrator.Knowledge.SyncAction,
 		SyncGlossaryAction:      cfg.Orchestrator.Knowledge.SyncGlossaryAction,

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -892,6 +892,7 @@ type sessionSinkAdapter struct {
 
 func (s *sessionSinkAdapter) Emit(_ context.Context, e emit.Event) {
 	s.writer.Submit(store.SessionEvent{
+		ID:         e.ID,
 		SessionID:  e.SessionID,
 		EventType:  e.EventType,
 		ParentID:   e.ParentID,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -248,6 +248,14 @@ state:
   # Structured session_events log: always-on per-turn analytics trail
   # (turn_start, llm_response, tool_call_extracted, parse failures, ...).
   # See internal/state/store/events for the full payload schema.
+  #
+  # Current producer coverage: the OpenAI-compatible provider emits
+  # llm_request / llm_response / llm_refused / llm_error at the HTTP
+  # boundary. The Anthropic provider and the orchestrator-internal event
+  # types (turn_start, tool_call_*, planner_*, summarization_*, ...) are
+  # wired in subsequent phases; until then, sessions routed via Anthropic
+  # models or driven through those orchestrator surfaces will be absent
+  # from the corresponding event types.
   # session_events:
   #   retention_days: 90         # days to keep session_events rows (default 90)
   #   retention_disabled: false  # set true to keep rows forever; overrides retention_days

--- a/internal/lua/runner_test.go
+++ b/internal/lua/runner_test.go
@@ -253,7 +253,7 @@ func formatResponseScriptPath(t *testing.T) string {
 func TestFormatResponseSlackToolDebug(t *testing.T) {
 	path := formatResponseScriptPath(t)
 
-	input := "[tool_call] timly.list-containers(page=1, per_page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
+	input := "[tool_call] inventory.list-containers(page=1, per_page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
 	result, err := RunFormat(path, input, "slack")
 	if err != nil {
 		t.Fatal(err)
@@ -262,7 +262,7 @@ func TestFormatResponseSlackToolDebug(t *testing.T) {
 	if !strings.Contains(result, "> :wrench:") {
 		t.Errorf("expected Slack wrench emoji in blockquote, got:\n%s", result)
 	}
-	if !strings.Contains(result, "`timly.list-containers(page=1, per_page=1)`") {
+	if !strings.Contains(result, "`inventory.list-containers(page=1, per_page=1)`") {
 		t.Errorf("expected tool call in code block, got:\n%s", result)
 	}
 	// Response should be Slack-formatted (bold: *text* not **text**)
@@ -291,7 +291,7 @@ func TestFormatResponseSlackToolDebugError(t *testing.T) {
 func TestFormatResponseMarkdownToolDebug(t *testing.T) {
 	path := formatResponseScriptPath(t)
 
-	input := "[tool_call] timly.list-containers(page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
+	input := "[tool_call] inventory.list-containers(page=1)\n[tool_result] {\"total\": 7}\n\n---\n\nYou have **7** containers."
 	result, err := RunFormat(path, input, "markdown")
 	if err != nil {
 		t.Fatal(err)
@@ -308,7 +308,7 @@ func TestFormatResponseMarkdownToolDebug(t *testing.T) {
 func TestFormatResponseHTMLToolDebug(t *testing.T) {
 	path := formatResponseScriptPath(t)
 
-	input := "[tool_call] timly.list-containers(page=1)\n[tool_result] ok\n\n---\n\nDone."
+	input := "[tool_call] inventory.list-containers(page=1)\n[tool_result] ok\n\n---\n\nDone."
 	result, err := RunFormat(path, input, "html")
 	if err != nil {
 		t.Fatal(err)
@@ -316,7 +316,7 @@ func TestFormatResponseHTMLToolDebug(t *testing.T) {
 	if !strings.Contains(result, "<blockquote>") {
 		t.Errorf("expected HTML blockquote, got:\n%s", result)
 	}
-	if !strings.Contains(result, "<code>timly.list-containers(page=1)</code>") {
+	if !strings.Contains(result, "<code>inventory.list-containers(page=1)</code>") {
 		t.Errorf("expected HTML code tag, got:\n%s", result)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1482,6 +1482,17 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			log.Info("native tool calls received", "round", i+1, "count", len(calls))
 		} else {
 			calls = o.parser.Parse(resp.Content)
+			// Phase 4: emit tool_call_parse_failed when the LLM clearly
+			// attempted a structured tool call (a [tool_call] / <invoke> /
+			// <function_calls> marker is present) but the parser produced
+			// no valid call. Detected post-Parse rather than instrumenting
+			// the parser to avoid an interface-signature ripple. raw_snippet
+			// is the full response content (excerpted + sanitized by the
+			// emit helper); per-block error detail is not surfaced today
+			// because the default parser silently continues on each
+			// individual decode failure — capturing that would require a
+			// failures slice on the ToolCallParser interface, deferred.
+			o.emitParseFailedIfApplicable(ctx, resp.Content, calls)
 		}
 		if calls == nil {
 			// Detect hallucinated results: the LLM fabricated a response with
@@ -3261,6 +3272,42 @@ func (o *Orchestrator) emitToolCallNotFound(ctx context.Context, call ToolCall) 
 		return
 	}
 	emit.EmitToolCallNotFound(ctx, o.eventSink, call.Plugin+"."+call.Action)
+}
+
+// emitParseFailedIfApplicable emits one tool_call_parse_failed event when
+// the response contains a structured tool-call marker but the parser
+// produced no valid call. Narrated-placeholder is excluded — that path
+// signals "LLM never tried the format", not a decode failure. An
+// empty-plugin placeholder in calls indicates "parser saw a block but
+// could not decode its body" (default parser's sawBlock fallback +
+// bare-JSON-without-tool-key fallback both produce this signal). Mixed
+// success (some valid calls + a discarded malformed block) does NOT
+// trigger this — len(calls) > 0 with no empty-plugin entry is treated as
+// success, accepting the v1 limitation noted at the call site.
+func (o *Orchestrator) emitParseFailedIfApplicable(ctx context.Context, response string, calls []ToolCall) {
+	if !containsToolCallMarker(response) {
+		return
+	}
+	if IsNarratedPlaceholder(calls) {
+		return
+	}
+	if calls != nil {
+		hasEmptyPlugin := false
+		for _, c := range calls {
+			if c.Plugin == "" {
+				hasEmptyPlugin = true
+				break
+			}
+		}
+		if !hasEmptyPlugin {
+			return
+		}
+	}
+	emit.EmitToolCallParseFailed(ctx, o.eventSink, emit.ToolCallParseFailedArgs{
+		RawSnippet: response,
+		ParserUsed: "default",
+		ParseError: "tool-call marker present but no valid tool call could be decoded",
+	})
 }
 
 // emitRefusalResult emits a tool_call_result with status="error" for policy

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -153,7 +153,7 @@ type OrchestratorOpts struct {
 	GroupPluginLookup       GroupPluginLookup      // optional; when set, filters tool list by profile group
 	UsageRecorder           UsageRecorder          // optional; when set, records LLM usage after each run
 	PluginCallObserver      PluginCallObserver     // optional; when set, notified after each plugin/tool call
-	EventSink               emit.Sink              // optional; when set, structured session events are emitted; nil defaults to emit.NoOpSink
+	EventSink               emit.Sink              // optional; nil defaults to emit.NoOpSink (helpers run unconditionally, the no-op sink discards them)
 	PromptSnapshotStore     PromptSnapshotUpserter // optional; when set, system prompt + server instructions + tool descriptions are persisted by sha256 so turn_start hashes resolve to content
 	SyncActionsPlugin       string                 // optional; plugin name for action sync (e.g. "weaviate")
 	SyncActionsAction       string                 // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -211,9 +211,10 @@ type Orchestrator struct {
 	summarizePrompt         string                        // system prompt for initial summarization (config; empty = default English)
 	summarizeUpdatePrompt   string                        // system prompt for updating summary (config; empty = default English)
 	planner                 *pipeline.Planner             // nil = pipeline disabled
-	pendingMu               sync.Mutex                    // guards pendingPipelines and pendingToolCalls maps
-	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline (access via pendingMu)
-	pendingToolCalls        map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
+	pendingMu              sync.Mutex                    // guards pendingPipelines, pendingToolCalls, pendingConfirmationIDs
+	pendingPipelines       map[string]*pipeline.Pipeline // sessionID -> pending pipeline
+	pendingToolCalls       map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
+	pendingConfirmationIDs map[string]string             // sessionID -> session-event id of the confirmation_requested event; stamped as parent on the matching confirmation_resolved emit
 	pipelineConfig          pipeline.PipelineConfig
 	confirmationPlugin      string                 // optional; plugin for confirmation strategy
 	confirmationAction      string                 // optional; action name for confirmation check
@@ -344,6 +345,7 @@ func NewWithRules(
 		planner:                 planner,
 		pendingPipelines:        make(map[string]*pipeline.Pipeline),
 		pendingToolCalls:        make(map[string]*ToolCall),
+		pendingConfirmationIDs:  make(map[string]string),
 		pipelineConfig:          pipelineCfg,
 		confirmationPlugin:      opts.ConfirmationPlugin,
 		confirmationAction:      opts.ConfirmationAction,
@@ -822,11 +824,21 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	}
 	o.pendingMu.Lock()
 	pendingPipeline := o.pendingPipelines[sessionID]
+	pendingPipelineConfID := o.pendingConfirmationIDs[sessionID]
 	if pendingPipeline != nil {
 		delete(o.pendingPipelines, sessionID)
+		delete(o.pendingConfirmationIDs, sessionID)
 	}
 	o.pendingMu.Unlock()
 	if p := pendingPipeline; p != nil {
+		// Parent the resolved event onto the original confirmation_requested
+		// so analytics can pair the two across turns. Empty id (no sink at
+		// request time, or pre-instrumentation pending state) leaves the
+		// turn_start parent in place.
+		resolvedCtx := ctx
+		if pendingPipelineConfID != "" {
+			resolvedCtx = emit.WithParent(ctx, pendingPipelineConfID)
+		}
 		var decision pipeline.ConfirmationDecision
 		if o.planner != nil {
 			d, classErr := o.planner.ClassifyConfirmation(ctx, userMessage)
@@ -842,7 +854,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		log.Debug("pipeline pending", "pipeline_id", p.ID, "session", sessionID, "input", userMessage, "decision", decision)
 		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
 		if decision == pipeline.Approved {
-			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "approve"})
+			emit.EmitConfirmationResolved(resolvedCtx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "approve"})
 			log.Debug("pipeline executing", "pipeline_id", p.ID, "steps", len(p.Steps))
 			res, err := o.executePipeline(ctx, sessionID, p)
 			if err == nil && res != nil {
@@ -853,7 +865,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			return res, err
 		}
-		emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "reject"})
+		emit.EmitConfirmationResolved(resolvedCtx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "reject"})
 		resp := "Pipeline cancelled."
 		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
 		log.Debug("pipeline rejected", "pipeline_id", p.ID, "input", userMessage)
@@ -871,18 +883,31 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// metadata (survives restarts and multi-instance deployments).
 	o.pendingMu.Lock()
 	pendingCall := o.pendingToolCalls[sessionID]
+	pendingCallConfID := o.pendingConfirmationIDs[sessionID]
 	if pendingCall != nil {
 		delete(o.pendingToolCalls, sessionID)
+		delete(o.pendingConfirmationIDs, sessionID)
 	}
 	o.pendingMu.Unlock()
 	if pendingCall == nil {
-		pendingCall = loadPendingToolCall(sessions, sessionID)
+		// Fallback: in-memory state lost (pod restart, failover). Recover
+		// the call AND the original confirmation_requested event id from
+		// session metadata so the resolved event still links to the
+		// request that started the pending state.
+		pendingCall, pendingCallConfID = loadPendingToolCall(sessions, sessionID)
 	}
 	if pendingCall != nil {
 		_ = sessions.SetMetadata(sessionID, "pending_tool_call", "")
 	}
 	toolCallConfirmed := false
 	if tc := pendingCall; tc != nil {
+		// Parent the resolved event onto the matching confirmation_requested
+		// (potentially from a prior turn or even a prior pod). Empty id is
+		// the legacy/pre-instrumentation path — leave the turn_start parent.
+		resolvedCtx := ctx
+		if pendingCallConfID != "" {
+			resolvedCtx = emit.WithParent(ctx, pendingCallConfID)
+		}
 		var decision pipeline.ConfirmationDecision
 		// Prefer explicit frontend signal (metadata["confirmation"]) over
 		// LLM-based or text-based classification — faster and deterministic.
@@ -907,7 +932,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// Only record the user's approval in session — rejections are
 			// kept out so the LLM doesn't avoid re-calling the tool later.
 			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
-			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{
+			emit.EmitConfirmationResolved(resolvedCtx, o.eventSink, emit.ConfirmationResolvedArgs{
 				Choice:     "approve",
 				ToolCallID: tc.ID,
 			})
@@ -934,7 +959,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// LLM summarizes the result for the user.
 			toolCallConfirmed = true
 		} else {
-			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{
+			emit.EmitConfirmationResolved(resolvedCtx, o.eventSink, emit.ConfirmationResolvedArgs{
 				Choice:     "reject",
 				ToolCallID: tc.ID,
 			})
@@ -1060,13 +1085,19 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		// is intentionally not instrumented here: those calls are short
 		// classifications, not full plans, and would dilute the analytics
 		// signal if grouped under the same event_type.
-		emit.EmitPlannerInvoked(ctx, o.eventSink, "agent_loop")
-		emit.EmitPlannerRequest(ctx, o.eventSink, emit.PlannerRequestArgs{
+		plannerInvokedID := emit.EmitPlannerInvoked(ctx, o.eventSink, "agent_loop")
+		// Scope planner-internal emits — including the LLM call's
+		// llm_request/llm_response, which fire from the provider while
+		// Plan() runs — under planner_invoked as their parent. The outer
+		// ctx (rooted at turn_start) is untouched, so the agent loop
+		// below isn't pulled into the planner span.
+		plannerCtx := emit.WithParent(ctx, plannerInvokedID)
+		emit.EmitPlannerRequest(plannerCtx, o.eventSink, emit.PlannerRequestArgs{
 			ModelID:      "", // planner uses provider-default routing; not exposed by pipeline.Planner
 			MessageCount: 2,  // planner hardcodes system+user, see pipeline.Planner.Plan
 		})
 		plannerStart := time.Now()
-		planResult, err := o.planner.Plan(ctx, stripKnowledgeContext(content), capabilitiesToPlannerInfo(plannerCaps), convContext)
+		planResult, err := o.planner.Plan(plannerCtx, stripKnowledgeContext(content), capabilitiesToPlannerInfo(plannerCaps), convContext)
 		plannerLatency := time.Since(plannerStart).Milliseconds()
 		var plannerRaw string
 		if err != nil {
@@ -1076,7 +1107,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			plannerRaw = fmt.Sprintf("planner ok: type=%s steps=%d", planResult.Type, len(planResult.Steps))
 			log.Debug("planner result", "type", planResult.Type, "steps", len(planResult.Steps))
 		}
-		emit.EmitPlannerResponse(ctx, o.eventSink, emit.PlannerResponseArgs{
+		emit.EmitPlannerResponse(plannerCtx, o.eventSink, emit.PlannerResponseArgs{
 			RawContent: plannerRaw,
 			LatencyMS:  plannerLatency,
 		})
@@ -1086,7 +1117,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				if step.Command != nil {
 					note = step.Command.Plugin + "." + step.Command.Action
 				}
-				emit.EmitPlannerStep(ctx, o.eventSink, emit.PlannerStepArgs{
+				emit.EmitPlannerStep(plannerCtx, o.eventSink, emit.PlannerStepArgs{
 					StepIndex: i,
 					StepKind:  "tool",
 					Note:      note,
@@ -1179,9 +1210,6 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				}
 				p := pipeline.NewPipeline(writeSteps, o.pipelineConfig)
 				p.Context = readPipeline.Context
-				o.pendingMu.Lock()
-				o.pendingPipelines[sessionID] = p
-				o.pendingMu.Unlock()
 				// Narrate only the write steps for confirmation.
 				var planText string
 				if narrated, narrateErr := o.planner.NarratePlan(ctx, writeSteps, content); narrateErr != nil {
@@ -1192,10 +1220,16 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 				log.Debug("pipeline stored, awaiting confirmation for write steps",
 					"pipeline_id", p.ID, "session", sessionID, "write_steps", len(writeSteps))
-				emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+				confID := emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
 					Prompt:  planText,
 					Choices: []string{"approve", "reject"},
 				})
+				o.pendingMu.Lock()
+				o.pendingPipelines[sessionID] = p
+				if confID != "" {
+					o.pendingConfirmationIDs[sessionID] = confID
+				}
+				o.pendingMu.Unlock()
 				return &RunResult{
 					Response: planText,
 					Metadata: map[string]string{
@@ -1208,9 +1242,6 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			// ConfirmBeforeStep == 0: confirm entire pipeline (original behavior).
 			p := pipeline.NewPipeline(planResult.Steps, o.pipelineConfig)
-			o.pendingMu.Lock()
-			o.pendingPipelines[sessionID] = p
-			o.pendingMu.Unlock()
 			var planText string
 			if narrated, narrateErr := o.planner.NarratePlan(ctx, planResult.Steps, content); narrateErr != nil {
 				log.Warn("plan narration failed, using fallback", "error", narrateErr)
@@ -1220,10 +1251,16 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 			log.Debug("pipeline stored, awaiting confirmation", "pipeline_id", p.ID, "session", sessionID, "steps", len(p.Steps))
-			emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+			confID := emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
 				Prompt:  planText,
 				Choices: []string{"approve", "reject"},
 			})
+			o.pendingMu.Lock()
+			o.pendingPipelines[sessionID] = p
+			if confID != "" {
+				o.pendingConfirmationIDs[sessionID] = confID
+			}
+			o.pendingMu.Unlock()
 			return &RunResult{
 				Response: planText,
 				Metadata: map[string]string{
@@ -1390,7 +1427,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// confirmation) intentionally bypass this emission: the LLM is not
 	// driving those decisions, so there's no "turn" to start. They still
 	// emit user_message (above) because the user did send input.
-	emit.EmitTurnStart(ctx, o.eventSink, o.prepareTurnStart(ctx, sysPromptWithHint, profileModel, cachedTools))
+	turnStartID := emit.EmitTurnStart(ctx, o.eventSink, o.prepareTurnStart(ctx, sysPromptWithHint, profileModel, cachedTools))
+	// Root every subsequent event in this turn under turn_start by
+	// stamping it as the default parent on ctx. Specific spans (planner,
+	// llm_response, tool_call_extracted) overwrite this slot with their
+	// own id before nested emits so the analytics tree has tight scopes
+	// — turn_start is the fallback root, not a flat list of children.
+	ctx = emit.WithParent(ctx, turnStartID)
 
 	var stripRetries int
 	var toolRetries int // retries when planner expected tools but LLM didn't call any
@@ -1514,6 +1557,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		llmDuration := time.Since(llmStart)
 		if err != nil {
 			return nil, fmt.Errorf("LLM completion: %w", err)
+		}
+		// Stamp the just-emitted llm_response as parent for the rest of
+		// this iteration: tool_call_extracted / tool_call_result / retry
+		// / confirmation events all form a tight subtree under the LLM
+		// response that produced them. The next iteration's llm_request
+		// inherits this parent, which produces a chain of rounds — each
+		// round is causally a continuation of the previous, so the chain
+		// is the correct semantic. resp.EventID is "" when no sink is
+		// configured or the response was a refusal; we leave ctx alone
+		// in that case so the existing turn_start parent stays.
+		if resp.EventID != "" {
+			ctx = emit.WithParent(ctx, resp.EventID)
 		}
 		log.Info("LLM response", "round", i+1, "duration", llmDuration.Round(time.Millisecond).String(), "input_tokens", resp.Usage.InputTokens, "output_tokens", resp.Usage.OutputTokens, "content", resp.Content)
 
@@ -1765,12 +1820,6 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				if confResult.RequiresConfirmation {
 					log.Info("tool call requires confirmation", "plugin", calls[i].Plugin, "action", calls[i].Action)
 					pending := calls[i]
-					o.pendingMu.Lock()
-					o.pendingToolCalls[sessionID] = &pending
-					o.pendingMu.Unlock()
-					// Also persist to session metadata so pending calls survive
-					// restarts and work across multiple instances.
-					savePendingToolCall(sessions, sessionID, &pending)
 					// Build a confirmation message describing what will be done.
 					// Prefer LLM narration to hide raw tool names from the user.
 					var confirmMsg string
@@ -1793,11 +1842,23 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 					// for the next turn (approval or follow-up questions). On
 					// rejection, the rollback (msgCountAtStart) removes it.
 					_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: confirmMsg})
-					emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+					confID := emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
 						Prompt:     confirmMsg,
 						Choices:    []string{"approve", "reject"},
 						ToolCallID: calls[i].ID,
 					})
+					o.pendingMu.Lock()
+					o.pendingToolCalls[sessionID] = &pending
+					if confID != "" {
+						o.pendingConfirmationIDs[sessionID] = confID
+					}
+					o.pendingMu.Unlock()
+					// Also persist to session metadata so pending calls survive
+					// restarts and work across multiple instances. The
+					// confirmation_requested event id is embedded in the
+					// serialized form so the parent_id linkage survives
+					// pod restarts and multi-instance failover.
+					savePendingToolCall(sessions, sessionID, &pending, confID)
 					return &RunResult{
 						Response: confirmMsg,
 						Metadata: map[string]string{
@@ -2068,6 +2129,10 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 		logger.FromContext(ctx).Debug("streaming unavailable, falling back to complete", "error", err)
 		return o.llm.Complete(ctx, req)
 	}
+	// Close is idempotent (see oaiResponseStream.closed guard); the
+	// explicit Close after the loop forces emitStreamEnd to fire BEFORE
+	// we read EventID below, so the deferred Close becomes a safety net
+	// rather than the actual emit trigger.
 	defer func() { _ = stream.Close() }()
 
 	var buf strings.Builder
@@ -2108,10 +2173,20 @@ func (o *Orchestrator) streamComplete(ctx context.Context, req *provider.Complet
 		}
 	}
 
+	// Fire the end-of-stream emit now so EventID is populated before we
+	// build the response. Any stream implementation that doesn't surface
+	// an event id (test fakes, future providers) simply returns "".
+	_ = stream.Close()
+	var eventID string
+	if exposer, ok := stream.(interface{ EventID() string }); ok {
+		eventID = exposer.EventID()
+	}
+
 	return &provider.CompletionResponse{
 		Content: buf.String(),
 		Model:   model,
 		Usage:   usage,
+		EventID: eventID,
 	}, nil
 }
 
@@ -3137,8 +3212,9 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	// (raw-capture rule). Internal calls (preparers, guards, pipelines)
 	// are host-orchestrated, not part of the LLM reasoning trace, and are
 	// not emitted. CallID joins the matching tool_call_result emitted
-	// further down; session_events.parent_id linkage is reserved for a
-	// follow-up that introduces producer-side event_id generation.
+	// further down; tool_call_extracted's event id is also stamped onto
+	// ctx via WithParent so the eventual tool_call_result and any
+	// refusal/not-found emits in between link back via parent_id.
 	//
 	// dispatchStart is initialized unconditionally so emitRefusalResult
 	// can compute a meaningful LatencyMS regardless of where the policy
@@ -3155,13 +3231,16 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 		// frozen here BEFORE the context-arg injection below mutates
 		// call.Args. If this emit ever becomes async, the call.Args map
 		// must be copied first to preserve the raw-capture invariant.
-		emit.EmitToolCallExtracted(ctx, o.eventSink, emit.ToolCallExtractedArgs{
+		extractedID := emit.EmitToolCallExtracted(ctx, o.eventSink, emit.ToolCallExtractedArgs{
 			CallID:    call.ID,
 			Plugin:    call.Plugin,
 			Action:    call.Action,
 			Arguments: call.Args,
 			Mode:      mode,
 		})
+		if extractedID != "" {
+			ctx = emit.WithParent(ctx, extractedID)
+		}
 	}
 
 	if call.Plugin == "" {
@@ -3578,15 +3657,28 @@ func formatToolCallMessage(call ToolCall) string {
 
 // pendingToolCallMeta is the JSON-serializable form of a pending tool call
 // stored in session metadata so it survives restarts.
+//
+// ConfirmationRequestedID carries the session-event id of the
+// confirmation_requested event that started this pending state, so the
+// matching confirmation_resolved event can be parented back to it even
+// across pod restarts or multi-instance failover where the in-memory
+// pendingConfirmationIDs map is empty.
 type pendingToolCallMeta struct {
-	ID     string            `json:"id"`
-	Plugin string            `json:"plugin"`
-	Action string            `json:"action"`
-	Args   map[string]string `json:"args,omitempty"`
+	ID                      string            `json:"id"`
+	Plugin                  string            `json:"plugin"`
+	Action                  string            `json:"action"`
+	Args                    map[string]string `json:"args,omitempty"`
+	ConfirmationRequestedID string            `json:"confirmation_requested_id,omitempty"`
 }
 
-func savePendingToolCall(sessions SessionStoreInterface, sessionID string, tc *ToolCall) {
-	meta := pendingToolCallMeta{ID: tc.ID, Plugin: tc.Plugin, Action: tc.Action, Args: tc.Args}
+func savePendingToolCall(sessions SessionStoreInterface, sessionID string, tc *ToolCall, confirmationRequestedID string) {
+	meta := pendingToolCallMeta{
+		ID:                      tc.ID,
+		Plugin:                  tc.Plugin,
+		Action:                  tc.Action,
+		Args:                    tc.Args,
+		ConfirmationRequestedID: confirmationRequestedID,
+	}
 	data, err := json.Marshal(meta)
 	if err != nil {
 		return
@@ -3594,20 +3686,23 @@ func savePendingToolCall(sessions SessionStoreInterface, sessionID string, tc *T
 	_ = sessions.SetMetadata(sessionID, "pending_tool_call", string(data))
 }
 
-func loadPendingToolCall(sessions SessionStoreInterface, sessionID string) *ToolCall {
+// loadPendingToolCall restores the pending tool call from session metadata.
+// Returns the ToolCall and the confirmation_requested event id (empty when
+// the persisted row predates the field or no event was captured).
+func loadPendingToolCall(sessions SessionStoreInterface, sessionID string) (*ToolCall, string) {
 	sess, err := sessions.Get(sessionID)
 	if err != nil || sess == nil {
-		return nil
+		return nil, ""
 	}
 	raw := sess.Metadata["pending_tool_call"]
 	if raw == "" {
-		return nil
+		return nil, ""
 	}
 	var meta pendingToolCallMeta
 	if json.Unmarshal([]byte(raw), &meta) != nil {
-		return nil
+		return nil, ""
 	}
-	return &ToolCall{ID: meta.ID, Plugin: meta.Plugin, Action: meta.Action, Args: meta.Args}
+	return &ToolCall{ID: meta.ID, Plugin: meta.Plugin, Action: meta.Action, Args: meta.Args}, meta.ConfirmationRequestedID
 }
 
 // toolCallSignature builds a deterministic string from a set of tool calls

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3041,7 +3041,41 @@ func rejectUnknownArgs(call ToolCall, action *Action) error {
 }
 
 func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResult {
+	// Phase 3: emit tool_call_extracted at the very top for LLM-originated
+	// calls so the raw decoded view is captured before any validation,
+	// normalization, policy gating, or context-arg injection mutates it
+	// (raw-capture rule). Internal calls (preparers, guards, pipelines)
+	// are host-orchestrated, not part of the LLM reasoning trace, and are
+	// not emitted. CallID joins the matching tool_call_result emitted
+	// further down; session_events.parent_id linkage is reserved for a
+	// follow-up that introduces producer-side event_id generation.
+	//
+	// dispatchStart is initialized unconditionally so emitRefusalResult
+	// can compute a meaningful LatencyMS regardless of where the policy
+	// gate fires. Even non-FromLLM calls pay one time.Now() — cheap and
+	// keeps the contract simple.
+	dispatchStart := time.Now()
+	if call.FromLLM {
+		mode := emit.ToolCallModeText
+		if o.supportsNativeTools() {
+			mode = emit.ToolCallModeNative
+		}
+		// Arguments captured as the raw map ref; send() in the emit
+		// package marshals payload synchronously, so the JSON snapshot is
+		// frozen here BEFORE the context-arg injection below mutates
+		// call.Args. If this emit ever becomes async, the call.Args map
+		// must be copied first to preserve the raw-capture invariant.
+		emit.EmitToolCallExtracted(ctx, o.eventSink, emit.ToolCallExtractedArgs{
+			CallID:    call.ID,
+			Plugin:    call.Plugin,
+			Action:    call.Action,
+			Arguments: call.Args,
+			Mode:      mode,
+		})
+	}
+
 	if call.Plugin == "" {
+		o.emitToolCallNotFound(ctx, call)
 		return ToolResult{
 			CallID: call.ID,
 			Error:  `tool call format not recognized. You MUST use this exact format: [tool_call] {"tool": "plugin.action", "args": {"key": "value"}} [/tool_call]. Do NOT use XML or any other format. Retry the same action now using the correct format.`,
@@ -3049,6 +3083,7 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	}
 	exec, ok := o.registry.GetExecutor(call.Plugin)
 	if !ok {
+		o.emitToolCallNotFound(ctx, call)
 		return ToolResult{
 			CallID: call.ID,
 			Error:  fmt.Sprintf("plugin %q not found", call.Plugin),
@@ -3075,6 +3110,7 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 			}
 		}
 		if !resolved {
+			o.emitToolCallNotFound(ctx, call)
 			return ToolResult{
 				CallID: call.ID,
 				Error:  fmt.Sprintf("action %q not found in plugin %q", call.Action, call.Plugin),
@@ -3091,16 +3127,10 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 		allowed, err := o.permissionChecker.Allowed(ctx, actorID, call.Plugin)
 		if err != nil {
 			slog.Warn("permission check failed", "actor", actorID, "plugin", call.Plugin, "error", err)
-			return ToolResult{
-				CallID: call.ID,
-				Error:  "permission denied",
-			}
+			return o.emitRefusalResult(ctx, call, "permission denied", dispatchStart)
 		}
 		if !allowed {
-			return ToolResult{
-				CallID: call.ID,
-				Error:  "permission denied",
-			}
+			return o.emitRefusalResult(ctx, call, "permission denied", dispatchStart)
 		}
 	}
 
@@ -3134,10 +3164,9 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 				"in_allowlist", allowed.m[capForCheck.Name],
 				"allowlist_keys", mapKeys(allowed.m),
 			)
-			return ToolResult{
-				CallID: call.ID,
-				Error:  fmt.Sprintf("plugin %q is not available for this profile", call.Plugin),
-			}
+			return o.emitRefusalResult(ctx, call,
+				fmt.Sprintf("plugin %q is not available for this profile", call.Plugin),
+				dispatchStart)
 		} else {
 			slog.Debug("tool call allowed",
 				"plugin", call.Plugin,
@@ -3150,10 +3179,9 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 
 	if call.FromLLM && action != nil && action.UserOnly {
 		slog.Warn("BLOCKED LLM attempt to invoke user_only action", "actor", actorID, "plugin", call.Plugin, "action", call.Action, "args", call.Args)
-		return ToolResult{
-			CallID: call.ID,
-			Error:  fmt.Sprintf("action %q can only be invoked by the user, not the LLM", call.Action),
-		}
+		return o.emitRefusalResult(ctx, call,
+			fmt.Sprintf("action %q can only be invoked by the user, not the LLM", call.Action),
+			dispatchStart)
 	}
 	// Reject unknown args from LLM-originated calls. Without this, stray keys
 	// (e.g. Haiku emitting `message=` at top level instead of inside `args`)
@@ -3163,9 +3191,22 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	// exempt — they construct calls programmatically and may legitimately use
 	// names outside the declared Parameters set. InjectContextArgs are not
 	// accepted from the LLM; the host injects them below.
+	// rejectUnknownArgs is pre-dispatch validation: emit
+	// tool_call_args_invalid (its own typed failure event) and return
+	// early. Unlike the policy refusals further up, no tool_call_result
+	// fires here — the dispatcher never ran, so there is no "result" to
+	// record. Consumer-side analytics count
+	//   extracted == not_found + args_invalid + result
+	// for orthogonality.
 	if call.FromLLM && action != nil && len(call.Args) > 0 {
 		if err := rejectUnknownArgs(call, action); err != nil {
 			slog.Warn("BLOCKED LLM call with unknown args", "plugin", call.Plugin, "action", call.Action, "error", err.Error())
+			emit.EmitToolCallArgsInvalid(ctx, o.eventSink, emit.ToolCallArgsInvalidArgs{
+				CallID:          call.ID,
+				Plugin:          call.Plugin,
+				Action:          call.Action,
+				ValidationError: err.Error(),
+			})
 			return ToolResult{CallID: call.ID, Error: err.Error()}
 		}
 	}
@@ -3194,7 +3235,50 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	result := o.guard.ExecuteWithTimeout(ctx, exec, call)
 	result = o.guard.ValidateResult(call, result)
 	result = o.guard.Sanitize(result)
+	if call.FromLLM {
+		status := "ok"
+		respBody := result.Content
+		if result.Error != "" {
+			status = "error"
+			respBody = result.Error
+		}
+		emit.EmitToolCallResult(ctx, o.eventSink, emit.ToolCallResultArgs{
+			CallID:    call.ID,
+			Status:    status,
+			Response:  respBody,
+			LatencyMS: time.Since(dispatchStart).Milliseconds(),
+		})
+	}
 	return result
+}
+
+// emitToolCallNotFound emits a tool_call_not_found event for an LLM-originated
+// call whose plugin or action could not be resolved. The requested-name format
+// matches the LLM's own "plugin.action" naming convention so analytics can
+// group mis-spellings without re-parsing.
+func (o *Orchestrator) emitToolCallNotFound(ctx context.Context, call ToolCall) {
+	if !call.FromLLM {
+		return
+	}
+	emit.EmitToolCallNotFound(ctx, o.eventSink, call.Plugin+"."+call.Action)
+}
+
+// emitRefusalResult emits a tool_call_result with status="error" for policy
+// refusals (permission denied, restricted plugin, user-only action) and
+// returns the matching ToolResult. The call was extracted and identified
+// before the refusal, so tool_call_result — not tool_call_not_found — is
+// the right shape; the error message is captured verbatim in response_excerpt
+// for downstream attribution.
+func (o *Orchestrator) emitRefusalResult(ctx context.Context, call ToolCall, errMsg string, dispatchStart time.Time) ToolResult {
+	if call.FromLLM {
+		emit.EmitToolCallResult(ctx, o.eventSink, emit.ToolCallResultArgs{
+			CallID:    call.ID,
+			Status:    "error",
+			Response:  errMsg,
+			LatencyMS: time.Since(dispatchStart).Milliseconds(),
+		})
+	}
+	return ToolResult{CallID: call.ID, Error: errMsg}
 }
 
 func (o *Orchestrator) maybeRecordWorkflow(ctx context.Context, result *RunResult, userMessage string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1036,11 +1036,52 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		// "which type of object?").
 		sess, _ := sessions.Get(sessionID)
 		convContext := buildPlannerConversationContext(sess)
+		// Planner instrumentation: invoked + request fire before the
+		// synchronous Plan() call; response fires after with a synthetic
+		// summary in raw_content_excerpt because the pipeline.Planner
+		// parses and discards the raw LLM response internally (capturing
+		// the raw bytes would require a planner-pkg refactor — out of
+		// scope here). One planner_step event per Step is emitted only on
+		// pipeline plans; direct plans have no steps to enumerate.
+		//
+		// Reason "agent_loop" marks the main per-turn planning call. The
+		// planner's other entry point — ClassifyConfirmation, used by
+		// pending-pipeline / pending-tool-call confirmation paths above —
+		// is intentionally not instrumented here: those calls are short
+		// classifications, not full plans, and would dilute the analytics
+		// signal if grouped under the same event_type.
+		emit.EmitPlannerInvoked(ctx, o.eventSink, "agent_loop")
+		emit.EmitPlannerRequest(ctx, o.eventSink, emit.PlannerRequestArgs{
+			ModelID:      "", // planner uses provider-default routing; not exposed by pipeline.Planner
+			MessageCount: 2,  // planner hardcodes system+user, see pipeline.Planner.Plan
+		})
+		plannerStart := time.Now()
 		planResult, err := o.planner.Plan(ctx, stripKnowledgeContext(content), capabilitiesToPlannerInfo(plannerCaps), convContext)
+		plannerLatency := time.Since(plannerStart).Milliseconds()
+		var plannerRaw string
 		if err != nil {
+			plannerRaw = "planner error: " + err.Error()
 			log.Warn("planner error, falling through to agent loop", "error", err)
 		} else {
+			plannerRaw = fmt.Sprintf("planner ok: type=%s steps=%d", planResult.Type, len(planResult.Steps))
 			log.Debug("planner result", "type", planResult.Type, "steps", len(planResult.Steps))
+		}
+		emit.EmitPlannerResponse(ctx, o.eventSink, emit.PlannerResponseArgs{
+			RawContent: plannerRaw,
+			LatencyMS:  plannerLatency,
+		})
+		if err == nil && planResult.Type == "pipeline" {
+			for i, step := range planResult.Steps {
+				note := ""
+				if step.Command != nil {
+					note = step.Command.Plugin + "." + step.Command.Action
+				}
+				emit.EmitPlannerStep(ctx, o.eventSink, emit.PlannerStepArgs{
+					StepIndex: i,
+					StepKind:  "tool",
+					Note:      note,
+				})
+			}
 		}
 		if err == nil && planResult.Type == "pipeline" && len(planResult.Steps) > 1 {
 			confResult := confirmationResult{RequiresConfirmation: true, ConfirmBeforeStep: 0}
@@ -1482,8 +1523,8 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			log.Info("native tool calls received", "round", i+1, "count", len(calls))
 		} else {
 			calls = o.parser.Parse(resp.Content)
-			// Phase 4: emit tool_call_parse_failed when the LLM clearly
-			// attempted a structured tool call (a [tool_call] / <invoke> /
+			// Emit tool_call_parse_failed when the LLM clearly attempted a
+			// structured tool call (a [tool_call] / <invoke> /
 			// <function_calls> marker is present) but the parser produced
 			// no valid call. Detected post-Parse rather than instrumenting
 			// the parser to avoid an interface-signature ripple. raw_snippet
@@ -1491,7 +1532,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// emit helper); per-block error detail is not surfaced today
 			// because the default parser silently continues on each
 			// individual decode failure — capturing that would require a
-			// failures slice on the ToolCallParser interface, deferred.
+			// failures slice on the ToolCallParser interface.
 			o.emitParseFailedIfApplicable(ctx, resp.Content, calls)
 		}
 		if calls == nil {
@@ -1636,7 +1677,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			return result, nil
 		}
 
-		// The LLM narrated a tool call ("We need to call timly__list-items")
+		// The LLM narrated a tool call ("We need to call plugin__action")
 		// instead of using [tool_call] format. Retry with an explicit nudge.
 		if IsNarratedPlaceholder(calls) {
 			log.Debug("narrated tool call detected, retrying with nudge", "round", i+1)
@@ -2824,7 +2865,7 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 
 	// When RAG filtering is active, list plugins that have actions but none
 	// matched the current query. The LLM can use ask_knowledge to discover
-	// their actions on demand. Use alias names (e.g. "jira", "timly") when
+	// their actions on demand. Use alias names (e.g. "jira", "tickets") when
 	// available, since those are the names the LLM should use.
 	if len(discoverablePlugins) > 0 {
 		sb.WriteString("## Other available plugins\n")
@@ -3052,8 +3093,8 @@ func rejectUnknownArgs(call ToolCall, action *Action) error {
 }
 
 func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResult {
-	// Phase 3: emit tool_call_extracted at the very top for LLM-originated
-	// calls so the raw decoded view is captured before any validation,
+	// Emit tool_call_extracted at the very top for LLM-originated calls
+	// so the raw decoded view is captured before any validation,
 	// normalization, policy gating, or context-arg injection mutates it
 	// (raw-capture rule). Internal calls (preparers, guards, pipelines)
 	// are host-orchestrated, not part of the LLM reasoning trace, and are
@@ -3360,12 +3401,21 @@ func (o *Orchestrator) maybeSummarizeSession(ctx context.Context, sessionID stri
 	if len(sess.Messages) < o.summarizeAfterMessages {
 		return
 	}
+	// This fires from a background goroutine started in Run with
+	// context.Background(), so actor.SessionID(ctx) would resolve to "" and
+	// session_events writes would fail validation. Wrap the session id back
+	// onto ctx here so the emit helpers can read it via the standard slot.
+	ctx = actor.WithSessionID(ctx, sessionID)
 	keep := o.maxMessagesAfterSummary
 	if keep > len(sess.Messages) {
 		keep = len(sess.Messages)
 	}
 	toSummarize := sess.Messages[:len(sess.Messages)-keep]
 	keepMessages := sess.Messages[len(sess.Messages)-keep:]
+	emit.EmitSummarizationTriggered(ctx, o.eventSink, emit.SummarizationTriggeredArgs{
+		MessageCount: len(sess.Messages),
+		Reason:       "threshold_reached",
+	})
 
 	var sysPrompt, userContent string
 	if sess.Summary != "" {
@@ -3399,9 +3449,13 @@ func (o *Orchestrator) maybeSummarizeSession(ctx context.Context, sessionID stri
 			{Role: provider.RoleUser, Content: userContent},
 		},
 	}
+	summarizeStart := time.Now()
 	resp, err := o.llm.Complete(ctx, req)
 	if err != nil {
 		slog.Warn("session summarization failed", "error", err)
+		// No completed event on LLM failure: triggered-without-completed
+		// is the analytics signal for "summarization started but did not
+		// finish". Same pattern as other failure-mode events in this file.
 		return
 	}
 	newSummary := strings.TrimSpace(resp.Content)
@@ -3409,8 +3463,20 @@ func (o *Orchestrator) maybeSummarizeSession(ctx context.Context, sessionID stri
 		return
 	}
 	if err := o.sessions.SetSummary(sessionID, newSummary, keepMessages); err != nil {
+		// Same "triggered without completed" failure signal as the LLM
+		// error path above. SessionStore.SetSummary only errors on
+		// "session not found", which is already excluded by the earlier
+		// Get() check; reaching this branch would require the session
+		// being deleted concurrently between Get and SetSummary. Treated
+		// as a defensive return for that race, no dedicated test.
 		slog.Warn("set session summary failed", "error", err)
+		return
 	}
+	emit.EmitSummarizationCompleted(ctx, o.eventSink, emit.SummarizationCompletedArgs{
+		Summary:      newSummary,
+		KeptMessages: len(keepMessages),
+		LatencyMS:    time.Since(summarizeStart).Milliseconds(),
+	})
 }
 
 // RunAction executes a single plugin action directly, bypassing the LLM loop.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -211,10 +211,10 @@ type Orchestrator struct {
 	summarizePrompt         string                        // system prompt for initial summarization (config; empty = default English)
 	summarizeUpdatePrompt   string                        // system prompt for updating summary (config; empty = default English)
 	planner                 *pipeline.Planner             // nil = pipeline disabled
-	pendingMu              sync.Mutex                    // guards pendingPipelines, pendingToolCalls, pendingConfirmationIDs
-	pendingPipelines       map[string]*pipeline.Pipeline // sessionID -> pending pipeline
-	pendingToolCalls       map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
-	pendingConfirmationIDs map[string]string             // sessionID -> session-event id of the confirmation_requested event; stamped as parent on the matching confirmation_resolved emit
+	pendingMu               sync.Mutex                    // guards pendingPipelines, pendingToolCalls, pendingConfirmationIDs
+	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline
+	pendingToolCalls        map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
+	pendingConfirmationIDs  map[string]string             // sessionID -> session-event id of the confirmation_requested event; stamped as parent on the matching confirmation_resolved emit
 	pipelineConfig          pipeline.PipelineConfig
 	confirmationPlugin      string                 // optional; plugin for confirmation strategy
 	confirmationAction      string                 // optional; action name for confirmation check

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -842,6 +842,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		log.Debug("pipeline pending", "pipeline_id", p.ID, "session", sessionID, "input", userMessage, "decision", decision)
 		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
 		if decision == pipeline.Approved {
+			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "approve"})
 			log.Debug("pipeline executing", "pipeline_id", p.ID, "steps", len(p.Steps))
 			res, err := o.executePipeline(ctx, sessionID, p)
 			if err == nil && res != nil {
@@ -852,6 +853,7 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			return res, err
 		}
+		emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{Choice: "reject"})
 		resp := "Pipeline cancelled."
 		_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: resp})
 		log.Debug("pipeline rejected", "pipeline_id", p.ID, "input", userMessage)
@@ -905,6 +907,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// Only record the user's approval in session — rejections are
 			// kept out so the LLM doesn't avoid re-calling the tool later.
 			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleUser, Content: userMessage})
+			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{
+				Choice:     "approve",
+				ToolCallID: tc.ID,
+			})
 			log.Debug("tool call confirmed, executing", "plugin", tc.Plugin, "action", tc.Action)
 			result := o.executeCall(ctx, *tc)
 			// Record in session history.
@@ -928,6 +934,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// LLM summarizes the result for the user.
 			toolCallConfirmed = true
 		} else {
+			emit.EmitConfirmationResolved(ctx, o.eventSink, emit.ConfirmationResolvedArgs{
+				Choice:     "reject",
+				ToolCallID: tc.ID,
+			})
 			// Rollback session to before this Run — remove the user message
 			// and any tool calls/results that were added during the
 			// confirmation attempt. Without this, the LLM sees prior tool
@@ -1182,6 +1192,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 				log.Debug("pipeline stored, awaiting confirmation for write steps",
 					"pipeline_id", p.ID, "session", sessionID, "write_steps", len(writeSteps))
+				emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+					Prompt:  planText,
+					Choices: []string{"approve", "reject"},
+				})
 				return &RunResult{
 					Response: planText,
 					Metadata: map[string]string{
@@ -1206,6 +1220,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			}
 			_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: planText})
 			log.Debug("pipeline stored, awaiting confirmation", "pipeline_id", p.ID, "session", sessionID, "steps", len(p.Steps))
+			emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+				Prompt:  planText,
+				Choices: []string{"approve", "reject"},
+			})
 			return &RunResult{
 				Response: planText,
 				Metadata: map[string]string{
@@ -1542,6 +1560,11 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			if hasHallucinatedResult(resp.Content) && stripRetries < 3 {
 				stripRetries++
 				log.Warn("hallucinated result detected, retrying", "round", i+1)
+				emit.EmitRetry(ctx, o.eventSink, emit.RetryArgs{
+					Phase:     "llm_call",
+					Attempt:   stripRetries,
+					LastError: "hallucinated tool result",
+				})
 				// Escape {{ to { { in the hallucinated content before sending it back —
 				// vLLM chat templates use Jinja2 which chokes on unescaped {{ in messages.
 				escaped := strings.ReplaceAll(resp.Content, "{{", "{ {")
@@ -1568,6 +1591,11 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 					return result, nil
 				}
 				stripRetries++
+				emit.EmitRetry(ctx, o.eventSink, emit.RetryArgs{
+					Phase:     "llm_call",
+					Attempt:   stripRetries,
+					LastError: "empty or unparseable response",
+				})
 				retryHint := "[system] Your previous response was empty or contained only unparseable tool call blocks. Please respond to the user in natural language. If you need to call a tool, use the [tool_call] format shown in your instructions."
 				if resp.Content != "" {
 					transientMessages = []provider.Message{
@@ -1594,6 +1622,11 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			log.Debug("planner retry check", "expected_steps", len(steps), "tool_retries", toolRetries, "will_retry", len(steps) > 0 && toolRetries < 2)
 			if len(steps) > 0 && toolRetries < 2 {
 				toolRetries++
+				emit.EmitRetry(ctx, o.eventSink, emit.RetryArgs{
+					Phase:     "llm_call",
+					Attempt:   toolRetries,
+					LastError: "planner expected tool call but LLM returned plain text",
+				})
 				log.Warn("planner expected tool calls but LLM returned plain text, retrying",
 					"round", i+1, "retry", toolRetries, "expected_steps", len(steps))
 				nudge := buildToolCallNudge(steps)
@@ -1760,6 +1793,11 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 					// for the next turn (approval or follow-up questions). On
 					// rejection, the rollback (msgCountAtStart) removes it.
 					_ = sessions.AddMessage(sessionID, provider.Message{Role: provider.RoleAssistant, Content: confirmMsg})
+					emit.EmitConfirmationRequested(ctx, o.eventSink, emit.ConfirmationRequestedArgs{
+						Prompt:     confirmMsg,
+						Choices:    []string{"approve", "reject"},
+						ToolCallID: calls[i].ID,
+					})
 					return &RunResult{
 						Response: confirmMsg,
 						Metadata: map[string]string{

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -23,6 +23,8 @@ import (
 	"github.com/opentalon/opentalon/internal/prompts"
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
 	pkgchannel "github.com/opentalon/opentalon/pkg/channel"
 )
 
@@ -104,6 +106,17 @@ type UsageRecorder interface {
 	RecordUsage(ctx context.Context, entityID, groupID, channelID, sessionID, modelID string, inputTokens, outputTokens, toolCalls int)
 }
 
+// PromptSnapshotUpserter persists content-addressed prompt bodies so a
+// consumer reading a turn_start event can resolve its system_prompt_sha256,
+// server_instructions[].sha256, and available_tools[].desc_sha256 back to
+// the original text. SessionEventStore satisfies this interface in
+// production; tests may inject a fake. Implementations must be safe to
+// call concurrently and idempotent on conflicting sha256 (first insert
+// wins; later identical writes are no-ops).
+type PromptSnapshotUpserter interface {
+	UpsertPromptSnapshot(ctx context.Context, sha256, kind, content string) error
+}
+
 // PluginCallObserver is notified after each plugin/tool call executed by the orchestrator.
 type PluginCallObserver interface {
 	ObservePluginCall(plugin, action string, failed bool, inputTokens, outputTokens int)
@@ -133,20 +146,22 @@ type OrchestratorOpts struct {
 	PipelineEnabled         bool                          // when true, create Planner from llm
 	PlanTimeout             time.Duration                 // max time for planner LLM call; 0 = default 15s
 	PipelineConfig          pipeline.PipelineConfig
-	ConfirmationPlugin      string              // optional; plugin name for confirmation strategy (e.g. "planner")
-	ConfirmationAction      string              // optional; action name (e.g. "check_confirmation")
-	ContextWindow           int                 // model context window in tokens; 0 = no trimming
-	MaxConcurrentSessions   int                 // max sessions running in parallel; default 1 (sequential)
-	GroupPluginLookup       GroupPluginLookup   // optional; when set, filters tool list by profile group
-	UsageRecorder           UsageRecorder       // optional; when set, records LLM usage after each run
-	PluginCallObserver      PluginCallObserver  // optional; when set, notified after each plugin/tool call
-	SyncActionsPlugin       string              // optional; plugin name for action sync (e.g. "weaviate")
-	SyncActionsAction       string              // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
-	SyncGlossaryAction      string              // optional; action name for glossary sync (e.g. "sync_glossary"); uses SyncActionsPlugin
-	Knowledge               KnowledgeConfig     // optional; knowledge directory ingestion
-	Subprocess              SubprocessConfig    // optional; subprocess (sub-agent) support
-	OnStreamChunk           StreamChunkCallback // optional; when set and LLM supports streaming, final answers are streamed
-	ShowToolCalls           string              // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	ConfirmationPlugin      string                 // optional; plugin name for confirmation strategy (e.g. "planner")
+	ConfirmationAction      string                 // optional; action name (e.g. "check_confirmation")
+	ContextWindow           int                    // model context window in tokens; 0 = no trimming
+	MaxConcurrentSessions   int                    // max sessions running in parallel; default 1 (sequential)
+	GroupPluginLookup       GroupPluginLookup      // optional; when set, filters tool list by profile group
+	UsageRecorder           UsageRecorder          // optional; when set, records LLM usage after each run
+	PluginCallObserver      PluginCallObserver     // optional; when set, notified after each plugin/tool call
+	EventSink               emit.Sink              // optional; when set, structured session events are emitted; nil defaults to emit.NoOpSink
+	PromptSnapshotStore     PromptSnapshotUpserter // optional; when set, system prompt + server instructions + tool descriptions are persisted by sha256 so turn_start hashes resolve to content
+	SyncActionsPlugin       string                 // optional; plugin name for action sync (e.g. "weaviate")
+	SyncActionsAction       string                 // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
+	SyncGlossaryAction      string                 // optional; action name for glossary sync (e.g. "sync_glossary"); uses SyncActionsPlugin
+	Knowledge               KnowledgeConfig        // optional; knowledge directory ingestion
+	Subprocess              SubprocessConfig       // optional; subprocess (sub-agent) support
+	OnStreamChunk           StreamChunkCallback    // optional; when set and LLM supports streaming, final answers are streamed
+	ShowToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -200,19 +215,21 @@ type Orchestrator struct {
 	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline (access via pendingMu)
 	pendingToolCalls        map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
 	pipelineConfig          pipeline.PipelineConfig
-	confirmationPlugin      string              // optional; plugin for confirmation strategy
-	confirmationAction      string              // optional; action name for confirmation check
-	contextWindow           int                 // model context window in tokens; 0 = no trimming
-	groupPluginLookup       GroupPluginLookup   // optional; nil = no group-based filtering
-	usageRecorder           UsageRecorder       // optional; nil = no usage tracking
-	pluginCallObserver      PluginCallObserver  // optional; nil = no plugin call observation
-	syncActionsPlugin       string              // optional; plugin name for action sync
-	syncActionsAction       string              // optional; action name for action sync
-	syncGlossaryAction      string              // optional; action name for glossary sync (uses syncActionsPlugin)
-	knowledge               KnowledgeConfig     // optional; knowledge directory ingestion
-	subprocessConfig        SubprocessConfig    // optional; subprocess (sub-agent) support
-	onStreamChunk           StreamChunkCallback // optional; when set, final answers stream to caller
-	showToolCalls           string              // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	confirmationPlugin      string                 // optional; plugin for confirmation strategy
+	confirmationAction      string                 // optional; action name for confirmation check
+	contextWindow           int                    // model context window in tokens; 0 = no trimming
+	groupPluginLookup       GroupPluginLookup      // optional; nil = no group-based filtering
+	usageRecorder           UsageRecorder          // optional; nil = no usage tracking
+	pluginCallObserver      PluginCallObserver     // optional; nil = no plugin call observation
+	eventSink               emit.Sink              // structured session event sink; always non-nil (NoOpSink default)
+	snapshotStore           PromptSnapshotUpserter // optional; nil = turn_start hashes are emitted but content is not persisted
+	syncActionsPlugin       string                 // optional; plugin name for action sync
+	syncActionsAction       string                 // optional; action name for action sync
+	syncGlossaryAction      string                 // optional; action name for glossary sync (uses syncActionsPlugin)
+	knowledge               KnowledgeConfig        // optional; knowledge directory ingestion
+	subprocessConfig        SubprocessConfig       // optional; subprocess (sub-agent) support
+	onStreamChunk           StreamChunkCallback    // optional; when set, final answers stream to caller
+	showToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
 }
 
 // resolveAllowedPluginNames returns a JSON array of allowed plugin names for the
@@ -298,6 +315,11 @@ func NewWithRules(
 	// Always create a semaphore. cap=1 = sequential (default); cap=N = N parallel sessions.
 	semaphore := make(chan struct{}, maxConcurrent)
 
+	eventSink := opts.EventSink
+	if eventSink == nil {
+		eventSink = emit.NoOpSink{}
+	}
+
 	o := &Orchestrator{
 		sessionMuxes:            make(map[string]*sessionMutex),
 		semaphore:               semaphore,
@@ -329,6 +351,8 @@ func NewWithRules(
 		groupPluginLookup:       opts.GroupPluginLookup,
 		usageRecorder:           opts.UsageRecorder,
 		pluginCallObserver:      opts.PluginCallObserver,
+		eventSink:               eventSink,
+		snapshotStore:           opts.PromptSnapshotStore,
 		syncActionsPlugin:       opts.SyncActionsPlugin,
 		syncActionsAction:       opts.SyncActionsAction,
 		syncGlossaryAction:      opts.SyncGlossaryAction,
@@ -759,6 +783,13 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// Set up trace_id for this session so all logs are correlated.
 	traceID := logger.TraceIDFromSessionKey(sessionID)
 	ctx = logger.WithTraceID(ctx, traceID)
+
+	// Emit user_message exactly as the orchestrator received it, before any
+	// preparer mutates it. Fires on every Run — including paths that exit
+	// without reaching the agent loop (pending pipeline / tool-call
+	// confirmation), because the user did send a message regardless of how
+	// the orchestrator routes it.
+	emit.EmitUserMessage(ctx, o.eventSink, userMessage)
 
 	// Per-session deep debug: enabled by the set_debug_mode command, which
 	// stores debug=true in session metadata. With the flag set, the slog
@@ -1284,6 +1315,24 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	sysPromptNoHint := o.buildSystemPrompt(withSkipFormatHint(ctx), content, true)
 	sysPromptWithHint := o.buildSystemPrompt(ctx, content, true)
 
+	// Emit turn_start once per Run — captures the static request shape
+	// (system prompt digest, tool catalogue, model intent) that all agent
+	// rounds in this turn share. prepareTurnStart also upserts the
+	// underlying prompt bodies into prompt_snapshots when a store is
+	// configured, so a consumer reading the event can resolve every
+	// sha256 reference to content. Per-round mutations (e.g.
+	// reasoning-effort downgrade on summary rounds) are NOT reflected
+	// here; they remain on the individual llm_request events. The hinted
+	// variant is canonical: the unhinted one only differs by suppressing
+	// the format directive on round 1, which doesn't change tool
+	// selection.
+	//
+	// Early-exit paths above (pending pipeline / pending tool-call
+	// confirmation) intentionally bypass this emission: the LLM is not
+	// driving those decisions, so there's no "turn" to start. They still
+	// emit user_message (above) because the user did send input.
+	emit.EmitTurnStart(ctx, o.eventSink, o.prepareTurnStart(ctx, sysPromptWithHint, profileModel, cachedTools))
+
 	var stripRetries int
 	var toolRetries int // retries when planner expected tools but LLM didn't call any
 	var transientMessages []provider.Message
@@ -1805,6 +1854,85 @@ func (o *Orchestrator) buildToolDefinitions(ctx context.Context) []provider.Tool
 		}
 	}
 	return tools
+}
+
+// prepareTurnStart assembles the turn_start event payload from the static
+// request shape held at agent-loop entry AND, when a PromptSnapshotStore
+// is configured, synchronously upserts the underlying prompt bodies into
+// prompt_snapshots BEFORE returning — so the emitted sha256 references
+// resolve to content the moment the event becomes visible.
+//
+// Doing both in one place keeps the invariant tight: every (sha256, body)
+// pair is durable in the store before the event referencing the sha256
+// is emitted to the (potentially async-buffered) sink. A consumer
+// reading the event can then look up the snapshot without racing the
+// write.
+//
+// server_instructions are gathered from every registered capability's
+// SystemPromptAddition — unfiltered by allowed_plugins on purpose: a
+// consumer correlating system_prompt_sha256 to its server_instructions
+// list should see the same set of additions that contributed to that
+// hash. available_tools mirrors the cachedTools list used by the agent
+// loop; when native tool calling is off the slice is empty (text-mode
+// tools are described inside the system prompt and are already covered
+// by system_prompt_sha256). Both slices are sorted by Name so consumers
+// see stable order across runs — ListCapabilities() and cachedTools
+// both depend on Go map iteration, which is not deterministic.
+//
+// snapshot upsert errors are logged and swallowed: a transient DB
+// failure must not break the turn. The resulting event still ships;
+// the consumer just sees a hash without a resolvable body until the
+// snapshot is re-upserted on the next identical turn.
+func (o *Orchestrator) prepareTurnStart(ctx context.Context, systemPrompt, modelID string, cachedTools []provider.ToolDefinition) emit.TurnStartArgs {
+	args := emit.TurnStartArgs{ModelID: modelID}
+	if systemPrompt != "" {
+		sum := sha256.Sum256([]byte(systemPrompt))
+		args.SystemPromptSHA256 = hex.EncodeToString(sum[:])
+		o.upsertSnapshot(ctx, args.SystemPromptSHA256, events.PromptKindSystemPrompt, systemPrompt)
+	}
+	for _, cap := range o.registry.ListCapabilities() {
+		if cap.SystemPromptAddition == "" {
+			continue
+		}
+		sum := sha256.Sum256([]byte(cap.SystemPromptAddition))
+		sha := hex.EncodeToString(sum[:])
+		args.ServerInstructions = append(args.ServerInstructions, events.ServerInstructionRef{
+			Name:   cap.Name,
+			SHA256: sha,
+		})
+		o.upsertSnapshot(ctx, sha, events.PromptKindServerInstructions, cap.SystemPromptAddition)
+	}
+	sort.Slice(args.ServerInstructions, func(i, j int) bool {
+		return args.ServerInstructions[i].Name < args.ServerInstructions[j].Name
+	})
+	for _, td := range cachedTools {
+		sum := sha256.Sum256([]byte(td.Description))
+		sha := hex.EncodeToString(sum[:])
+		args.AvailableTools = append(args.AvailableTools, events.ToolRef{
+			Name:       td.Name,
+			DescSHA256: sha,
+		})
+		o.upsertSnapshot(ctx, sha, events.PromptKindToolDescription, td.Description)
+	}
+	sort.Slice(args.AvailableTools, func(i, j int) bool {
+		return args.AvailableTools[i].Name < args.AvailableTools[j].Name
+	})
+	return args
+}
+
+// upsertSnapshot writes a (sha256, kind, content) tuple to the configured
+// PromptSnapshotStore, swallowing nil-store and errors. Errors are
+// logged at warn level — the turn continues regardless because the
+// alternative (failing a user turn over an analytics snapshot write) is
+// worse than a dangling hash reference.
+func (o *Orchestrator) upsertSnapshot(ctx context.Context, sha256, kind, content string) {
+	if o.snapshotStore == nil {
+		return
+	}
+	if err := o.snapshotStore.UpsertPromptSnapshot(ctx, sha256, kind, content); err != nil {
+		slog.WarnContext(ctx, "prompt_snapshot upsert failed",
+			"sha256", sha256, "kind", kind, "error", err)
+	}
 }
 
 // retryToolCallsEnabled returns true if the model opts in to planner-informed

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -1099,6 +1099,199 @@ func TestOrchestrator_ExecuteCall_EmitsResultError_OnRestrictedPluginRefusal(t *
 	}
 }
 
+// -----------------------------------------------------------------------------
+// Phase 4 — text-parser instrumentation tests
+// -----------------------------------------------------------------------------
+
+// findParseFailedPayloads collects all tool_call_parse_failed payloads.
+func findParseFailedPayloads(t *testing.T, evs []emit.Event) []events.ToolCallParseFailedPayload {
+	t.Helper()
+	var out []events.ToolCallParseFailedPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeToolCallParseFailed {
+			continue
+		}
+		var p events.ToolCallParseFailedPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal tool_call_parse_failed: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestOrchestrator_ParseFailed_EmittedOnMalformedToolCallBody(t *testing.T) {
+	// LLM emits a [tool_call] block whose body is unparseable. Default
+	// parser falls through every format (json.Unmarshal fails, body
+	// doesn't start with '{' so the bare-JSON placeholder doesn't fire,
+	// inline parse fails) and at end-of-function returns the sawBlock
+	// empty-plugin placeholder. tool_call_parse_failed must fire once.
+	sink := &recordingEventSink{}
+	// Use DefaultParser so the real parser logic decides — fakeParser
+	// would bypass the marker-vs-empty-plugin signal that drives Phase 4.
+	llm := &fakeLLM{responses: []string{
+		"[tool_call] this is not a valid tool call body [/tool_call]",
+		"fallback final answer",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+
+	parseFailed := findParseFailedPayloads(t, sink.snapshot())
+	if len(parseFailed) != 1 {
+		t.Fatalf("tool_call_parse_failed count = %d, want 1", len(parseFailed))
+	}
+	got := parseFailed[0]
+	if got.V != events.ToolCallParseFailedVersion {
+		t.Errorf("Header.V = %d, want %d", got.V, events.ToolCallParseFailedVersion)
+	}
+	if got.ParserUsed != "default" {
+		t.Errorf("ParserUsed = %q, want default", got.ParserUsed)
+	}
+	if got.ParseError == "" {
+		t.Errorf("ParseError empty; want non-empty error text")
+	}
+	if got.RawSnippet == "" {
+		t.Errorf("RawSnippet empty; want full response content")
+	}
+}
+
+func TestOrchestrator_ParseFailed_EmittedOnBareJSONWithoutToolKey(t *testing.T) {
+	// LLM wraps a JSON object in [tool_call] markers but forgets the
+	// "tool" key. Parser's Format-A json.Unmarshal succeeds but
+	// block.Tool=="", so it falls through to Format B/C. Body starts
+	// with '{' → bare-JSON placeholder fires inside the loop (Plugin="").
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		`[tool_call]{"args": {"name": "test"}}[/tool_call]`,
+		"final",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+	parseFailed := findParseFailedPayloads(t, sink.snapshot())
+	if len(parseFailed) != 1 {
+		t.Fatalf("tool_call_parse_failed count = %d, want 1", len(parseFailed))
+	}
+}
+
+func TestOrchestrator_ParseFailed_NotEmittedOnPlainTextResponse(t *testing.T) {
+	// Pure text response with no tool-call markers — parser returns nil,
+	// containsToolCallMarker returns false. No event must fire (this is
+	// the most common path and would drown analytics).
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"Just a plain answer with no tool call attempts."}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 0 {
+		t.Errorf("tool_call_parse_failed fired on plain-text response (%d events); should not", len(pf))
+	}
+}
+
+func TestOrchestrator_ParseFailed_NotEmittedOnSuccessfulParse(t *testing.T) {
+	// LLM emits a valid Format A tool call. Parser returns one call with
+	// a real Plugin name. emitParseFailedIfApplicable sees no empty-plugin
+	// entry → no event.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		`[tool_call]{"tool": "gitlab.analyze_code", "args": {}}[/tool_call]`,
+		"summary after tool call",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 0 {
+		t.Errorf("tool_call_parse_failed fired on successful parse (%d events); should not", len(pf))
+	}
+	// Sanity: Phase 3 events still fire for the successful path.
+	if len(findToolCallExtractedPayloads(t, sink.snapshot())) != 1 {
+		t.Errorf("expected one tool_call_extracted on successful parse")
+	}
+}
+
+func TestOrchestrator_ParseFailed_NotEmittedOnNarratedPlaceholder(t *testing.T) {
+	// LLM narrates a tool call in plain text without using markers
+	// ("We'll fetch the inventory."). Parser detects via narratedIntentRe
+	// and returns narratedToolCallPlaceholder. containsToolCallMarker
+	// returns false (no [tool_call] tag); even if it did,
+	// IsNarratedPlaceholder check would skip emission.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		"I'll fetch the inventory list for you.",
+		"final after narration retry",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "show inventory"); err != nil {
+		t.Fatal(err)
+	}
+	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 0 {
+		t.Errorf("tool_call_parse_failed fired on narrated placeholder (%d events); should not", len(pf))
+	}
+}
+
+func TestOrchestrator_ParseFailed_EmittedOnAnthropicXMLLeak(t *testing.T) {
+	// Claude sometimes leaks <function_calls> XML when our prompt asks
+	// for [tool_call] format. Parser's parseXMLFunctionCalls path can
+	// extract calls — but if the XML is malformed (missing name attr,
+	// invalid tool name), no calls come out and the sawBlock fallback
+	// fires because containsInternalBlock detects <function_calls>.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		`<function_calls><invoke>no name attribute</invoke></function_calls>`,
+		"final",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 1 {
+		t.Errorf("tool_call_parse_failed count = %d, want 1 on malformed XML", len(pf))
+	}
+}
+
+func TestOrchestrator_ParseFailed_EmittedOnUnclosedToolCallMarker(t *testing.T) {
+	// [tool_call] opens but no closing [/tool_call] tag. The default
+	// parser's "no closing tag" branch (parser.go line 61-64) takes the
+	// rest-of-string as body, attempts Format A then Format B/C, and
+	// produces an empty-plugin placeholder via the sawBlock fallback.
+	// Phase 4 must catch this — without a closing marker, the response
+	// is incoherent and analytics needs to see the failure.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		"[tool_call] this has no closing marker and is malformed",
+		"final",
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, DefaultParser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 1 {
+		t.Errorf("tool_call_parse_failed count = %d, want 1 on unclosed marker", len(pf))
+	}
+}
+
+func TestOrchestrator_ParseFailed_NoEventSink_DoesNotPanic(t *testing.T) {
+	// NoOpSink default path coverage for the Phase 4 emit site.
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	llm := &fakeLLM{responses: []string{
+		"[tool_call] garbage [/tool_call]",
+		"final",
+	}}
+	orch := NewWithRules(llm, DefaultParser, registry, memory, sessions, OrchestratorOpts{})
+	if _, err := orch.Run(context.Background(), "sess", "ping"); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestOrchestrator_ExecuteCall_NoEventSink_DoesNotPanic(t *testing.T) {
 	// Mirrors the NoOpSink default-path coverage from Phase 2 — must also
 	// hold for the dispatcher path.

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -625,3 +625,497 @@ func findTurnStart(t *testing.T, evs []emit.Event) events.TurnStartPayload {
 	t.Fatal("turn_start event not found")
 	return events.TurnStartPayload{}
 }
+
+// -----------------------------------------------------------------------------
+// Phase 3 — tool dispatcher instrumentation tests
+// -----------------------------------------------------------------------------
+
+// nativeToolCallingLLM returns native ToolCalls on its first Complete call,
+// then a plain text response on subsequent rounds so the agent loop
+// terminates. Implements FeatureTools so the orchestrator picks the native
+// path. Embedding by value so SupportsFeature is promoted on the value.
+type nativeToolCallingLLM struct {
+	toolCalls []provider.ToolCall
+	textAfter string
+	calls     int
+}
+
+func (l *nativeToolCallingLLM) Complete(_ context.Context, _ *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	l.calls++
+	if l.calls == 1 {
+		return &provider.CompletionResponse{ToolCalls: l.toolCalls}, nil
+	}
+	return &provider.CompletionResponse{Content: l.textAfter}, nil
+}
+
+func (l *nativeToolCallingLLM) SupportsFeature(f provider.Feature) bool {
+	return f == provider.FeatureTools
+}
+
+// errorExecutor returns a tool error result, exercising the
+// tool_call_result status=error branch.
+type errorExecutor struct{ msg string }
+
+func (e *errorExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
+	return ToolResult{CallID: call.ID, Error: e.msg}
+}
+
+// findToolCallEvents collects all events of the given type into typed payloads.
+func findToolCallExtractedPayloads(t *testing.T, evs []emit.Event) []events.ToolCallExtractedPayload {
+	t.Helper()
+	var out []events.ToolCallExtractedPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeToolCallExtracted {
+			continue
+		}
+		var p events.ToolCallExtractedPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal tool_call_extracted: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func findToolCallResultPayloads(t *testing.T, evs []emit.Event) []events.ToolCallResultPayload {
+	t.Helper()
+	var out []events.ToolCallResultPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeToolCallResult {
+			continue
+		}
+		var p events.ToolCallResultPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal tool_call_result: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestOrchestrator_ExecuteCall_EmitsExtractedAndResult_NativeMode(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:   "call-1",
+			Name: "gitlab.analyze_code",
+			// gitlab.analyze_code declares no Parameters in the test fixture,
+			// so any args would trip rejectUnknownArgs. Leave empty for the
+			// happy-path assertion.
+			Arguments: map[string]string{},
+		}},
+		textAfter: "analysis complete",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "analyze main.go"); err != nil {
+		t.Fatal(err)
+	}
+
+	extracted := findToolCallExtractedPayloads(t, sink.snapshot())
+	if len(extracted) != 1 {
+		t.Fatalf("tool_call_extracted count = %d, want 1", len(extracted))
+	}
+	got := extracted[0]
+	if got.V != events.ToolCallExtractedVersion {
+		t.Errorf("Header.V = %d, want %d", got.V, events.ToolCallExtractedVersion)
+	}
+	if got.Mode != "native" {
+		t.Errorf("Mode = %q, want native", got.Mode)
+	}
+	if got.CallID != "call-1" {
+		t.Errorf("CallID = %q, want call-1", got.CallID)
+	}
+	if got.Plugin != "gitlab" || got.Action != "analyze_code" {
+		t.Errorf("Plugin/Action = %q/%q, want gitlab/analyze_code", got.Plugin, got.Action)
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].CallID != "call-1" {
+		t.Errorf("result.CallID = %q, want call-1", results[0].CallID)
+	}
+	if results[0].Status != "ok" {
+		t.Errorf("result.Status = %q, want ok", results[0].Status)
+	}
+	if results[0].ResponseExcerpt == "" {
+		t.Errorf("result.ResponseExcerpt is empty; want echoed body")
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsExtractedAndResult_TextMode(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"call the tool", "done"}}
+	parseCount := 0
+	parser := &fakeParser{parseFn: func(string) []ToolCall {
+		parseCount++
+		if parseCount == 1 {
+			return []ToolCall{{
+				ID:     "call-text-1",
+				Plugin: "gitlab",
+				Action: "analyze_code",
+				// gitlab.analyze_code declares no Parameters; args would
+				// trip rejectUnknownArgs. Happy-path assertion uses none.
+				Args: map[string]string{},
+			}}
+		}
+		return nil
+	}}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+
+	extracted := findToolCallExtractedPayloads(t, sink.snapshot())
+	if len(extracted) != 1 {
+		t.Fatalf("tool_call_extracted count = %d, want 1", len(extracted))
+	}
+	if extracted[0].Mode != "text" {
+		t.Errorf("Mode = %q, want text (plain fakeLLM has no FeatureTools)", extracted[0].Mode)
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "ok" {
+		t.Errorf("result.Status = %q, want ok", results[0].Status)
+	}
+}
+
+func TestOrchestrator_ExecuteCall_ResultStatus_ErrorOnDispatchError(t *testing.T) {
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "broken",
+		Actions: []Action{{Name: "do"}},
+	}, &errorExecutor{msg: "exec blew up"})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	call := ToolCall{ID: "c1", Plugin: "broken", Action: "do", FromLLM: true}
+	res := orch.executeCall(context.Background(), call)
+	if res.Error == "" {
+		t.Fatal("expected error result")
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "error" {
+		t.Errorf("Status = %q, want error", results[0].Status)
+	}
+	if results[0].ResponseExcerpt != "exec blew up" {
+		t.Errorf("ResponseExcerpt = %q, want %q", results[0].ResponseExcerpt, "exec blew up")
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsNotFound_UnknownPlugin(t *testing.T) {
+	sink := &recordingEventSink{}
+	orch, _ := setupOrchestratorWithSink(&fakeLLM{},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }}, sink)
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "no-such-plugin", Action: "anything", FromLLM: true,
+	})
+	if res.Error == "" {
+		t.Fatal("expected error result")
+	}
+
+	evs := sink.snapshot()
+	var notFound []emit.Event
+	var extracted int
+	for _, e := range evs {
+		switch e.EventType {
+		case events.TypeToolCallNotFound:
+			notFound = append(notFound, e)
+		case events.TypeToolCallExtracted:
+			extracted++
+		}
+	}
+	if extracted != 1 {
+		t.Errorf("extracted count = %d, want 1", extracted)
+	}
+	if len(notFound) != 1 {
+		t.Fatalf("not_found count = %d, want 1", len(notFound))
+	}
+	var p events.ToolCallNotFoundPayload
+	if err := json.Unmarshal(notFound[0].Payload, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.RequestedName != "no-such-plugin.anything" {
+		t.Errorf("RequestedName = %q, want no-such-plugin.anything", p.RequestedName)
+	}
+	// A tool_call_result MUST NOT fire on the not-found path (no dispatch happened).
+	if len(findToolCallResultPayloads(t, evs)) != 0 {
+		t.Errorf("tool_call_result emitted on not_found path; should not be")
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsNotFound_UnknownAction(t *testing.T) {
+	sink := &recordingEventSink{}
+	orch, _ := setupOrchestratorWithSink(&fakeLLM{},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }}, sink)
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "gitlab", Action: "totally-bogus-action", FromLLM: true,
+	})
+	if res.Error == "" {
+		t.Fatal("expected error result")
+	}
+
+	var notFound int
+	for _, e := range sink.snapshot() {
+		if e.EventType == events.TypeToolCallNotFound {
+			notFound++
+		}
+	}
+	if notFound != 1 {
+		t.Errorf("not_found count = %d, want 1", notFound)
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsArgsInvalid_OnRejectUnknownArgs(t *testing.T) {
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "strict",
+		Actions: []Action{{
+			Name:       "do",
+			Parameters: []Parameter{{Name: "expected", Required: false}},
+		}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID:      "c1",
+		Plugin:  "strict",
+		Action:  "do",
+		Args:    map[string]string{"stray": "value"},
+		FromLLM: true,
+	})
+	if res.Error == "" {
+		t.Fatal("expected validation error")
+	}
+
+	evs := sink.snapshot()
+	var invalid []emit.Event
+	for _, e := range evs {
+		if e.EventType == events.TypeToolCallArgsInvalid {
+			invalid = append(invalid, e)
+		}
+	}
+	if len(invalid) != 1 {
+		t.Fatalf("args_invalid count = %d, want 1", len(invalid))
+	}
+	var p events.ToolCallArgsInvalidPayload
+	if err := json.Unmarshal(invalid[0].Payload, &p); err != nil {
+		t.Fatal(err)
+	}
+	if p.CallID != "c1" || p.Plugin != "strict" || p.Action != "do" {
+		t.Errorf("payload identity drift: %+v", p)
+	}
+	if p.ValidationError == "" {
+		t.Errorf("ValidationError empty; want non-empty error text")
+	}
+	// No tool_call_result on the args_invalid path (validation rejects before dispatch).
+	if len(findToolCallResultPayloads(t, evs)) != 0 {
+		t.Errorf("tool_call_result emitted on args_invalid path; should not be")
+	}
+}
+
+func TestOrchestrator_ExecuteCall_NoEmission_WhenFromLLMFalse(t *testing.T) {
+	// Internal calls (preparers, guards, pipelines) carry FromLLM=false.
+	// They are host-orchestrated, not part of the LLM reasoning trace, and
+	// must not pollute session_events analytics.
+	sink := &recordingEventSink{}
+	orch, _ := setupOrchestratorWithSink(&fakeLLM{},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }}, sink)
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "internal-1", Plugin: "gitlab", Action: "analyze_code", FromLLM: false,
+	})
+	if res.Error != "" {
+		t.Fatalf("internal call failed unexpectedly: %s", res.Error)
+	}
+
+	for _, e := range sink.snapshot() {
+		switch e.EventType {
+		case events.TypeToolCallExtracted, events.TypeToolCallResult,
+			events.TypeToolCallNotFound, events.TypeToolCallArgsInvalid:
+			t.Errorf("internal call emitted %q; should not emit any tool_call_* event", e.EventType)
+		}
+	}
+}
+
+func TestOrchestrator_ExecuteCall_RawCapture_ExtractedHasOriginalActionBeforeNormalization(t *testing.T) {
+	// LLMs frequently emit underscore-style action names (list_persons)
+	// when the registry uses hyphen-style (list-persons). The orchestrator
+	// normalizes silently; raw-capture rule says the extracted event MUST
+	// preserve the original (un-normalized) action the LLM emitted.
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "persons",
+		Actions: []Action{{Name: "list-persons"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "persons", Action: "list_persons", FromLLM: true,
+	})
+	if res.Error != "" {
+		t.Fatalf("normalization should have succeeded: %s", res.Error)
+	}
+
+	extracted := findToolCallExtractedPayloads(t, sink.snapshot())
+	if len(extracted) != 1 {
+		t.Fatalf("extracted count = %d", len(extracted))
+	}
+	if extracted[0].Action != "list_persons" {
+		t.Errorf("extracted.Action = %q, want raw %q (pre-normalization)",
+			extracted[0].Action, "list_persons")
+	}
+}
+
+func TestOrchestrator_ExecuteCall_LatencyMSPopulatedAndNonNegative(t *testing.T) {
+	sink := &recordingEventSink{}
+	orch, _ := setupOrchestratorWithSink(&fakeLLM{},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }}, sink)
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "gitlab", Action: "analyze_code", FromLLM: true,
+	})
+	if res.Error != "" {
+		t.Fatal(res.Error)
+	}
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("result count = %d", len(results))
+	}
+	if results[0].LatencyMS < 0 {
+		t.Errorf("LatencyMS = %d, want >= 0", results[0].LatencyMS)
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsResultError_OnUserOnlyRefusal(t *testing.T) {
+	// Policy refusal: UserOnly actions cannot be called by the LLM. The
+	// call was extracted and identified before the gate fired, so the
+	// orchestrator emits tool_call_result with status="error" (NOT
+	// tool_call_not_found — the action was found, just refused).
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "admin",
+		Actions: []Action{{Name: "destroy", UserOnly: true}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	res := orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "admin", Action: "destroy", FromLLM: true,
+	})
+	if res.Error == "" {
+		t.Fatal("expected UserOnly refusal")
+	}
+
+	evs := sink.snapshot()
+	results := findToolCallResultPayloads(t, evs)
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "error" {
+		t.Errorf("Status = %q, want error", results[0].Status)
+	}
+	if results[0].ResponseExcerpt == "" {
+		t.Errorf("ResponseExcerpt empty; want refusal message")
+	}
+	// Must NOT emit not_found / args_invalid — the action was found and
+	// args are not the issue; this is a policy refusal.
+	for _, e := range evs {
+		if e.EventType == events.TypeToolCallNotFound || e.EventType == events.TypeToolCallArgsInvalid {
+			t.Errorf("unexpected %q on UserOnly refusal path", e.EventType)
+		}
+	}
+}
+
+func TestOrchestrator_ExecuteCall_EmitsResultError_OnRestrictedPluginRefusal(t *testing.T) {
+	// Policy refusal via strict allowlist (profile.Plugins). The LLM's
+	// extracted plugin name resolves, but the profile excludes it →
+	// pluginAllowed returns false → tool_call_result with status="error".
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "restricted",
+		Actions: []Action{{Name: "do"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	// Strict allowlist that excludes the "restricted" plugin.
+	ctx := profile.WithProfile(context.Background(), &profile.Profile{
+		Plugins: []string{"other-plugin"},
+	})
+	res := orch.executeCall(ctx, ToolCall{
+		ID: "c1", Plugin: "restricted", Action: "do", FromLLM: true,
+	})
+	if res.Error == "" {
+		t.Fatal("expected restricted-plugin refusal")
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "error" {
+		t.Errorf("Status = %q, want error", results[0].Status)
+	}
+}
+
+func TestOrchestrator_ExecuteCall_NoEventSink_DoesNotPanic(t *testing.T) {
+	// Mirrors the NoOpSink default-path coverage from Phase 2 — must also
+	// hold for the dispatcher path.
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Actions: []Action{{Name: "analyze_code"}},
+	}, &echoExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{}) // no EventSink
+
+	_ = orch.executeCall(context.Background(), ToolCall{
+		ID: "c1", Plugin: "gitlab", Action: "analyze_code", FromLLM: true,
+	})
+	_ = orch.executeCall(context.Background(), ToolCall{
+		ID: "c2", Plugin: "missing", Action: "anything", FromLLM: true,
+	})
+}

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -1,0 +1,627 @@
+package orchestrator
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/profile"
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
+)
+
+var errSnapshotStoreFailure = errors.New("simulated snapshot store failure")
+
+// recordingEventSink captures emit.Event values for assertion in tests.
+// The mutex makes concurrent Emit calls safe; the snapshot accessor
+// returns a copy so callers can iterate without holding the lock.
+type recordingEventSink struct {
+	mu     sync.Mutex
+	events []emit.Event
+}
+
+func (s *recordingEventSink) Emit(_ context.Context, e emit.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *recordingEventSink) snapshot() []emit.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]emit.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// nativeToolsLLM is a fake LLM that opts in to FeatureTools so the
+// orchestrator builds the cachedTools list at the start of each turn.
+// Embedding fakeLLM by pointer promotes its Complete method.
+type nativeToolsLLM struct{ *fakeLLM }
+
+func (nativeToolsLLM) SupportsFeature(f provider.Feature) bool {
+	return f == provider.FeatureTools
+}
+
+// recordingSnapshotStore captures UpsertPromptSnapshot calls.
+type recordingSnapshotStore struct {
+	mu      sync.Mutex
+	calls   []promptSnapshotCall
+	failErr error // if non-nil, every call returns this error (still recorded)
+}
+
+type promptSnapshotCall struct {
+	SHA256, Kind, Content string
+}
+
+func (s *recordingSnapshotStore) UpsertPromptSnapshot(_ context.Context, sha256, kind, content string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, promptSnapshotCall{SHA256: sha256, Kind: kind, Content: content})
+	return s.failErr
+}
+
+func (s *recordingSnapshotStore) snapshot() []promptSnapshotCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]promptSnapshotCall, len(s.calls))
+	copy(out, s.calls)
+	return out
+}
+
+func setupOrchestratorWithSink(llm LLMClient, parser ToolCallParser, sink emit.Sink) (*Orchestrator, string) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:                 "gitlab",
+		Description:          "GitLab integration",
+		SystemPromptAddition: "Use gitlab to analyze code.",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code for issues"},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "jira",
+		Description: "Jira integration",
+		Actions:     []Action{{Name: "create_issue", Description: "Create a Jira issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("test-session", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+	return orch, "test-session"
+}
+
+func setupOrchestratorWithSinkAndStore(llm LLMClient, parser ToolCallParser, sink emit.Sink, store PromptSnapshotUpserter) (*Orchestrator, string) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:                 "gitlab",
+		Description:          "GitLab integration",
+		SystemPromptAddition: "Use gitlab to analyze code.",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code for issues"},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:        "jira",
+		Description: "Jira integration",
+		Actions:     []Action{{Name: "create_issue", Description: "Create a Jira issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("test-session", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		PromptSnapshotStore: store,
+	})
+	return orch, "test-session"
+}
+
+func TestOrchestrator_EmitsUserMessage(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"hello back"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "Hello, world!"); err != nil {
+		t.Fatal(err)
+	}
+
+	var seen int
+	var got events.UserMessagePayload
+	var gotSessionID string
+	for _, e := range sink.snapshot() {
+		if e.EventType != events.TypeUserMessage {
+			continue
+		}
+		seen++
+		if err := json.Unmarshal(e.Payload, &got); err != nil {
+			t.Fatalf("unmarshal user_message payload: %v", err)
+		}
+		gotSessionID = e.SessionID
+	}
+	if seen != 1 {
+		t.Fatalf("user_message emitted %d times, want 1", seen)
+	}
+	if got.Content != "Hello, world!" {
+		t.Errorf("Content = %q, want %q", got.Content, "Hello, world!")
+	}
+	if got.ContentLength != len("Hello, world!") {
+		t.Errorf("ContentLength = %d, want %d", got.ContentLength, len("Hello, world!"))
+	}
+	if got.V != events.UserMessageVersion {
+		t.Errorf("Header.V = %d, want %d", got.V, events.UserMessageVersion)
+	}
+	if gotSessionID != sessID {
+		t.Errorf("SessionID = %q, want %q", gotSessionID, sessID)
+	}
+}
+
+func TestOrchestrator_EmitsTurnStart_HashesSystemPromptAndServerInstructions(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"done"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "do the thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	p := findTurnStart(t, sink.snapshot())
+	if p.V != events.TurnStartVersion {
+		t.Errorf("Header.V = %d, want %d", p.V, events.TurnStartVersion)
+	}
+	// system_prompt_sha256 must be a 64-hex digest (sha256 over the actual
+	// system prompt built by buildSystemPrompt — exact value depends on
+	// internal defaults, so we only sanity-check the shape).
+	if len(p.SystemPromptSHA256) != 64 {
+		t.Errorf("SystemPromptSHA256 length = %d, want 64; got %q", len(p.SystemPromptSHA256), p.SystemPromptSHA256)
+	}
+	// Only gitlab has a SystemPromptAddition; jira must not appear.
+	if len(p.ServerInstructions) != 1 {
+		t.Fatalf("ServerInstructions count = %d, want 1; got %+v", len(p.ServerInstructions), p.ServerInstructions)
+	}
+	if p.ServerInstructions[0].Name != "gitlab" {
+		t.Errorf("ServerInstructions[0].Name = %q, want gitlab", p.ServerInstructions[0].Name)
+	}
+	wantHash := sha256.Sum256([]byte("Use gitlab to analyze code."))
+	if p.ServerInstructions[0].SHA256 != hex.EncodeToString(wantHash[:]) {
+		t.Errorf("ServerInstructions[0].SHA256 = %q, want %q", p.ServerInstructions[0].SHA256, hex.EncodeToString(wantHash[:]))
+	}
+}
+
+func TestOrchestrator_TurnStart_AvailableToolsTextMode_Empty(t *testing.T) {
+	// Plain fakeLLM does not implement ReasoningProvider, so
+	// supportsNativeTools() returns false → cachedTools is never built →
+	// AvailableTools must be empty. Text-mode tool catalogues live inside
+	// the system prompt (already covered by system_prompt_sha256), so
+	// double-counting them in available_tools would be misleading.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	p := findTurnStart(t, sink.snapshot())
+	if len(p.AvailableTools) != 0 {
+		t.Errorf("text mode: AvailableTools = %d entries, want 0", len(p.AvailableTools))
+	}
+}
+
+func TestOrchestrator_TurnStart_AvailableToolsNativeMode_Populated(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := nativeToolsLLM{fakeLLM: &fakeLLM{responses: []string{"answer"}}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	p := findTurnStart(t, sink.snapshot())
+	if len(p.AvailableTools) == 0 {
+		t.Fatal("native mode: AvailableTools is empty")
+	}
+	got := make(map[string]string, len(p.AvailableTools))
+	for _, tr := range p.AvailableTools {
+		got[tr.Name] = tr.DescSHA256
+	}
+	if _, ok := got["gitlab.analyze_code"]; !ok {
+		t.Errorf("gitlab.analyze_code missing from AvailableTools; got: %v", got)
+	}
+	if _, ok := got["jira.create_issue"]; !ok {
+		t.Errorf("jira.create_issue missing from AvailableTools; got: %v", got)
+	}
+	wantDesc := sha256.Sum256([]byte("Analyze code for issues"))
+	if got["gitlab.analyze_code"] != hex.EncodeToString(wantDesc[:]) {
+		t.Errorf("gitlab.analyze_code desc_sha256 = %s, want %s", got["gitlab.analyze_code"], hex.EncodeToString(wantDesc[:]))
+	}
+}
+
+func TestOrchestrator_TurnStartFiresOnce_AcrossMultiRoundAgentLoop(t *testing.T) {
+	// Three LLM rounds in one Run. turn_start fires once at agent-loop
+	// entry, NOT per round; user_message fires once at Run entry. The
+	// surrounding model_id/system_prompt/tool catalogue don't change
+	// mid-turn, so re-emitting would be noise.
+	llm := &fakeLLM{responses: []string{
+		"[tool] gitlab.analyze_code",
+		"[tool] jira.create_issue",
+		"Done!",
+	}}
+	callNum := 0
+	parser := &fakeParser{parseFn: func(string) []ToolCall {
+		callNum++
+		switch callNum {
+		case 1:
+			return []ToolCall{{ID: "c1", Plugin: "gitlab", Action: "analyze_code"}}
+		case 2:
+			return []ToolCall{{ID: "c2", Plugin: "jira", Action: "create_issue"}}
+		}
+		return nil
+	}}
+	sink := &recordingEventSink{}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "go"); err != nil {
+		t.Fatal(err)
+	}
+
+	var turns, users int
+	for _, e := range sink.snapshot() {
+		switch e.EventType {
+		case events.TypeTurnStart:
+			turns++
+		case events.TypeUserMessage:
+			users++
+		}
+	}
+	if turns != 1 {
+		t.Errorf("turn_start emitted %d times, want 1", turns)
+	}
+	if users != 1 {
+		t.Errorf("user_message emitted %d times, want 1", users)
+	}
+}
+
+func TestOrchestrator_EmitsUserMessage_EmptyContent(t *testing.T) {
+	// Empty user message (e.g. user sent only file attachments) is captured
+	// verbatim. The event still fires — content_length = 0 is the truthful
+	// representation of "user posted with no text". Phase 2 does not yet
+	// capture file metadata; that's intentional out-of-scope.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"empty echo"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, ""); err != nil {
+		t.Fatal(err)
+	}
+	var got events.UserMessagePayload
+	var seen int
+	for _, e := range sink.snapshot() {
+		if e.EventType != events.TypeUserMessage {
+			continue
+		}
+		seen++
+		if err := json.Unmarshal(e.Payload, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("user_message events = %d, want 1", seen)
+	}
+	if got.Content != "" {
+		t.Errorf("Content = %q, want empty", got.Content)
+	}
+	if got.ContentLength != 0 {
+		t.Errorf("ContentLength = %d, want 0", got.ContentLength)
+	}
+}
+
+func TestOrchestrator_TurnStart_ProfileModelOverridesModelID(t *testing.T) {
+	// When a profile in ctx supplies a model, turn_start's ModelID must
+	// reflect that override (not the empty string the bare config would
+	// have produced). Phase 2 captures *intent* — what the orchestrator
+	// asked the provider for — not the resolved model the provider may
+	// substitute downstream (that lands in llm_response, Phase 1 territory).
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"ok"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	ctx := profile.WithProfile(context.Background(), &profile.Profile{Model: "openai/gpt-4o-mini"})
+	if _, err := orch.Run(ctx, sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	p := findTurnStart(t, sink.snapshot())
+	// Profile prefix "openai/" must be stripped — matches the orchestrator's
+	// own resolution logic (line ~1265).
+	if p.ModelID != "gpt-4o-mini" {
+		t.Errorf("ModelID = %q, want %q", p.ModelID, "gpt-4o-mini")
+	}
+}
+
+func TestOrchestrator_TurnStart_ServerInstructionsSortedByName(t *testing.T) {
+	// Registry uses Go maps internally; iteration order is randomized.
+	// buildTurnStartArgs must sort ServerInstructions deterministically
+	// so downstream consumers comparing payloads across turns don't see
+	// spurious diffs. Three plugins with additions ensures the sort is
+	// actually exercised (with one or two, accidentally-deterministic
+	// runs can mask a missing sort).
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "zeta", SystemPromptAddition: "Zeta instructions",
+		Actions: []Action{{Name: "a", Description: "a"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "alpha", SystemPromptAddition: "Alpha instructions",
+		Actions: []Action{{Name: "a", Description: "a"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "mike", SystemPromptAddition: "Mike instructions",
+		Actions: []Action{{Name: "a", Description: "a"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"ok"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	if _, err := orch.Run(context.Background(), "s1", "hi"); err != nil {
+		t.Fatal(err)
+	}
+	p := findTurnStart(t, sink.snapshot())
+
+	names := make([]string, 0, len(p.ServerInstructions))
+	for _, si := range p.ServerInstructions {
+		names = append(names, si.Name)
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("ServerInstructions not sorted by name: %v", names)
+	}
+	if len(names) != 3 {
+		t.Fatalf("ServerInstructions count = %d, want 3", len(names))
+	}
+}
+
+func TestOrchestrator_SessionNotFound_NoEventEmitted(t *testing.T) {
+	// Session lookup happens BEFORE EmitUserMessage; if the session is
+	// missing, Run returns with no events emitted. Asserting this ensures
+	// the EmitUserMessage placement stays after the lookup — if it ever
+	// moves earlier and starts firing on nonexistent sessions, sessionID
+	// would carry stale values into analytics.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"unused"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	// Deliberately NOT calling sessions.Create — the session must not exist.
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+	if _, err := orch.Run(context.Background(), "missing-session", "hi"); err == nil {
+		t.Fatal("expected session-lookup error, got nil")
+	}
+	if events := sink.snapshot(); len(events) != 0 {
+		t.Errorf("expected zero events on session-not-found, got %d: %+v", len(events), events)
+	}
+}
+
+func TestOrchestrator_PendingToolCallRejected_EmitsUserMessageButNotTurnStart(t *testing.T) {
+	// When the user rejects a previously-queued tool-call confirmation,
+	// the orchestrator returns "OK, action cancelled." without entering
+	// the agent loop. Per the doc-comment at the EmitTurnStart call site,
+	// turn_start must NOT fire in this path (no LLM turn was started),
+	// but user_message must (the user did send "no").
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"unused"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	// Seed a pending tool call so Run takes the confirmation branch.
+	orch.pendingMu.Lock()
+	orch.pendingToolCalls[sessID] = &ToolCall{
+		ID:     "call-1",
+		Plugin: "gitlab",
+		Action: "analyze_code",
+		Args:   map[string]string{"repo": "myrepo"},
+	}
+	orch.pendingMu.Unlock()
+
+	result, err := orch.Run(context.Background(), sessID, "no")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Metadata["action"] != "confirmation_rejected" {
+		t.Fatalf("expected confirmation_rejected metadata, got: %+v", result.Metadata)
+	}
+
+	var users, turns int
+	for _, e := range sink.snapshot() {
+		switch e.EventType {
+		case events.TypeUserMessage:
+			users++
+		case events.TypeTurnStart:
+			turns++
+		}
+	}
+	if users != 1 {
+		t.Errorf("user_message events = %d, want 1", users)
+	}
+	if turns != 0 {
+		t.Errorf("turn_start events = %d, want 0 (rejection path skips agent loop)", turns)
+	}
+}
+
+func TestOrchestrator_PromptSnapshot_UpsertsSystemPromptAndServerInstructions(t *testing.T) {
+	// Every sha256 reference in a turn_start event must resolve to a row
+	// in prompt_snapshots — otherwise the Rails review UI sees a dangling
+	// hash and the dedup design (one row per unique prompt body, regardless
+	// of session count) collapses.
+	sink := &recordingEventSink{}
+	store := &recordingSnapshotStore{}
+	llm := &fakeLLM{responses: []string{"done"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSinkAndStore(llm, parser, sink, store)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+
+	p := findTurnStart(t, sink.snapshot())
+	if p.SystemPromptSHA256 == "" {
+		t.Fatal("turn_start carries no SystemPromptSHA256 — cannot verify upsert")
+	}
+
+	// Collect upserts keyed by (sha, kind). Each kind/sha pair must
+	// appear exactly once for this turn — the helper does not dedup
+	// within a single emission; that's the store's idempotency contract.
+	byKey := make(map[string]promptSnapshotCall)
+	for _, c := range store.snapshot() {
+		byKey[c.SHA256+":"+c.Kind] = c
+	}
+
+	// 1. The system_prompt hash must have a matching upsert.
+	sysCall, ok := byKey[p.SystemPromptSHA256+":"+events.PromptKindSystemPrompt]
+	if !ok {
+		t.Fatalf("no system_prompt upsert for sha %s; got %+v", p.SystemPromptSHA256, store.snapshot())
+	}
+	if sysCall.Content == "" {
+		t.Error("system_prompt upsert has empty content")
+	}
+	// Sanity check: the content must hash back to the emitted sha256.
+	gotSum := sha256.Sum256([]byte(sysCall.Content))
+	if hex.EncodeToString(gotSum[:]) != p.SystemPromptSHA256 {
+		t.Error("system_prompt upsert content does not hash to the emitted sha256")
+	}
+
+	// 2. Each server_instructions ref must have a matching upsert with
+	// kind=server_instructions and content that hashes back.
+	for _, si := range p.ServerInstructions {
+		c, ok := byKey[si.SHA256+":"+events.PromptKindServerInstructions]
+		if !ok {
+			t.Errorf("no server_instructions upsert for %s (sha %s)", si.Name, si.SHA256)
+			continue
+		}
+		gotSum := sha256.Sum256([]byte(c.Content))
+		if hex.EncodeToString(gotSum[:]) != si.SHA256 {
+			t.Errorf("server_instructions content for %s does not hash to %s", si.Name, si.SHA256)
+		}
+	}
+}
+
+func TestOrchestrator_PromptSnapshot_UpsertsToolDescriptions_NativeMode(t *testing.T) {
+	// Native-tools turns carry available_tools[].desc_sha256 in turn_start.
+	// Each must resolve via prompt_snapshots (kind=tool_description).
+	sink := &recordingEventSink{}
+	store := &recordingSnapshotStore{}
+	llm := nativeToolsLLM{fakeLLM: &fakeLLM{responses: []string{"done"}}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSinkAndStore(llm, parser, sink, store)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	p := findTurnStart(t, sink.snapshot())
+	if len(p.AvailableTools) == 0 {
+		t.Fatal("native mode produced no AvailableTools — wiring regression")
+	}
+
+	byKey := make(map[string]promptSnapshotCall)
+	for _, c := range store.snapshot() {
+		byKey[c.SHA256+":"+c.Kind] = c
+	}
+	for _, tr := range p.AvailableTools {
+		c, ok := byKey[tr.DescSHA256+":"+events.PromptKindToolDescription]
+		if !ok {
+			t.Errorf("no tool_description upsert for %s (sha %s)", tr.Name, tr.DescSHA256)
+			continue
+		}
+		gotSum := sha256.Sum256([]byte(c.Content))
+		if hex.EncodeToString(gotSum[:]) != tr.DescSHA256 {
+			t.Errorf("tool_description content for %s does not hash to %s", tr.Name, tr.DescSHA256)
+		}
+	}
+}
+
+func TestOrchestrator_PromptSnapshot_NilStore_NoPanic(t *testing.T) {
+	// PromptSnapshotStore is optional. With no store configured, Run
+	// must succeed without upsert side effects — the event still ships;
+	// the consumer just won't be able to resolve the hashes. This path
+	// covers the always-on capture case where state DB isn't configured.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"done"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	// And turn_start still emits — the absent store does not gate the event.
+	_ = findTurnStart(t, sink.snapshot())
+}
+
+func TestOrchestrator_PromptSnapshot_UpsertFailure_TurnContinues(t *testing.T) {
+	// A transient snapshot-store error must NOT kill the user turn. The
+	// alternative — failing every Run because analytics can't write —
+	// is worse than a dangling sha reference until the next upsert
+	// succeeds.
+	sink := &recordingEventSink{}
+	store := &recordingSnapshotStore{failErr: errSnapshotStoreFailure}
+	llm := &fakeLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSinkAndStore(llm, parser, sink, store)
+	result, err := orch.Run(context.Background(), sessID, "hi")
+	if err != nil {
+		t.Fatalf("Run returned %v despite snapshot upsert failures; should swallow", err)
+	}
+	if result == nil || result.Response != "answer" {
+		t.Errorf("expected unchanged result, got %+v", result)
+	}
+	// Even with failures, turn_start still emits.
+	_ = findTurnStart(t, sink.snapshot())
+	// And every upsert was attempted (failure is recorded).
+	if len(store.snapshot()) == 0 {
+		t.Error("expected upsert attempts despite failures, got none")
+	}
+}
+
+func TestOrchestrator_NoEventSinkConfigured_DefaultsToNoOp(t *testing.T) {
+	// setupOrchestrator uses New() which doesn't set EventSink — the
+	// constructor must fall back to emit.NoOpSink so Run doesn't panic
+	// on nil dereference. Run with no callers to the sink also exercises
+	// the happy path with the default.
+	llm := &fakeLLM{responses: []string{"hi"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestrator(llm, parser)
+	if _, err := orch.Run(context.Background(), sessID, "ping"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// findTurnStart returns the first turn_start payload found in the slice.
+// Fails the test if none is present.
+func findTurnStart(t *testing.T, evs []emit.Event) events.TurnStartPayload {
+	t.Helper()
+	for _, e := range evs {
+		if e.EventType != events.TypeTurnStart {
+			continue
+		}
+		var p events.TurnStartPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal turn_start payload: %v", err)
+		}
+		return p
+	}
+	t.Fatal("turn_start event not found")
+	return events.TurnStartPayload{}
+}

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -294,8 +296,8 @@ func TestOrchestrator_TurnStartFiresOnce_AcrossMultiRoundAgentLoop(t *testing.T)
 func TestOrchestrator_EmitsUserMessage_EmptyContent(t *testing.T) {
 	// Empty user message (e.g. user sent only file attachments) is captured
 	// verbatim. The event still fires — content_length = 0 is the truthful
-	// representation of "user posted with no text". Phase 2 does not yet
-	// capture file metadata; that's intentional out-of-scope.
+	// representation of "user posted with no text". File metadata is
+	// intentionally out of scope here.
 	sink := &recordingEventSink{}
 	llm := &fakeLLM{responses: []string{"empty echo"}}
 	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
@@ -328,9 +330,9 @@ func TestOrchestrator_EmitsUserMessage_EmptyContent(t *testing.T) {
 func TestOrchestrator_TurnStart_ProfileModelOverridesModelID(t *testing.T) {
 	// When a profile in ctx supplies a model, turn_start's ModelID must
 	// reflect that override (not the empty string the bare config would
-	// have produced). Phase 2 captures *intent* — what the orchestrator
+	// have produced). turn_start captures *intent* — what the orchestrator
 	// asked the provider for — not the resolved model the provider may
-	// substitute downstream (that lands in llm_response, Phase 1 territory).
+	// substitute downstream (that lands in llm_response).
 	sink := &recordingEventSink{}
 	llm := &fakeLLM{responses: []string{"ok"}}
 	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
@@ -627,7 +629,7 @@ func findTurnStart(t *testing.T, evs []emit.Event) events.TurnStartPayload {
 }
 
 // -----------------------------------------------------------------------------
-// Phase 3 — tool dispatcher instrumentation tests
+// Tool dispatcher instrumentation tests
 // -----------------------------------------------------------------------------
 
 // nativeToolCallingLLM returns native ToolCalls on its first Complete call,
@@ -1100,7 +1102,7 @@ func TestOrchestrator_ExecuteCall_EmitsResultError_OnRestrictedPluginRefusal(t *
 }
 
 // -----------------------------------------------------------------------------
-// Phase 4 — text-parser instrumentation tests
+// Text-parser instrumentation tests
 // -----------------------------------------------------------------------------
 
 // findParseFailedPayloads collects all tool_call_parse_failed payloads.
@@ -1128,7 +1130,8 @@ func TestOrchestrator_ParseFailed_EmittedOnMalformedToolCallBody(t *testing.T) {
 	// empty-plugin placeholder. tool_call_parse_failed must fire once.
 	sink := &recordingEventSink{}
 	// Use DefaultParser so the real parser logic decides — fakeParser
-	// would bypass the marker-vs-empty-plugin signal that drives Phase 4.
+	// would bypass the marker-vs-empty-plugin signal that drives the
+	// parse_failed emission.
 	llm := &fakeLLM{responses: []string{
 		"[tool_call] this is not a valid tool call body [/tool_call]",
 		"fallback final answer",
@@ -1209,7 +1212,7 @@ func TestOrchestrator_ParseFailed_NotEmittedOnSuccessfulParse(t *testing.T) {
 	if pf := findParseFailedPayloads(t, sink.snapshot()); len(pf) != 0 {
 		t.Errorf("tool_call_parse_failed fired on successful parse (%d events); should not", len(pf))
 	}
-	// Sanity: Phase 3 events still fire for the successful path.
+	// Sanity: tool_call_extracted still fires for the successful path.
 	if len(findToolCallExtractedPayloads(t, sink.snapshot())) != 1 {
 		t.Errorf("expected one tool_call_extracted on successful parse")
 	}
@@ -1260,8 +1263,8 @@ func TestOrchestrator_ParseFailed_EmittedOnUnclosedToolCallMarker(t *testing.T) 
 	// parser's "no closing tag" branch (parser.go line 61-64) takes the
 	// rest-of-string as body, attempts Format A then Format B/C, and
 	// produces an empty-plugin placeholder via the sawBlock fallback.
-	// Phase 4 must catch this — without a closing marker, the response
-	// is incoherent and analytics needs to see the failure.
+	// The parse_failed event must catch this — without a closing marker,
+	// the response is incoherent and analytics needs to see the failure.
 	sink := &recordingEventSink{}
 	llm := &fakeLLM{responses: []string{
 		"[tool_call] this has no closing marker and is malformed",
@@ -1277,7 +1280,7 @@ func TestOrchestrator_ParseFailed_EmittedOnUnclosedToolCallMarker(t *testing.T) 
 }
 
 func TestOrchestrator_ParseFailed_NoEventSink_DoesNotPanic(t *testing.T) {
-	// NoOpSink default path coverage for the Phase 4 emit site.
+	// NoOpSink default path coverage for the parse_failed emit site.
 	registry := NewToolRegistry()
 	memory := state.NewMemoryStore("")
 	sessions := state.NewSessionStore("")
@@ -1293,8 +1296,7 @@ func TestOrchestrator_ParseFailed_NoEventSink_DoesNotPanic(t *testing.T) {
 }
 
 func TestOrchestrator_ExecuteCall_NoEventSink_DoesNotPanic(t *testing.T) {
-	// Mirrors the NoOpSink default-path coverage from Phase 2 — must also
-	// hold for the dispatcher path.
+	// NoOpSink default-path coverage for the dispatcher emit site.
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
 		Name: "gitlab", Actions: []Action{{Name: "analyze_code"}},
@@ -1311,4 +1313,295 @@ func TestOrchestrator_ExecuteCall_NoEventSink_DoesNotPanic(t *testing.T) {
 	_ = orch.executeCall(context.Background(), ToolCall{
 		ID: "c2", Plugin: "missing", Action: "anything", FromLLM: true,
 	})
+}
+
+// -----------------------------------------------------------------------------
+// Planner + summarization instrumentation tests
+// -----------------------------------------------------------------------------
+
+func findPayloadsByType(t *testing.T, evs []emit.Event, eventType string) []json.RawMessage {
+	t.Helper()
+	var out []json.RawMessage
+	for _, e := range evs {
+		if e.EventType == eventType {
+			out = append(out, e.Payload)
+		}
+	}
+	return out
+}
+
+// setupOrchestratorWithPlanner builds an orchestrator with PipelineEnabled
+// so the real *pipeline.Planner is constructed against the fake LLM. The
+// fake LLM must produce a parseable JSON plan as its first response.
+func setupOrchestratorWithPlanner(llm LLMClient, parser ToolCallParser, sink emit.Sink) (*Orchestrator, string) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "gitlab",
+		Actions: []Action{{Name: "analyze_code"}},
+	}, &echoExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:       sink,
+		PipelineEnabled: true,
+	})
+	return orch, "sess"
+}
+
+func TestOrchestrator_Planner_EmitsInvokedRequestResponseOnDirectPlan(t *testing.T) {
+	sink := &recordingEventSink{}
+	// Round 1: planner LLM returns "direct" plan.
+	// Round 2: agent loop LLM returns final answer.
+	llm := &fakeLLM{responses: []string{
+		`{"type":"direct"}`,
+		"final answer",
+	}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithPlanner(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	evs := sink.snapshot()
+	if len(findPayloadsByType(t, evs, events.TypePlannerInvoked)) != 1 {
+		t.Errorf("planner_invoked count != 1")
+	}
+	if len(findPayloadsByType(t, evs, events.TypePlannerRequest)) != 1 {
+		t.Errorf("planner_request count != 1")
+	}
+	if len(findPayloadsByType(t, evs, events.TypePlannerResponse)) != 1 {
+		t.Errorf("planner_response count != 1")
+	}
+	// Direct plan has no steps, no planner_step events.
+	if n := len(findPayloadsByType(t, evs, events.TypePlannerStep)); n != 0 {
+		t.Errorf("planner_step count = %d, want 0 on direct plan", n)
+	}
+
+	// planner_invoked payload: reason set.
+	var inv events.PlannerInvokedPayload
+	_ = json.Unmarshal(findPayloadsByType(t, evs, events.TypePlannerInvoked)[0], &inv)
+	if inv.Reason == "" {
+		t.Errorf("planner_invoked.Reason empty")
+	}
+
+	// planner_response payload: synthetic summary, latency >= 0.
+	var resp events.PlannerResponsePayload
+	_ = json.Unmarshal(findPayloadsByType(t, evs, events.TypePlannerResponse)[0], &resp)
+	if !strings.Contains(resp.RawContentExcerpt, "type=direct") {
+		t.Errorf("planner_response.RawContentExcerpt = %q, want contains type=direct", resp.RawContentExcerpt)
+	}
+	if resp.LatencyMS < 0 {
+		t.Errorf("planner_response.LatencyMS = %d, want >= 0", resp.LatencyMS)
+	}
+}
+
+func TestOrchestrator_Planner_EmitsStepEventsOnPipelinePlan(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		// Pipeline plan with 2 steps. Single-step pipelines are special-cased,
+		// so use 2 to trigger the full pipeline path (and reach the planner
+		// branch we care about — single-step paths return early).
+		`{"type":"pipeline","steps":[
+			{"id":"s1","name":"step one","plugin":"gitlab","action":"analyze_code","args":{},"depends_on":[]},
+			{"id":"s2","name":"step two","plugin":"gitlab","action":"analyze_code","args":{},"depends_on":["s1"]}
+		]}`,
+		// In case pipeline confirmation needs an LLM round.
+		"continue",
+		"final",
+	}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithPlanner(llm, parser, sink)
+
+	// Plan-only path can pause for confirmation. We only need the planner
+	// events; tolerate any final state.
+	_, _ = orch.Run(context.Background(), sessID, "do two things")
+
+	steps := findPayloadsByType(t, sink.snapshot(), events.TypePlannerStep)
+	if len(steps) != 2 {
+		t.Fatalf("planner_step count = %d, want 2", len(steps))
+	}
+	for i, raw := range steps {
+		var p events.PlannerStepPayload
+		_ = json.Unmarshal(raw, &p)
+		if p.StepIndex != i {
+			t.Errorf("step[%d].StepIndex = %d, want %d", i, p.StepIndex, i)
+		}
+		if p.StepKind != "tool" {
+			t.Errorf("step[%d].StepKind = %q, want tool", i, p.StepKind)
+		}
+		if p.Note != "gitlab.analyze_code" {
+			t.Errorf("step[%d].Note = %q, want gitlab.analyze_code", i, p.Note)
+		}
+	}
+}
+
+func TestOrchestrator_Planner_EmitsResponseOnPlannerError(t *testing.T) {
+	// Planner LLM returns unparseable content; parsePlanResponse falls back
+	// to {Type: "direct"} but returns no error. To trigger an actual error
+	// we'd need the LLM Complete itself to fail — use an LLM that errors on
+	// the first call. The agent loop then runs against a fresh LLM call.
+	sink := &recordingEventSink{}
+	llm := &erroringPlannerLLM{plannerErr: errPlannerCallFailed}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithPlanner(llm, parser, sink)
+
+	_, _ = orch.Run(context.Background(), sessID, "hi")
+
+	evs := sink.snapshot()
+	// planner_invoked + planner_request + planner_response all fire even on error.
+	if len(findPayloadsByType(t, evs, events.TypePlannerInvoked)) != 1 {
+		t.Errorf("planner_invoked count != 1 on error path")
+	}
+	if len(findPayloadsByType(t, evs, events.TypePlannerResponse)) != 1 {
+		t.Errorf("planner_response count != 1 on error path")
+	}
+	var resp events.PlannerResponsePayload
+	_ = json.Unmarshal(findPayloadsByType(t, evs, events.TypePlannerResponse)[0], &resp)
+	if !strings.Contains(resp.RawContentExcerpt, "planner error:") {
+		t.Errorf("planner_response.RawContentExcerpt = %q, want contains 'planner error:'", resp.RawContentExcerpt)
+	}
+}
+
+var errPlannerCallFailed = errors.New("simulated planner LLM failure")
+
+// erroringPlannerLLM returns plannerErr on the first Complete (the planner's
+// own LLM call) and "fallback ok" on subsequent ones so the orchestrator's
+// agent loop can still terminate.
+type erroringPlannerLLM struct {
+	plannerErr error
+	calls      int
+}
+
+func (l *erroringPlannerLLM) Complete(_ context.Context, _ *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	l.calls++
+	if l.calls == 1 {
+		return nil, l.plannerErr
+	}
+	return &provider.CompletionResponse{Content: "fallback ok"}, nil
+}
+
+func TestOrchestrator_Summarization_EmitsTriggeredAndCompleted(t *testing.T) {
+	// Pre-populate the session with messages over the threshold, then call
+	// maybeSummarizeSession directly (avoid goroutine timing flakiness — the
+	// production caller fires it via `go ...` after Run, but the function
+	// itself is fully synchronous once invoked).
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	for i := 0; i < 10; i++ {
+		_ = sessions.AddMessage("sess", provider.Message{
+			Role: provider.RoleUser, Content: "msg " + strconv.Itoa(i),
+		})
+	}
+	llm := &fakeLLM{responses: []string{"summary of older turns"}}
+	orch := NewWithRules(llm, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:               sink,
+		SummarizeAfterMessages:  5,
+		MaxMessagesAfterSummary: 3,
+	})
+
+	orch.maybeSummarizeSession(context.Background(), "sess")
+
+	evs := sink.snapshot()
+	trig := findPayloadsByType(t, evs, events.TypeSummarizationTriggered)
+	comp := findPayloadsByType(t, evs, events.TypeSummarizationCompleted)
+	if len(trig) != 1 {
+		t.Fatalf("summarization_triggered count = %d, want 1", len(trig))
+	}
+	if len(comp) != 1 {
+		t.Fatalf("summarization_completed count = %d, want 1", len(comp))
+	}
+	var tp events.SummarizationTriggeredPayload
+	_ = json.Unmarshal(trig[0], &tp)
+	if tp.MessageCount != 10 {
+		t.Errorf("triggered.MessageCount = %d, want 10", tp.MessageCount)
+	}
+	if tp.Reason == "" {
+		t.Errorf("triggered.Reason empty")
+	}
+	var cp events.SummarizationCompletedPayload
+	_ = json.Unmarshal(comp[0], &cp)
+	if cp.SummaryExcerpt != "summary of older turns" {
+		t.Errorf("completed.SummaryExcerpt = %q", cp.SummaryExcerpt)
+	}
+	if cp.KeptMessages != 3 {
+		t.Errorf("completed.KeptMessages = %d, want 3", cp.KeptMessages)
+	}
+	if cp.LatencyMS < 0 {
+		t.Errorf("completed.LatencyMS = %d, want >= 0", cp.LatencyMS)
+	}
+}
+
+func TestOrchestrator_Summarization_NoCompletedOnLLMError(t *testing.T) {
+	// LLM errors on summarization → triggered fires, completed does not.
+	// Consumer-side analytics counts "triggered minus completed" as failure rate.
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	for i := 0; i < 10; i++ {
+		_ = sessions.AddMessage("sess", provider.Message{
+			Role: provider.RoleUser, Content: "msg",
+		})
+	}
+	llm := &erroringPlannerLLM{plannerErr: errPlannerCallFailed}
+	orch := NewWithRules(llm, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:               sink,
+		SummarizeAfterMessages:  5,
+		MaxMessagesAfterSummary: 3,
+	})
+	orch.maybeSummarizeSession(context.Background(), "sess")
+
+	evs := sink.snapshot()
+	if len(findPayloadsByType(t, evs, events.TypeSummarizationTriggered)) != 1 {
+		t.Errorf("triggered count != 1")
+	}
+	if n := len(findPayloadsByType(t, evs, events.TypeSummarizationCompleted)); n != 0 {
+		t.Errorf("completed count = %d, want 0 on LLM error", n)
+	}
+}
+
+func TestOrchestrator_Summarization_BelowThreshold_NoEvents(t *testing.T) {
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	// Only 2 messages; threshold is 5 → maybeSummarizeSession returns early.
+	for i := 0; i < 2; i++ {
+		_ = sessions.AddMessage("sess", provider.Message{Role: provider.RoleUser, Content: "m"})
+	}
+	orch := NewWithRules(&fakeLLM{}, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:               sink,
+		SummarizeAfterMessages:  5,
+		MaxMessagesAfterSummary: 3,
+	})
+	orch.maybeSummarizeSession(context.Background(), "sess")
+
+	if n := len(findPayloadsByType(t, sink.snapshot(), events.TypeSummarizationTriggered)); n != 0 {
+		t.Errorf("triggered fired below threshold (%d events)", n)
+	}
+}
+
+func TestOrchestrator_Planner_NoEventsWhenPlannerDisabled(t *testing.T) {
+	// PipelineEnabled defaults to false → planner is nil → no events.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"plain answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range sink.snapshot() {
+		switch e.EventType {
+		case events.TypePlannerInvoked, events.TypePlannerRequest,
+			events.TypePlannerResponse, events.TypePlannerStep:
+			t.Errorf("planner event %q fired with no planner configured", e.EventType)
+		}
+	}
 }

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/opentalon/opentalon/internal/pipeline"
 	"github.com/opentalon/opentalon/internal/profile"
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/state"
@@ -1603,5 +1604,342 @@ func TestOrchestrator_Planner_NoEventsWhenPlannerDisabled(t *testing.T) {
 			events.TypePlannerResponse, events.TypePlannerStep:
 			t.Errorf("planner event %q fired with no planner configured", e.EventType)
 		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Retry instrumentation tests
+// -----------------------------------------------------------------------------
+
+func findRetryPayloads(t *testing.T, evs []emit.Event) []events.RetryPayload {
+	t.Helper()
+	var out []events.RetryPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeRetry {
+			continue
+		}
+		var p events.RetryPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal retry: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestOrchestrator_Retry_EmitsOnHallucinatedResult(t *testing.T) {
+	sink := &recordingEventSink{}
+	// Round 1: response contains a fabricated template variable that
+	// hasHallucinatedResult matches. Round 2: plain answer to terminate.
+	llm := &fakeLLM{responses: []string{
+		"Result: {{plugin_output.data.count}} items found",
+		"Result: 5 items found",
+	}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "count items"); err != nil {
+		t.Fatal(err)
+	}
+
+	retries := findRetryPayloads(t, sink.snapshot())
+	if len(retries) != 1 {
+		t.Fatalf("retry count = %d, want 1", len(retries))
+	}
+	got := retries[0]
+	if got.V != events.RetryVersion {
+		t.Errorf("Header.V = %d, want %d", got.V, events.RetryVersion)
+	}
+	if got.Phase != "llm_call" {
+		t.Errorf("Phase = %q, want llm_call", got.Phase)
+	}
+	if got.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", got.Attempt)
+	}
+	if got.LastError != "hallucinated tool result" {
+		t.Errorf("LastError = %q", got.LastError)
+	}
+}
+
+func TestOrchestrator_Retry_EmitsOnEmptyResponse(t *testing.T) {
+	sink := &recordingEventSink{}
+	// Round 1: only an internal block, which StripInternalBlocks reduces to "".
+	// fakeParser returns nil so the empty-response retry path fires.
+	// Round 2: plain answer to terminate.
+	llm := &fakeLLM{responses: []string{
+		"[tool_call]unparseable garbage[/tool_call]",
+		"answer after retry",
+	}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	retries := findRetryPayloads(t, sink.snapshot())
+	if len(retries) != 1 {
+		t.Fatalf("retry count = %d, want 1", len(retries))
+	}
+	got := retries[0]
+	if got.Phase != "llm_call" {
+		t.Errorf("Phase = %q, want llm_call", got.Phase)
+	}
+	if got.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", got.Attempt)
+	}
+	if got.LastError != "empty or unparseable response" {
+		t.Errorf("LastError = %q", got.LastError)
+	}
+}
+
+func TestOrchestrator_Retry_EmitsOnPlannerExpectedTools(t *testing.T) {
+	sink := &recordingEventSink{}
+	// Three rounds of plain text — the agent loop retries twice (toolRetries
+	// caps at 2) then gives up and finalizes with the third response.
+	llm := &fakeLLM{responses: []string{"plain 1", "plain 2", "plain 3"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	// Seed expected-tools directly on the ctx so the planner-informed retry
+	// branch fires without needing a planner setup. Use a sentinel step
+	// (no Command) so the retries-exhausted fallback skips server-side
+	// invocation and the loop finalizes with the third response.
+	ctx := withExpectedTools(context.Background(), []*pipeline.Step{{ID: "direct"}})
+
+	if _, err := orch.Run(ctx, sessID, "do it"); err != nil {
+		t.Fatal(err)
+	}
+
+	retries := findRetryPayloads(t, sink.snapshot())
+	if len(retries) != 2 {
+		t.Fatalf("retry count = %d, want 2", len(retries))
+	}
+	for i, got := range retries {
+		if got.Phase != "llm_call" {
+			t.Errorf("retry[%d].Phase = %q, want llm_call", i, got.Phase)
+		}
+		if got.Attempt != i+1 {
+			t.Errorf("retry[%d].Attempt = %d, want %d", i, got.Attempt, i+1)
+		}
+		if got.LastError != "planner expected tool call but LLM returned plain text" {
+			t.Errorf("retry[%d].LastError = %q", i, got.LastError)
+		}
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Confirmation instrumentation tests
+// -----------------------------------------------------------------------------
+
+func findConfirmationResolvedPayloads(t *testing.T, evs []emit.Event) []events.ConfirmationResolvedPayload {
+	t.Helper()
+	var out []events.ConfirmationResolvedPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeConfirmationResolved {
+			continue
+		}
+		var p events.ConfirmationResolvedPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal confirmation_resolved: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func findConfirmationRequestedPayloads(t *testing.T, evs []emit.Event) []events.ConfirmationRequestedPayload {
+	t.Helper()
+	var out []events.ConfirmationRequestedPayload
+	for _, e := range evs {
+		if e.EventType != events.TypeConfirmationRequested {
+			continue
+		}
+		var p events.ConfirmationRequestedPayload
+		if err := json.Unmarshal(e.Payload, &p); err != nil {
+			t.Fatalf("unmarshal confirmation_requested: %v", err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+func TestOrchestrator_Confirmation_PipelineApproved_EmitsResolved(t *testing.T) {
+	sink := &recordingEventSink{}
+	// fakeLLM is only reached if the pending-pipeline path falls through to the
+	// agent loop after approval; the empty pipeline executes immediately so
+	// one fallback response is enough to terminate cleanly.
+	llm := &fakeLLM{responses: []string{"done"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	orch.pendingMu.Lock()
+	orch.pendingPipelines[sessID] = pipeline.NewPipeline(nil, pipeline.PipelineConfig{})
+	orch.pendingMu.Unlock()
+
+	if _, err := orch.Run(context.Background(), sessID, "yes"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationResolvedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_resolved count = %d, want 1", len(got))
+	}
+	if got[0].Choice != "approve" {
+		t.Errorf("Choice = %q, want approve", got[0].Choice)
+	}
+	if got[0].ToolCallID != "" {
+		t.Errorf("ToolCallID = %q, want empty for pipeline confirmation", got[0].ToolCallID)
+	}
+}
+
+func TestOrchestrator_Confirmation_PipelineRejected_EmitsResolved(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"never reached"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	orch.pendingMu.Lock()
+	orch.pendingPipelines[sessID] = pipeline.NewPipeline(nil, pipeline.PipelineConfig{})
+	orch.pendingMu.Unlock()
+
+	if _, err := orch.Run(context.Background(), sessID, "no"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationResolvedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_resolved count = %d, want 1", len(got))
+	}
+	if got[0].Choice != "reject" {
+		t.Errorf("Choice = %q, want reject", got[0].Choice)
+	}
+}
+
+func TestOrchestrator_Confirmation_ToolCallApproved_EmitsResolved(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final summary"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	pending := &ToolCall{
+		ID:     "pending-1",
+		Plugin: "gitlab",
+		Action: "analyze_code",
+		Args:   map[string]string{},
+	}
+	orch.pendingMu.Lock()
+	orch.pendingToolCalls[sessID] = pending
+	orch.pendingMu.Unlock()
+
+	if _, err := orch.Run(context.Background(), sessID, "yes"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationResolvedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_resolved count = %d, want 1", len(got))
+	}
+	if got[0].Choice != "approve" {
+		t.Errorf("Choice = %q, want approve", got[0].Choice)
+	}
+	if got[0].ToolCallID != "pending-1" {
+		t.Errorf("ToolCallID = %q, want pending-1", got[0].ToolCallID)
+	}
+}
+
+func TestOrchestrator_Confirmation_ToolCallRejected_EmitsResolved(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"never reached"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	pending := &ToolCall{
+		ID:     "pending-2",
+		Plugin: "gitlab",
+		Action: "analyze_code",
+		Args:   map[string]string{},
+	}
+	orch.pendingMu.Lock()
+	orch.pendingToolCalls[sessID] = pending
+	orch.pendingMu.Unlock()
+
+	if _, err := orch.Run(context.Background(), sessID, "no"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationResolvedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_resolved count = %d, want 1", len(got))
+	}
+	if got[0].Choice != "reject" {
+		t.Errorf("Choice = %q, want reject", got[0].Choice)
+	}
+	if got[0].ToolCallID != "pending-2" {
+		t.Errorf("ToolCallID = %q, want pending-2", got[0].ToolCallID)
+	}
+}
+
+// confirmingExecutor stubs a confirmation-plugin call: returns JSON requiring
+// confirmation so the orchestrator pauses on the next tool call.
+type confirmingExecutor struct{}
+
+func (confirmingExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
+	return ToolResult{
+		CallID:  call.ID,
+		Content: `{"requires_confirmation":true,"confirm_before_step":0}`,
+	}
+}
+
+func TestOrchestrator_Confirmation_ToolCallRequiresConfirmation_EmitsRequested(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:        "tc-1",
+			Name:      "gitlab.analyze_code",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "summary",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "gitlab",
+		Actions: []Action{{Name: "analyze_code"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:    "conf",
+		Actions: []Action{{Name: "check"}},
+	}, confirmingExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:          sink,
+		ConfirmationPlugin: "conf",
+		ConfirmationAction: "check",
+	})
+
+	if _, err := orch.Run(context.Background(), "sess", "analyze it"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationRequestedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_requested count = %d, want 1", len(got))
+	}
+	if got[0].V != events.ConfirmationRequestedVersion {
+		t.Errorf("Header.V = %d, want %d", got[0].V, events.ConfirmationRequestedVersion)
+	}
+	if got[0].ToolCallID != "tc-1" {
+		t.Errorf("ToolCallID = %q, want tc-1", got[0].ToolCallID)
+	}
+	if len(got[0].Choices) != 2 || got[0].Choices[0] != "approve" || got[0].Choices[1] != "reject" {
+		t.Errorf("Choices = %v, want [approve reject]", got[0].Choices)
+	}
+	if got[0].Prompt == "" {
+		t.Errorf("Prompt is empty")
 	}
 }

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -1943,3 +1943,288 @@ func TestOrchestrator_Confirmation_ToolCallRequiresConfirmation_EmitsRequested(t
 		t.Errorf("Prompt is empty")
 	}
 }
+
+// -----------------------------------------------------------------------------
+// parent_id linkage tests — verify that producer-side event_id generation
+// and WithParent ctx wiring produces the expected event tree.
+// -----------------------------------------------------------------------------
+
+// findEventByType returns the first event of the given type, or nil.
+func findEventByType(evs []emit.Event, eventType string) *emit.Event {
+	for i := range evs {
+		if evs[i].EventType == eventType {
+			return &evs[i]
+		}
+	}
+	return nil
+}
+
+// findEventsByType returns all events of the given type.
+func findEventsByType(evs []emit.Event, eventType string) []emit.Event {
+	var out []emit.Event
+	for i := range evs {
+		if evs[i].EventType == eventType {
+			out = append(out, evs[i])
+		}
+	}
+	return out
+}
+
+func TestParentID_TurnStartIsRoot(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"hello back"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
+		t.Fatal(err)
+	}
+	ts := findEventByType(sink.snapshot(), events.TypeTurnStart)
+	if ts == nil {
+		t.Fatal("turn_start not emitted")
+	}
+	if ts.ID == "" {
+		t.Errorf("turn_start.ID empty — producer-side id generation broken")
+	}
+	if ts.ParentID != "" {
+		t.Errorf("turn_start.ParentID = %q, want empty (root of turn tree)", ts.ParentID)
+	}
+}
+
+func TestParentID_ToolCallResultParentsExtracted(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:        "call-1",
+			Name:      "gitlab.analyze_code",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "done",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "analyze"); err != nil {
+		t.Fatal(err)
+	}
+	evs := sink.snapshot()
+	extracted := findEventByType(evs, events.TypeToolCallExtracted)
+	result := findEventByType(evs, events.TypeToolCallResult)
+	if extracted == nil || result == nil {
+		t.Fatalf("missing events: extracted=%v result=%v", extracted != nil, result != nil)
+	}
+	if extracted.ID == "" {
+		t.Errorf("tool_call_extracted.ID empty")
+	}
+	if result.ParentID != extracted.ID {
+		t.Errorf("tool_call_result.ParentID = %q, want %q (extracted.ID)", result.ParentID, extracted.ID)
+	}
+}
+
+func TestParentID_PlannerRequestResponseStepParentsInvoked(t *testing.T) {
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{
+		// Round 1: planner returns pipeline plan with 2 steps.
+		`{"type":"pipeline","steps":[
+			{"id":"s1","name":"one","plugin":"gitlab","action":"analyze_code","args":{},"depends_on":[]},
+			{"id":"s2","name":"two","plugin":"gitlab","action":"analyze_code","args":{},"depends_on":["s1"]}
+		]}`,
+		"continue",
+		"final",
+	}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithPlanner(llm, parser, sink)
+	_, _ = orch.Run(context.Background(), sessID, "two-step task")
+	evs := sink.snapshot()
+	invoked := findEventByType(evs, events.TypePlannerInvoked)
+	req := findEventByType(evs, events.TypePlannerRequest)
+	resp := findEventByType(evs, events.TypePlannerResponse)
+	steps := findEventsByType(evs, events.TypePlannerStep)
+	if invoked == nil || req == nil || resp == nil {
+		t.Fatalf("missing planner events: invoked=%v request=%v response=%v",
+			invoked != nil, req != nil, resp != nil)
+	}
+	if invoked.ID == "" {
+		t.Errorf("planner_invoked.ID empty")
+	}
+	if req.ParentID != invoked.ID {
+		t.Errorf("planner_request.ParentID = %q, want %q", req.ParentID, invoked.ID)
+	}
+	if resp.ParentID != invoked.ID {
+		t.Errorf("planner_response.ParentID = %q, want %q", resp.ParentID, invoked.ID)
+	}
+	for i, s := range steps {
+		if s.ParentID != invoked.ID {
+			t.Errorf("planner_step[%d].ParentID = %q, want %q", i, s.ParentID, invoked.ID)
+		}
+	}
+}
+
+func TestParentID_ConfirmationResolvedParentsRequested_ToolCall(t *testing.T) {
+	// Turn 1: native LLM emits a tool call, confirmation plugin says
+	// requires_confirmation → confirmation_requested fires, pending state
+	// stored. Turn 2: user replies "yes" → confirmation_resolved fires
+	// with parent_id = requested.ID.
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID: "tc-7", Name: "gitlab.analyze_code", Arguments: map[string]string{},
+		}},
+		textAfter: "after-confirm-summary",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "gitlab",
+		Actions: []Action{{Name: "analyze_code"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:    "conf",
+		Actions: []Action{{Name: "check"}},
+	}, confirmingExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:          sink,
+		ConfirmationPlugin: "conf",
+		ConfirmationAction: "check",
+	})
+
+	if _, err := orch.Run(context.Background(), "sess", "analyze"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := orch.Run(context.Background(), "sess", "yes"); err != nil {
+		t.Fatal(err)
+	}
+
+	evs := sink.snapshot()
+	req := findEventByType(evs, events.TypeConfirmationRequested)
+	resolved := findEventByType(evs, events.TypeConfirmationResolved)
+	if req == nil || resolved == nil {
+		t.Fatalf("missing events: requested=%v resolved=%v", req != nil, resolved != nil)
+	}
+	if req.ID == "" {
+		t.Errorf("confirmation_requested.ID empty")
+	}
+	if resolved.ParentID != req.ID {
+		t.Errorf("confirmation_resolved.ParentID = %q, want %q (requested.ID)", resolved.ParentID, req.ID)
+	}
+}
+
+func TestParentID_ConfirmationResolvedParentsRequested_Pipeline(t *testing.T) {
+	// Inject a pending pipeline + the matching confirmation_requested id
+	// directly so we don't have to run a full planner+confirmation turn
+	// first. The under-test linkage is the *resolved* side reading from
+	// pendingConfirmationIDs and stamping it as parent.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"done"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	const fakeReqID = "00000000000000000000000000000001"
+	orch.pendingMu.Lock()
+	orch.pendingPipelines[sessID] = pipeline.NewPipeline(nil, pipeline.PipelineConfig{})
+	orch.pendingConfirmationIDs[sessID] = fakeReqID
+	orch.pendingMu.Unlock()
+
+	if _, err := orch.Run(context.Background(), sessID, "yes"); err != nil {
+		t.Fatal(err)
+	}
+	resolved := findEventByType(sink.snapshot(), events.TypeConfirmationResolved)
+	if resolved == nil {
+		t.Fatal("confirmation_resolved not emitted")
+	}
+	if resolved.ParentID != fakeReqID {
+		t.Errorf("confirmation_resolved.ParentID = %q, want %q", resolved.ParentID, fakeReqID)
+	}
+}
+
+// emittingLLM mimics what the real provider does: emits an llm_response
+// event via the shared sink and threads the returned event id onto
+// CompletionResponse.EventID. The orchestrator then wraps ctx with that
+// id before dispatching tool calls, so tool_call_extracted should parent
+// to llm_response. This is the only fake LLM in the test suite that
+// closes the provider→orchestrator parent_id contract.
+type emittingLLM struct {
+	sink      emit.Sink
+	toolCalls []provider.ToolCall
+	textAfter string
+	calls     int
+}
+
+func (l *emittingLLM) Complete(ctx context.Context, _ *provider.CompletionRequest) (*provider.CompletionResponse, error) {
+	l.calls++
+	id := emit.EmitLLMResponse(ctx, l.sink, emit.LLMResponseArgs{
+		RawContent:   "synthetic",
+		FinishReason: "stop",
+	})
+	if l.calls == 1 {
+		return &provider.CompletionResponse{ToolCalls: l.toolCalls, EventID: id}, nil
+	}
+	return &provider.CompletionResponse{Content: l.textAfter, EventID: id}, nil
+}
+
+func (l *emittingLLM) SupportsFeature(f provider.Feature) bool {
+	return f == provider.FeatureTools
+}
+
+func TestParentID_ToolCallExtractedParentsLLMResponse(t *testing.T) {
+	// Cross-package linkage test: the LLM-equivalent (a fake that mirrors
+	// what the openai provider does) emits llm_response and surfaces its
+	// id on CompletionResponse.EventID. The orchestrator stamps that id
+	// as parent on ctx, so the subsequent tool_call_extracted event must
+	// link back to the llm_response it was derived from. This is the
+	// contract that would silently break if the provider stopped
+	// populating EventID or the orchestrator stopped reading it.
+	sink := &recordingEventSink{}
+	llm := &emittingLLM{
+		sink: sink,
+		toolCalls: []provider.ToolCall{{
+			ID:        "tc-9",
+			Name:      "gitlab.analyze_code",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "done",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "go"); err != nil {
+		t.Fatal(err)
+	}
+	evs := sink.snapshot()
+	llmResp := findEventByType(evs, events.TypeLLMResponse)
+	extracted := findEventByType(evs, events.TypeToolCallExtracted)
+	if llmResp == nil || extracted == nil {
+		t.Fatalf("missing events: llm_response=%v extracted=%v", llmResp != nil, extracted != nil)
+	}
+	if llmResp.ID == "" {
+		t.Fatal("llm_response.ID empty — emit framework regression")
+	}
+	if extracted.ParentID != llmResp.ID {
+		t.Errorf("tool_call_extracted.ParentID = %q, want %q (llm_response.ID)",
+			extracted.ParentID, llmResp.ID)
+	}
+}
+
+func TestParentID_EveryEventHasID(t *testing.T) {
+	// Smoke test: across a representative run with planner + tool calls,
+	// every emitted event has a non-empty ID. Catches future helpers that
+	// might forget to thread the send() return value through.
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID: "x", Name: "gitlab.analyze_code", Arguments: map[string]string{},
+		}},
+		textAfter: "done",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+	if _, err := orch.Run(context.Background(), sessID, "go"); err != nil {
+		t.Fatal(err)
+	}
+	for i, e := range sink.snapshot() {
+		if e.ID == "" {
+			t.Errorf("event[%d] type=%q has empty ID", i, e.EventType)
+		}
+	}
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1479,8 +1479,8 @@ func TestUserOnlyActionHiddenFromSystemPrompt(t *testing.T) {
 func TestServerInstructionsBeforeToolsInSystemPrompt(t *testing.T) {
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
-		Name:                 "timly",
-		Description:          "Timly MCP",
+		Name:                 "inventory",
+		Description:          "Inventory MCP",
 		SystemPromptAddition: "## Counting records\nUse list-items with per_page:1.",
 		Actions: []Action{
 			{Name: "list-items", Description: "List items"},
@@ -1499,7 +1499,7 @@ func TestServerInstructionsBeforeToolsInSystemPrompt(t *testing.T) {
 	}
 	// Server instructions must appear BEFORE tool definitions.
 	instrIdx := strings.Index(prompt, "Counting records")
-	toolIdx := strings.Index(prompt, "timly.list-items")
+	toolIdx := strings.Index(prompt, "inventory.list-items")
 	if instrIdx >= toolIdx {
 		t.Errorf("server instructions (at %d) must appear before tools (at %d)", instrIdx, toolIdx)
 	}
@@ -2677,8 +2677,8 @@ func TestSyncActionsCarriesServerInstructions(t *testing.T) {
 		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
 	}})
 	_ = registry.Register(PluginCapability{
-		Name: "timly", Description: "Timly",
-		SystemPromptAddition: "Timly MCP server.\n\n## Org-units vs Containers\nA Place is a storage unit; an Org-unit is a structural unit.",
+		Name: "inventory", Description: "Inventory",
+		SystemPromptAddition: "Inventory MCP server.\n\n## Org-units vs Containers\nA Place is a storage unit; an Org-unit is a structural unit.",
 		Actions:              []Action{{Name: "list-items", Description: "List items"}},
 	}, &echoExecutor{})
 	// Plugin with no actions and no SystemPromptAddition: should be skipped entirely.
@@ -2702,10 +2702,10 @@ func TestSyncActionsCarriesServerInstructions(t *testing.T) {
 
 	orch.SyncActions(context.Background())
 
-	// timly (has actions) + prose-only (has SystemPromptAddition but no actions)
+	// inventory (has actions) + prose-only (has SystemPromptAddition but no actions)
 	// are synced; empty (neither) is skipped.
 	if len(syncCalls) != 2 {
-		t.Fatalf("expected 2 sync calls (timly + prose-only), got %d: %v", len(syncCalls), syncCalls)
+		t.Fatalf("expected 2 sync calls (inventory + prose-only), got %d: %v", len(syncCalls), syncCalls)
 	}
 
 	all := strings.Join(syncCalls, " ")
@@ -2717,7 +2717,7 @@ func TestSyncActionsCarriesServerInstructions(t *testing.T) {
 		t.Error("server_instructions should be present in sync payload for plugins with SystemPromptAddition")
 	}
 	if !strings.Contains(all, "Org-units vs Containers") {
-		t.Error("expected timly's SystemPromptAddition content in sync payload")
+		t.Error("expected inventory's SystemPromptAddition content in sync payload")
 	}
 	if strings.Contains(all, `"plugin_name":"empty"`) {
 		t.Error("empty plugin (no actions, no prose) should not be synced")
@@ -2774,7 +2774,7 @@ func TestSyncActionsCarriesKnowledgeArticles(t *testing.T) {
 		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
 	}})
 	_ = registry.Register(PluginCapability{
-		Name: "timly", Description: "Timly",
+		Name: "inventory", Description: "Inventory",
 		Actions: []Action{{Name: "list-items", Description: "List items"}},
 		KnowledgeArticles: []KnowledgeArticle{
 			{ID: "org-units-vs-containers", Title: "Org-units vs Containers (Places)", Content: "A Place is a storage unit; an Org-unit is a structural unit.", Tags: []string{"places"}},
@@ -2899,7 +2899,7 @@ func TestSyncActionsCarriesKeepPlugins(t *testing.T) {
 		return ToolResult{CallID: call.ID, Content: `{"ok": true}`}
 	}})
 	_ = registry.Register(PluginCapability{
-		Name: "timly", Description: "Timly",
+		Name: "inventory", Description: "Inventory",
 		Actions: []Action{{Name: "list-items", Description: "List items"}},
 	}, &echoExecutor{})
 	_ = registry.Register(PluginCapability{
@@ -2919,8 +2919,8 @@ func TestSyncActionsCarriesKeepPlugins(t *testing.T) {
 		t.Fatalf("expected 2 full-sync calls, got %d", len(fullSyncCalls))
 	}
 	for _, p := range fullSyncCalls {
-		if !strings.Contains(p, `"keep_plugins":["timly","gitlab"]`) &&
-			!strings.Contains(p, `"keep_plugins":["gitlab","timly"]`) {
+		if !strings.Contains(p, `"keep_plugins":["inventory","gitlab"]`) &&
+			!strings.Contains(p, `"keep_plugins":["gitlab","inventory"]`) {
 			t.Errorf("full-sync payload missing expected keep_plugins: %s", p)
 		}
 		if strings.Contains(p, `"weaviate"`) {
@@ -2929,7 +2929,7 @@ func TestSyncActionsCarriesKeepPlugins(t *testing.T) {
 	}
 
 	mode = "late"
-	orch.SyncPluginActions(context.Background(), "timly")
+	orch.SyncPluginActions(context.Background(), "inventory")
 	if len(lateLoadCalls) != 1 {
 		t.Fatalf("expected 1 late-load call, got %d", len(lateLoadCalls))
 	}
@@ -3252,14 +3252,14 @@ func TestBuildToolCallNudgeWithConcreteStep(t *testing.T) {
 			ID:   "1",
 			Name: "List person types",
 			Command: &pipeline.PluginCommand{
-				Plugin: "timly",
-				Action: "timly__list-person-types",
+				Plugin: "inventory",
+				Action: "inventory__list-person-types",
 				Args:   map[string]any{},
 			},
 		},
 	}
 	nudge := buildToolCallNudge(steps)
-	if !strings.Contains(nudge, `"tool": "timly.timly__list-person-types"`) {
+	if !strings.Contains(nudge, `"tool": "inventory.inventory__list-person-types"`) {
 		t.Errorf("nudge should contain concrete tool name, got: %s", nudge)
 	}
 	if !strings.Contains(nudge, "[tool_call]") {
@@ -3282,14 +3282,14 @@ func TestBuildToolCallNudgeWithArgs(t *testing.T) {
 			ID:   "1",
 			Name: "List items",
 			Command: &pipeline.PluginCommand{
-				Plugin: "timly",
-				Action: "timly__list-items",
+				Plugin: "inventory",
+				Action: "inventory__list-items",
 				Args:   map[string]any{"query": "status:active", "per_page": "1"},
 			},
 		},
 	}
 	nudge := buildToolCallNudge(steps)
-	if !strings.Contains(nudge, `"timly.timly__list-items"`) {
+	if !strings.Contains(nudge, `"inventory.inventory__list-items"`) {
 		t.Errorf("nudge should contain tool name, got: %s", nudge)
 	}
 	if !strings.Contains(nudge, `"query"`) {
@@ -3303,8 +3303,8 @@ func TestPlannerStepsToInvoke(t *testing.T) {
 			ID:   "1",
 			Name: "List person types",
 			Command: &pipeline.PluginCommand{
-				Plugin: "timly",
-				Action: "timly__list-person-types",
+				Plugin: "inventory",
+				Action: "inventory__list-person-types",
 				Args:   map[string]any{"per_page": "1"},
 			},
 		},
@@ -3313,7 +3313,7 @@ func TestPlannerStepsToInvoke(t *testing.T) {
 	if len(invoke) != 1 {
 		t.Fatalf("expected 1 invoke step, got %d", len(invoke))
 	}
-	if invoke[0].Plugin != "timly" || invoke[0].Action != "timly__list-person-types" {
+	if invoke[0].Plugin != "inventory" || invoke[0].Action != "inventory__list-person-types" {
 		t.Errorf("unexpected step: %+v", invoke[0])
 	}
 	if invoke[0].Args["per_page"] != "1" {
@@ -3377,7 +3377,7 @@ func TestServerSideFallbackOnRetryExhaustion(t *testing.T) {
 	// LLM responses:
 	//   [0] planner: returns a single-step pipeline → tool executed server-side
 	//   [1] round 1: LLM sees real tool results → summarises
-	planJSON := `{"type": "pipeline", "steps": [{"id": "1", "name": "List person types", "plugin": "timly", "action": "timly__list-person-types", "args": {}, "depends_on": []}]}`
+	planJSON := `{"type": "pipeline", "steps": [{"id": "1", "name": "List person types", "plugin": "inventory", "action": "inventory__list-person-types", "args": {}, "depends_on": []}]}`
 	llm := &fakeLLMWithFeatures{
 		fakeLLM: &fakeLLM{responses: []string{
 			planJSON, // [0] planner
@@ -3390,9 +3390,9 @@ func TestServerSideFallbackOnRetryExhaustion(t *testing.T) {
 
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
-		Name:        "timly",
-		Description: "Timly MCP",
-		Actions:     []Action{{Name: "timly__list-person-types", Description: "List person types"}},
+		Name:        "inventory",
+		Description: "Inventory MCP",
+		Actions:     []Action{{Name: "inventory__list-person-types", Description: "List person types"}},
 	}, &fixedResultExecutor{content: `{"person_types": [{"id":1},{"id":2},{"id":3}], "pagination": {"total": 3}}`})
 
 	memory := state.NewMemoryStore("")
@@ -3424,8 +3424,8 @@ func TestPlannerError_FallsThroughWithoutPanic(t *testing.T) {
 
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
-		Name:        "timly",
-		Description: "Timly",
+		Name:        "inventory",
+		Description: "Inventory",
 		Actions:     []Action{{Name: "create-item", Description: "Create item"}},
 	}, &echoExecutor{})
 
@@ -3464,8 +3464,8 @@ func TestPlannerError_RetryEnabledWithoutPanic(t *testing.T) {
 
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
-		Name:        "timly",
-		Description: "Timly",
+		Name:        "inventory",
+		Description: "Inventory",
 		Actions:     []Action{{Name: "create-item", Description: "Create item"}},
 	}, &echoExecutor{})
 
@@ -3487,19 +3487,19 @@ func TestPlannerError_RetryEnabledWithoutPanic(t *testing.T) {
 }
 
 func TestDeduplicateKnowledgeOutput(t *testing.T) {
-	knowledgeBlock := "[plugin_output]\n## Knowledge Articles\n\n### 1. timly MCP server instructions\nSource: mcp:timly\n## timly\nTimly MCP server. Read/write operations...\n\n## Available Tools\n\n### 1. timly.timly__list-items\nList items in your account.\n[/plugin_output]"
+	knowledgeBlock := "[plugin_output]\n## Knowledge Articles\n\n### 1. inventory MCP server instructions\nSource: mcp:inventory\n## inventory\nInventory MCP server. Read/write operations...\n\n## Available Tools\n\n### 1. inventory.inventory__list-items\nList items in your account.\n[/plugin_output]"
 
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "how many items?"},
 		{Role: provider.RoleAssistant, Content: "[tool_call] weaviate.ask_knowledge(query=items)"},
 		{Role: provider.RoleUser, Content: knowledgeBlock},
-		{Role: provider.RoleAssistant, Content: "[tool_call] timly.timly__list-items"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] inventory.inventory__list-items"},
 		{Role: provider.RoleUser, Content: "[plugin_output]\nItems: 370 total\n[/plugin_output]"},
 		{Role: provider.RoleAssistant, Content: "You have 370 items."},
 		{Role: provider.RoleUser, Content: "show me categories"},
 		{Role: provider.RoleAssistant, Content: "[tool_call] weaviate.ask_knowledge(query=categories)"},
 		{Role: provider.RoleUser, Content: knowledgeBlock}, // duplicate
-		{Role: provider.RoleAssistant, Content: "[tool_call] timly.timly__list-categories"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] inventory.inventory__list-categories"},
 	}
 
 	var dst []provider.Message
@@ -3509,12 +3509,12 @@ func TestDeduplicateKnowledgeOutput(t *testing.T) {
 	if !strings.Contains(deduped[2].Content, "## Knowledge Articles") {
 		t.Error("first knowledge output should be preserved")
 	}
-	if !strings.Contains(deduped[2].Content, "timly MCP server") {
+	if !strings.Contains(deduped[2].Content, "inventory MCP server") {
 		t.Error("first knowledge output should contain full content")
 	}
 
 	// Second (duplicate) should be replaced with stub.
-	if strings.Contains(deduped[8].Content, "timly MCP server") {
+	if strings.Contains(deduped[8].Content, "inventory MCP server") {
 		t.Error("duplicate knowledge output should be replaced with stub")
 	}
 	if !strings.Contains(deduped[8].Content, "Same knowledge articles") {

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -126,7 +126,7 @@ func (defaultParser) Parse(response string) []ToolCall {
 			return xmlCalls
 		}
 		// Fallback: detect narrated tool calls in plain text.
-		// Weak LLMs sometimes say "We need to call timly__list-items" instead
+		// Weak LLMs sometimes say "We need to call plugin__action" instead
 		// of using [tool_call] format. Flag this so the orchestrator can retry.
 		if hasNarratedToolCall(response) || hasNarratedIntent(response) {
 			return narratedToolCallPlaceholder
@@ -410,8 +410,8 @@ func parseXMLParameters(body string) map[string]string {
 }
 
 // narratedToolRe matches tool names in plain text narration from weak LLMs.
-// Captures patterns like "call timly.timly__list-items", "call the list-items tool",
-// or "use timly__list-container-types".  Allows optional articles (the/a) between
+// Captures patterns like "call plugin.plugin__list-items", "call the list-items tool",
+// or "use plugin__list-container-types".  Allows optional articles (the/a) between
 // the verb and the tool name.
 var narratedToolRe = regexp.MustCompile(`(?i)(?:call|use|invoke|execute|run|fetch|query|check|search|look\s*up|retrieve)\s+(?:the\s+|a\s+)?` + "`?" + `([a-zA-Z0-9_.-]+(?:\.[a-zA-Z0-9_.-]+|__[a-zA-Z0-9_-]+|[-][a-zA-Z0-9_-]+))` + "`?")
 
@@ -470,9 +470,9 @@ func containsInternalBlock(s string) bool {
 // the parser would treat as a structured tool-call attempt: the
 // orchestrator's own [tool_call] tag, Claude's <function_calls> XML, or a
 // bare <invoke ...> / <invoke> tag (the namespaced antml:* form is
-// caught by the same prefix scan in parseXMLFunctionCalls). Used by
-// Phase 4 to gate tool_call_parse_failed emission so plain-text replies
-// never trigger the event.
+// caught by the same prefix scan in parseXMLFunctionCalls). Used to gate
+// tool_call_parse_failed emission so plain-text replies never trigger
+// the event.
 func containsToolCallMarker(s string) bool {
 	if containsInternalBlock(s) {
 		return true

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -466,6 +466,20 @@ func containsInternalBlock(s string) bool {
 	return false
 }
 
+// containsToolCallMarker returns true if s carries any syntactic marker
+// the parser would treat as a structured tool-call attempt: the
+// orchestrator's own [tool_call] tag, Claude's <function_calls> XML, or a
+// bare <invoke ...> / <invoke> tag (the namespaced antml:* form is
+// caught by the same prefix scan in parseXMLFunctionCalls). Used by
+// Phase 4 to gate tool_call_parse_failed emission so plain-text replies
+// never trigger the event.
+func containsToolCallMarker(s string) bool {
+	if containsInternalBlock(s) {
+		return true
+	}
+	return strings.Contains(s, "<invoke ") || strings.Contains(s, "<invoke>")
+}
+
 // internalBlockTags lists the open/close tag pairs for internal protocol
 // blocks that must never be forwarded to channel users.
 //

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -199,7 +199,7 @@ func TestParseFormatA_MixedArgTypes(t *testing.T) {
 
 func TestParseFormatA_LargeNumericID(t *testing.T) {
 	// Large numeric IDs must not be converted to scientific notation (e.g. 2.004555e+06).
-	response := `[tool_call] {"tool": "timly.timly__assign-item", "args": {"item_id": 2004555, "container_id": 170909}}
+	response := `[tool_call] {"tool": "inventory.inventory__assign-item", "args": {"item_id": 2004555, "container_id": 170909}}
 `
 	calls := DefaultParser.Parse(response)
 	if len(calls) != 1 {
@@ -499,7 +499,7 @@ func TestParseBareJSONToolCall_NoToolKey(t *testing.T) {
 
 func TestParseXMLFunctionCalls(t *testing.T) {
 	response := `<function_calls>
-<invoke name="timly.timly__list-person-types">
+<invoke name="inventory.inventory__list-person-types">
 <parameter name="per_page">1</parameter>
 </invoke>
 </function_calls>`
@@ -507,11 +507,11 @@ func TestParseXMLFunctionCalls(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(calls))
 	}
-	if calls[0].Plugin != "timly" {
-		t.Errorf("plugin = %q, want timly", calls[0].Plugin)
+	if calls[0].Plugin != "inventory" {
+		t.Errorf("plugin = %q, want inventory", calls[0].Plugin)
 	}
-	if calls[0].Action != "timly__list-person-types" {
-		t.Errorf("action = %q, want timly__list-person-types", calls[0].Action)
+	if calls[0].Action != "inventory__list-person-types" {
+		t.Errorf("action = %q, want inventory__list-person-types", calls[0].Action)
 	}
 	if calls[0].Args["per_page"] != "1" {
 		t.Errorf("per_page = %q, want 1", calls[0].Args["per_page"])
@@ -520,16 +520,16 @@ func TestParseXMLFunctionCalls(t *testing.T) {
 
 func TestParseXMLFunctionCalls_NoArgs(t *testing.T) {
 	response := `<function_calls>
-<invoke name="timly.timly__list-items"/>
+<invoke name="inventory.inventory__list-items"/>
 </function_calls>`
 	calls := DefaultParser.Parse(response)
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(calls))
 	}
-	if calls[0].Plugin != "timly" {
+	if calls[0].Plugin != "inventory" {
 		t.Errorf("plugin = %q", calls[0].Plugin)
 	}
-	if calls[0].Action != "timly__list-items" {
+	if calls[0].Action != "inventory__list-items" {
 		t.Errorf("action = %q", calls[0].Action)
 	}
 }

--- a/internal/orchestrator/pipeline_args.go
+++ b/internal/orchestrator/pipeline_args.go
@@ -38,8 +38,8 @@ func pipelineArgsToWire(args map[string]any) map[string]string {
 
 // argToWireString formats a single typed value for the wire layer.
 //
-// The plain-decimal float rendering matters for IDs: a Timly item id like
-// 2_037_838 becomes float64 after JSON unmarshal, and fmt.Sprintf("%v", v)
+// The plain-decimal float rendering matters for IDs: a numeric record id
+// like 2_037_838 becomes float64 after JSON unmarshal, and fmt.Sprintf("%v", v)
 // (the previous behaviour) renders it as "2.037838e+06", which the
 // downstream MCP server then rejects as "type string did not match the
 // following type: integer". strconv.FormatFloat with 'f', -1 keeps the

--- a/internal/orchestrator/sanitize_history_test.go
+++ b/internal/orchestrator/sanitize_history_test.go
@@ -47,7 +47,7 @@ func TestSanitizeHistory_RemovesNarratedAndFabricatedAnswers(t *testing.T) {
 func TestSanitizeHistory_KeepsToolCallAndResults(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "how many items?"},
-		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
+		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"inventory.list-items\"}[/tool_call]"},
 		{Role: provider.RoleUser, Content: "[plugin_output]{\"pagination\":{\"total\":370}}[/plugin_output]"},
 		{Role: provider.RoleAssistant, Content: "You have 370 items."},
 	}
@@ -64,7 +64,7 @@ func TestSanitizeHistory_KeepsMixedSession(t *testing.T) {
 		{Role: provider.RoleAssistant, Content: "You have 0 items."},
 		// Second turn: real tool call (should be kept)
 		{Role: provider.RoleUser, Content: "list my items"},
-		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"timly.list-items\"}[/tool_call]"},
+		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"inventory.list-items\"}[/tool_call]"},
 		{Role: provider.RoleUser, Content: "[plugin_output]Items: 370 total[/plugin_output]"},
 		{Role: provider.RoleAssistant, Content: "You have 370 items."},
 		// Third turn: hallucinated again (should be removed)

--- a/internal/orchestrator/stream_filter_test.go
+++ b/internal/orchestrator/stream_filter_test.go
@@ -102,7 +102,7 @@ func TestStreamTagFilter_HiddenMode(t *testing.T) {
 
 func TestStreamTagFilter_NarratedToolCallSuppressed(t *testing.T) {
 	f := newStreamTagFilter(false)
-	out := f.Feed("We will call timly__list-containers with subcategory filter.")
+	out := f.Feed("We will call inventory__list-containers with subcategory filter.")
 	out += f.Flush()
 	if out != "" {
 		t.Errorf("narrated tool call should be suppressed, got %q", out)
@@ -113,7 +113,7 @@ func TestStreamTagFilter_NarratedChunked(t *testing.T) {
 	f := newStreamTagFilter(false)
 	var out string
 	out += f.Feed("We will ")
-	out += f.Feed("call timly__list-containers")
+	out += f.Feed("call inventory__list-containers")
 	out += f.Feed(" with subcategory filter.")
 	out += f.Flush()
 	if out != "" {
@@ -124,7 +124,7 @@ func TestStreamTagFilter_NarratedChunked(t *testing.T) {
 func TestStreamTagFilter_NarratedFollowedByRealContent(t *testing.T) {
 	f := newStreamTagFilter(false)
 	var out string
-	out += f.Feed("Let me use timly__show-container to look that up.\nHere are the details.")
+	out += f.Feed("Let me use inventory__show-container to look that up.\nHere are the details.")
 	out += f.Flush()
 	// The narrated sentence should be suppressed, the real content kept.
 	if out != "\nHere are the details." {

--- a/internal/pipeline/executor_test.go
+++ b/internal/pipeline/executor_test.go
@@ -237,12 +237,12 @@ func TestExecutorSubstitutesStepReferences(t *testing.T) {
 	}
 
 	steps := []*Step{
-		{ID: "step1", Name: "Find container", Command: &PluginCommand{Plugin: "timly", Action: "list-containers", Args: map[string]any{"query": "name:Berlin"}}, MaxRetries: -1, State: StepPending},
-		{ID: "step2", Name: "Find item", Command: &PluginCommand{Plugin: "timly", Action: "list-items", Args: map[string]any{"query": "name:Tesla"}}, MaxRetries: -1, State: StepPending},
+		{ID: "step1", Name: "Find container", Command: &PluginCommand{Plugin: "inventory", Action: "list-containers", Args: map[string]any{"query": "name:Berlin"}}, MaxRetries: -1, State: StepPending},
+		{ID: "step2", Name: "Find item", Command: &PluginCommand{Plugin: "inventory", Action: "list-items", Args: map[string]any{"query": "name:Tesla"}}, MaxRetries: -1, State: StepPending},
 		{
 			ID: "step3", Name: "Schedule",
 			Command: &PluginCommand{
-				Plugin: "timly", Action: "schedule-item",
+				Plugin: "inventory", Action: "schedule-item",
 				Args: map[string]any{
 					"container_id": "{{step1.output.containers[0].id}}",
 					"item_id":      "{{step2.output.items[0].id}}",

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -287,8 +287,8 @@ func TestBuildPlannerPromptMCPDotActions(t *testing.T) {
 func TestBuildPlannerPrompt_ExcludesServerInstructions(t *testing.T) {
 	caps := []CapabilityInfo{
 		{
-			Name:                 "timly",
-			Description:          "Timly MCP",
+			Name:                 "inventory",
+			Description:          "Inventory MCP",
 			SystemPromptAddition: "## Counting records\nUse list-items with per_page:1 and read pagination.total.",
 			Actions: []ActionInfo{
 				{Name: "list-items", Description: "List items"},
@@ -304,7 +304,7 @@ func TestBuildPlannerPrompt_ExcludesServerInstructions(t *testing.T) {
 		t.Error("planner prompt must not include server instructions")
 	}
 	// Tool definitions must still be present.
-	if !containsStr(prompt, "plugin=timly | action=list-items") {
+	if !containsStr(prompt, "plugin=inventory | action=list-items") {
 		t.Error("planner prompt must include tool definitions")
 	}
 }

--- a/internal/pipeline/substitution_test.go
+++ b/internal/pipeline/substitution_test.go
@@ -162,8 +162,8 @@ func TestResolveArgsInterpolation(t *testing.T) {
 }
 
 func TestResolveArgsLargeIntegerNoScientificNotation(t *testing.T) {
-	// Regression for the planner-emitted IDs: a Timly item id like 2_037_838
-	// becomes float64 after JSON unmarshal and would render as
+	// Regression for the planner-emitted IDs: a numeric record id like
+	// 2_037_838 becomes float64 after JSON unmarshal and would render as
 	// "2.037838e+06" with a default fmt.Sprintf("%v", v). That broke the
 	// downstream MCP server before the boundary stringification was fixed.
 	ctx := ctxWith("step1", map[string]any{

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -7,7 +7,7 @@ package profile
 import "time"
 
 // CredentialHeader is a per-MCP-server credential returned by the WhoAmI server.
-// Header is the HTTP header name to set (e.g. "X-Timly-User") and Value is the
+// Header is the HTTP header name to set (e.g. "X-App-User") and Value is the
 // header value. When making requests to the named MCP server, these are merged
 // with the server's static config headers; WhoAmI-returned headers take priority.
 type CredentialHeader struct {

--- a/internal/provider/anthropic.go
+++ b/internal/provider/anthropic.go
@@ -20,6 +20,13 @@ const (
 
 // AnthropicProvider implements the Provider interface for the
 // Anthropic Messages API.
+//
+// TODO: instrument with emit.Sink in a follow-up phase. The OpenAI
+// provider emits llm_request / llm_response / llm_error / llm_refused
+// at every HTTP call; the Anthropic path produces none of those today,
+// so sessions routed via Anthropic models are absent from session_events
+// analytics. ProviderConfig.EventSink is wired through factory.go but
+// the Anthropic constructor does not yet consume it.
 type AnthropicProvider struct {
 	id      string
 	baseURL string

--- a/internal/provider/factory.go
+++ b/internal/provider/factory.go
@@ -1,6 +1,10 @@
 package provider
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
+)
 
 const (
 	APIOpenAI    = "openai-completions"
@@ -13,6 +17,12 @@ const (
 // OpenAI-compatible provider (the Anthropic provider has no raw HTTP
 // capture today). Wire both from main.go to enable per-session /debug
 // capture; leaving either nil disables capture entirely.
+//
+// EventSink is the structured session-event sink. It is also currently
+// consumed only by the OpenAI-compatible provider; the Anthropic
+// provider will adopt it in a follow-up. Always-on by design — there is
+// no per-session resolver — so a non-nil sink enables capture for every
+// LLM call. A nil sink disables it.
 type ProviderConfig struct {
 	ID           string
 	BaseURL      string
@@ -21,6 +31,7 @@ type ProviderConfig struct {
 	Models       []ModelInfo
 	DebugSink    DebugEventSink
 	DebugResolve DebugContextResolver
+	EventSink    emit.Sink
 }
 
 // FromConfig creates a Provider from a config entry. The api field
@@ -36,6 +47,9 @@ func FromConfig(cfg ProviderConfig) (Provider, error) {
 		}
 		if cfg.DebugResolve != nil {
 			opts = append(opts, WithOpenAIDebugResolver(cfg.DebugResolve))
+		}
+		if cfg.EventSink != nil {
+			opts = append(opts, WithOpenAISessionEventSink(cfg.EventSink))
 		}
 		return NewOpenAIProvider(cfg.ID, cfg.BaseURL, cfg.APIKey, cfg.Models, opts...), nil
 	case APIAnthropic:

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -257,6 +257,20 @@ type oaiResponseStream struct {
 	tokensIn     int
 	tokensOut    int
 	streamErr    error // non-nil → Close emits llm_error instead of llm_response/llm_refused
+
+	// lastEventID is the session-event id of the llm_response event emitted
+	// at end-of-stream; empty for refusal/error paths and when no sink is
+	// configured. Exposed via EventID() so the orchestrator can stamp
+	// subsequent tool_call_extracted events with the right parent.
+	lastEventID string
+}
+
+// EventID returns the session-event id of the llm_response event this
+// stream emitted at end-of-stream, or "" if no llm_response event was
+// produced (refusal, error, or no sink). The orchestrator uses this
+// after Close to parent subsequent tool_call_extracted events.
+func (s *oaiResponseStream) EventID() string {
+	return s.lastEventID
 }
 
 // streamAccumulator buffers the raw SSE wire bytes for end-of-stream debug
@@ -462,13 +476,18 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	// llm_refused so analytics keeps refusals distinct from successful
 	// generations — they have different remediation paths (prompt tuning
 	// vs model swap vs user education).
+	var eventID string
 	if finishReason == openAIFinishReasonContentFilter {
 		emit.EmitLLMRefused(ctx, p.eventSink, emit.LLMRefusedArgs{
 			RefusalText:      content,
 			ContentSafetyHit: openAIFinishReasonContentFilter,
 		})
+		// Refusal path: leave EventID empty so a downstream consumer can
+		// distinguish "no event captured" from "captured under llm_response".
+		// Refusals don't lead to tool dispatch, so a parent_id link from
+		// tool_call_extracted is not meaningful here anyway.
 	} else {
-		emit.EmitLLMResponse(ctx, p.eventSink, emit.LLMResponseArgs{
+		eventID = emit.EmitLLMResponse(ctx, p.eventSink, emit.LLMResponseArgs{
 			RawContent:         content,
 			NativeToolCallsRaw: nativeToolCallsRaw,
 			FinishReason:       finishReason,
@@ -488,6 +507,7 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 			InputTokens:  oaiResp.Usage.PromptTokens,
 			OutputTokens: oaiResp.Usage.CompletionTokens,
 		},
+		EventID: eventID,
 	}, nil
 }
 
@@ -748,7 +768,7 @@ func (s *oaiResponseStream) emitStreamEnd() {
 		})
 		return
 	}
-	emit.EmitLLMResponse(s.emitCtx, s.eventSink, emit.LLMResponseArgs{
+	s.lastEventID = emit.EmitLLMResponse(s.emitCtx, s.eventSink, emit.LLMResponseArgs{
 		RawContent:         content,
 		FinishReason:       s.finishReason,
 		TokensIn:           s.tokensIn,

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
 )
 
 const (
@@ -31,6 +33,7 @@ type OpenAIProvider struct {
 	client       *http.Client
 	debugSink    DebugEventSink       // optional; nil disables persistent debug capture
 	debugResolve DebugContextResolver // optional; returns (sessionID, traceID, enabled?) for this ctx
+	eventSink    emit.Sink            // structured session event sink; always non-nil (NoOpSink default)
 }
 
 // OpenAIOption configures an OpenAIProvider.
@@ -56,6 +59,24 @@ func WithOpenAIDebugResolver(r DebugContextResolver) OpenAIOption {
 	return func(p *OpenAIProvider) { p.debugResolve = r }
 }
 
+// WithOpenAISessionEventSink wires a structured session-event sink so
+// every LLM HTTP exchange emits llm_request / llm_response (or
+// llm_refused when finish_reason indicates a content-safety block) /
+// llm_error events. Unlike the debug sink, capture is always-on — no
+// per-session opt-in — because structured events are the canonical audit
+// trail for analytics, score worker, and the review UI. A nil sink is
+// permitted: it is replaced with an emit.NoOpSink so every emission path
+// stays nil-safe without per-call checks.
+func WithOpenAISessionEventSink(s emit.Sink) OpenAIOption {
+	return func(p *OpenAIProvider) {
+		if s == nil {
+			p.eventSink = emit.NoOpSink{}
+			return
+		}
+		p.eventSink = s
+	}
+}
+
 // resolveDebug returns capture metadata for ctx. When any wiring is missing
 // or the session has not opted in, ok is false and the caller skips capture
 // before any body work — keeping the LLM hot path zero-cost for non-debug
@@ -75,11 +96,12 @@ func NewOpenAIProvider(id, baseURL, apiKey string, models []ModelInfo, opts ...O
 	baseURL = strings.TrimRight(baseURL, "/")
 
 	p := &OpenAIProvider{
-		id:      id,
-		baseURL: baseURL,
-		apiKey:  apiKey,
-		models:  models,
-		client:  &http.Client{Timeout: 120 * time.Second},
+		id:        id,
+		baseURL:   baseURL,
+		apiKey:    apiKey,
+		models:    models,
+		client:    &http.Client{Timeout: 120 * time.Second},
+		eventSink: emit.NoOpSink{},
 	}
 	for _, o := range opts {
 		o(p)
@@ -156,8 +178,9 @@ type oaiResponse struct {
 }
 
 type oaiChoice struct {
-	Index   int        `json:"index"`
-	Message oaiMessage `json:"message"`
+	Index        int        `json:"index"`
+	Message      oaiMessage `json:"message"`
+	FinishReason string     `json:"finish_reason,omitempty"`
 }
 
 type oaiUsage struct {
@@ -212,6 +235,28 @@ type oaiResponseStream struct {
 	accumulator *streamAccumulator // nil when capture disabled for this stream
 	onClose     func(rawBody []byte)
 	closed      bool // guard for double-Close (body.Close + onClose flush)
+
+	// --- Session-event capture state. ---
+	// Distinct from the debug-only `accumulator` + `onClose` block
+	// above: that one is opt-in per session (driven by /debug);
+	// everything below is always-on so every stream produces exactly
+	// one llm_response / llm_refused / llm_error event at Close,
+	// regardless of /debug state.
+	//
+	// Storing ctx on the struct is deliberate: ResponseStream.Close
+	// has no ctx parameter today and a chunked SSE stream is short-
+	// lived, so the usual ctx-in-struct guidance (avoid hiding
+	// cancellation) does not apply here.
+	emitCtx      context.Context //nolint:containedctx // Close has no ctx arg; stream is short-lived. Re-instated defensively so a future containedctx-enabled lint config has the suppression already in place — costs nothing today, prevents a regression search-and-tag later.
+	eventSink    emit.Sink
+	startTime    time.Time
+	lastChunkAt  time.Time // wall-clock of the most recent chunk; used as latency endpoint instead of Close so we don't bill the orchestrator's drain time as LLM latency
+	responseID   string
+	contentBuf   strings.Builder
+	finishReason string
+	tokensIn     int
+	tokensOut    int
+	streamErr    error // non-nil → Close emits llm_error instead of llm_response/llm_refused
 }
 
 // streamAccumulator buffers the raw SSE wire bytes for end-of-stream debug
@@ -277,10 +322,25 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	// single `kubectl logs -f | jq 'select(.msg=="openai raw http")'`
 	// covers both request and response.
 	p.captureRawHTTP(ctx, "request", 0, body, nil)
+	// Structured session-event capture: always-on metadata about the
+	// outbound LLM call (no full body — bloat). Paired with EmitLLMResponse
+	// / EmitLLMError below so analytics get one request row per turn even
+	// when the response path fails.
+	emit.EmitLLMRequest(ctx, p.eventSink, emit.LLMRequestArgs{
+		ModelID:      oaiReq.Model,
+		MessageCount: len(oaiReq.Messages),
+		HasTools:     len(oaiReq.Tools) > 0,
+		MaxTokens:    oaiReq.MaxTokens,
+	})
 
+	start := time.Now()
 	httpResp, err := p.client.Do(httpReq)
 	if err != nil {
 		p.captureRawHTTP(ctx, "error", 0, nil, err)
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseChatTransport,
+			ResponseBodyText: err.Error(),
+		})
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 	defer func() { _ = httpResp.Body.Close() }()
@@ -288,20 +348,44 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 	respBody, err := io.ReadAll(httpResp.Body)
 	if err != nil {
 		p.captureRawHTTP(ctx, "error", 0, nil, err)
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseChatReadResponse,
+			StatusCode:       httpResp.StatusCode,
+			ResponseBodyText: err.Error(),
+		})
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
 	p.captureRawHTTP(ctx, "response", httpResp.StatusCode, respBody, nil)
+	// Capture latency here — the network/server side of the call is
+	// over. Unmarshal cost below is CPU on this host and would skew the
+	// "LLM latency" measurement consumed by analytics dashboards.
+	latencyMS := time.Since(start).Milliseconds()
 
 	if httpResp.StatusCode != http.StatusOK {
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseChatHTTPStatus,
+			StatusCode:       httpResp.StatusCode,
+			ResponseBodyText: string(respBody),
+		})
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
 	}
 
 	var oaiResp oaiResponse
 	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseChatUnmarshal,
+			StatusCode:       httpResp.StatusCode,
+			ResponseBodyText: string(respBody),
+		})
 		return nil, fmt.Errorf("unmarshal response: %w", err)
 	}
 	if oaiResp.Error != nil {
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseChatAPIError,
+			StatusCode:       httpResp.StatusCode,
+			ResponseBodyText: oaiResp.Error.Message,
+		})
 		return nil, fmt.Errorf("openai error [%s]: %s", oaiResp.Error.Type, oaiResp.Error.Message)
 	}
 
@@ -361,6 +445,40 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 		}
 	}
 
+	// Capture the provider-emitted ToolCalls JSON verbatim so the
+	// downstream llm_response event preserves the on-the-wire shape even
+	// if the parser above evolves (drops nulls, normalizes keys, etc).
+	var nativeToolCallsRaw json.RawMessage
+	finishReason := ""
+	if len(oaiResp.Choices) > 0 {
+		finishReason = oaiResp.Choices[0].FinishReason
+		if len(oaiResp.Choices[0].Message.ToolCalls) > 0 {
+			nativeToolCallsRaw, _ = json.Marshal(oaiResp.Choices[0].Message.ToolCalls)
+		}
+	}
+
+	// Refusal detection: OpenAI signals content-safety blocks via
+	// finish_reason="content_filter" (no separate refusal field). Emit
+	// llm_refused so analytics keeps refusals distinct from successful
+	// generations — they have different remediation paths (prompt tuning
+	// vs model swap vs user education).
+	if finishReason == openAIFinishReasonContentFilter {
+		emit.EmitLLMRefused(ctx, p.eventSink, emit.LLMRefusedArgs{
+			RefusalText:      content,
+			ContentSafetyHit: openAIFinishReasonContentFilter,
+		})
+	} else {
+		emit.EmitLLMResponse(ctx, p.eventSink, emit.LLMResponseArgs{
+			RawContent:         content,
+			NativeToolCallsRaw: nativeToolCallsRaw,
+			FinishReason:       finishReason,
+			TokensIn:           oaiResp.Usage.PromptTokens,
+			TokensOut:          oaiResp.Usage.CompletionTokens,
+			LatencyMS:          latencyMS,
+			ProviderResponseID: oaiResp.ID,
+		})
+	}
+
 	return &CompletionResponse{
 		ID:        oaiResp.ID,
 		Model:     oaiResp.Model,
@@ -372,6 +490,39 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 		},
 	}, nil
 }
+
+// openAIFinishReasonContentFilter is the wire-level finish_reason that
+// OpenAI returns when the response was suppressed by content moderation.
+// Centralised here so the Complete and Stream paths agree on the spelling.
+const openAIFinishReasonContentFilter = "content_filter"
+
+// Phase labels for emit.LLMErrorArgs. Hoisted into named constants so
+// the spelling is asserted by the compiler at every emission and test
+// site — a typo in a string literal would otherwise silently fragment
+// analytics dashboards that group by Phase.
+//
+// Naming convention: <call_type>.<failure_mode>, dot-separated, all
+// lowercase. <call_type> is "chat" for the non-streaming Complete path
+// and "stream" for the streaming Stream/Recv/Close path.
+//
+// VALUES ARE WIRE-STABLE. Once persisted into session_events.payload as
+// the Phase field, the literal strings here become part of the analytics
+// surface that downstream tooling (api-plugin, score worker, Rails UI)
+// groups by. Renaming a constant's *value* (the right-hand side) silently
+// rotates analytics dashboards — historical rows keep the old spelling
+// while new rows get the new one. Add new phases here, never rewrite
+// existing ones. The Go identifier (left-hand side) can be renamed
+// freely since it's an internal symbol.
+const (
+	phaseChatTransport    = "chat.transport"
+	phaseChatReadResponse = "chat.read_response"
+	phaseChatHTTPStatus   = "chat.http_status"
+	phaseChatUnmarshal    = "chat.unmarshal"
+	phaseChatAPIError     = "chat.api_error"
+	phaseStreamTransport  = "stream.transport"
+	phaseStreamHTTPStatus = "stream.http_status"
+	phaseStreamRecv       = "stream.recv"
+)
 
 // Stream sends a streaming completion request and returns a ResponseStream
 // that yields chunks as they arrive via SSE.
@@ -399,12 +550,23 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 	// streaming response is captured at end-of-stream by the accumulator
 	// inside oaiResponseStream.
 	p.captureRawHTTP(ctx, "request", 0, body, nil)
+	emit.EmitLLMRequest(ctx, p.eventSink, emit.LLMRequestArgs{
+		ModelID:      oaiReq.Model,
+		MessageCount: len(oaiReq.Messages),
+		HasTools:     len(oaiReq.Tools) > 0,
+		MaxTokens:    oaiReq.MaxTokens,
+	})
 
 	// Use a client without timeout for streaming; context handles cancellation.
 	streamClient := &http.Client{}
+	start := time.Now()
 	httpResp, err := streamClient.Do(httpReq)
 	if err != nil {
 		p.captureRawHTTP(ctx, "error", 0, nil, err)
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseStreamTransport,
+			ResponseBodyText: err.Error(),
+		})
 		return nil, fmt.Errorf("http request: %w", err)
 	}
 
@@ -412,12 +574,20 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 		defer func() { _ = httpResp.Body.Close() }()
 		respBody, _ := io.ReadAll(httpResp.Body)
 		p.captureRawHTTP(ctx, "response", httpResp.StatusCode, respBody, nil)
+		emit.EmitLLMError(ctx, p.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseStreamHTTPStatus,
+			StatusCode:       httpResp.StatusCode,
+			ResponseBodyText: string(respBody),
+		})
 		return nil, fmt.Errorf("openai api error (status %d): %s", httpResp.StatusCode, string(respBody))
 	}
 
 	stream := &oaiResponseStream{
-		body:    httpResp.Body,
-		scanner: bufio.NewScanner(httpResp.Body),
+		body:      httpResp.Body,
+		scanner:   bufio.NewScanner(httpResp.Body),
+		emitCtx:   ctx,
+		eventSink: p.eventSink,
+		startTime: start,
 	}
 	// Wire end-of-stream capture only when this session opted in. Sessions
 	// without /debug get the lighter struct without the buffer.
@@ -453,7 +623,33 @@ func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 			continue // skip malformed chunks
 		}
 		if chunk.Error != nil {
-			return StreamChunk{}, fmt.Errorf("openai stream error [%s]: %s", chunk.Error.Type, chunk.Error.Message)
+			err := fmt.Errorf("openai stream error [%s]: %s", chunk.Error.Type, chunk.Error.Message)
+			if s.streamErr == nil {
+				// First error wins: a caller that ignored the error
+				// and re-entered Recv must not overwrite the original
+				// cause that Close will surface as llm_error.
+				s.streamErr = err
+			}
+			return StreamChunk{}, err
+		}
+
+		// Accumulate session-event state. These fields drive the single
+		// llm_response / llm_refused / llm_error emission in Close. The
+		// usage and finish_reason fields land on the final usage chunk in
+		// most OpenAI deployments, so the last write wins by construction.
+		s.lastChunkAt = time.Now()
+		if chunk.ID != "" && s.responseID == "" {
+			s.responseID = chunk.ID
+		}
+		if chunk.Usage != nil {
+			s.tokensIn = chunk.Usage.PromptTokens
+			s.tokensOut = chunk.Usage.CompletionTokens
+		}
+		if len(chunk.Choices) > 0 {
+			if chunk.Choices[0].FinishReason != nil {
+				s.finishReason = *chunk.Choices[0].FinishReason
+			}
+			s.contentBuf.WriteString(chunk.Choices[0].Delta.Content)
 		}
 
 		// Usage-only chunk (sent as the final chunk when stream_options.include_usage is true).
@@ -482,7 +678,11 @@ func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 	}
 
 	if err := s.scanner.Err(); err != nil {
-		return StreamChunk{}, fmt.Errorf("read stream: %w", err)
+		wrapped := fmt.Errorf("read stream: %w", err)
+		if s.streamErr == nil {
+			s.streamErr = wrapped
+		}
+		return StreamChunk{}, wrapped
 	}
 	// Scanner exhausted without [DONE] — treat as done.
 	return StreamChunk{Done: true}, nil
@@ -494,6 +694,13 @@ func (s *oaiResponseStream) Recv() (StreamChunk, error) {
 // connection" error from the body. The orchestrator calls Close via defer,
 // so a panic-during-Recv path could in principle hit Close twice if the
 // caller has its own defer too — guarding here costs one bool.
+//
+// Close is also the single emission site for the stream's structured
+// llm_response / llm_refused / llm_error event: the per-chunk Recv path
+// accumulates content, finish_reason, tokens and any stream error onto
+// fields of s, and Close fires exactly one event per stream based on
+// what landed. The closed guard above doubles as the "emitted-once"
+// guard so a double Close cannot double-emit.
 func (s *oaiResponseStream) Close() error {
 	if s.closed {
 		return nil
@@ -503,7 +710,52 @@ func (s *oaiResponseStream) Close() error {
 		s.onClose(s.accumulator.buf)
 		s.onClose = nil
 	}
+	s.emitStreamEnd()
 	return s.body.Close()
+}
+
+// emitStreamEnd writes the single llm_response / llm_refused / llm_error
+// event that summarises this stream. Called once from Close.
+func (s *oaiResponseStream) emitStreamEnd() {
+	if s.eventSink == nil {
+		// Defensive: streams constructed by tests outside Stream() may
+		// leave the sink unset. Skip emission rather than panic.
+		return
+	}
+	// Latency endpoint is the last chunk timestamp, not Close — so a
+	// slow orchestrator that holds the stream open while processing
+	// tool calls doesn't inflate the measured "LLM latency". When no
+	// chunks were received (transport-error mid-stream or HTTP-status
+	// error already routed above), fall back to time.Now() so the
+	// number stays non-zero for analytics.
+	endpoint := s.lastChunkAt
+	if endpoint.IsZero() {
+		endpoint = time.Now()
+	}
+	latencyMS := endpoint.Sub(s.startTime).Milliseconds()
+	if s.streamErr != nil {
+		emit.EmitLLMError(s.emitCtx, s.eventSink, emit.LLMErrorArgs{
+			Phase:            phaseStreamRecv,
+			ResponseBodyText: s.streamErr.Error(),
+		})
+		return
+	}
+	content := s.contentBuf.String()
+	if s.finishReason == openAIFinishReasonContentFilter {
+		emit.EmitLLMRefused(s.emitCtx, s.eventSink, emit.LLMRefusedArgs{
+			RefusalText:      content,
+			ContentSafetyHit: openAIFinishReasonContentFilter,
+		})
+		return
+	}
+	emit.EmitLLMResponse(s.emitCtx, s.eventSink, emit.LLMResponseArgs{
+		RawContent:         content,
+		FinishReason:       s.finishReason,
+		TokensIn:           s.tokensIn,
+		TokensOut:          s.tokensOut,
+		LatencyMS:          latencyMS,
+		ProviderResponseID: s.responseID,
+	})
 }
 
 func (p *OpenAIProvider) toOAIRequest(req *CompletionRequest) (oaiRequest, error) {

--- a/internal/provider/openai_session_events_test.go
+++ b/internal/provider/openai_session_events_test.go
@@ -1,0 +1,1044 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
+)
+
+// recordingEventSink captures every emit.Event in arrival order. Mirrors
+// the recordingSink used for DebugEventSink tests. The mutex protects
+// concurrent Emit calls from arbitrary callers — note that this says
+// nothing about the SafetyOfRecv/Close on the oaiResponseStream itself,
+// whose accumulator fields are not mutex-protected and follow the
+// orchestrator's single-goroutine Recv→Close contract.
+type recordingEventSink struct {
+	mu     sync.Mutex
+	events []emit.Event
+}
+
+func (s *recordingEventSink) Emit(_ context.Context, e emit.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *recordingEventSink) snapshot() []emit.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]emit.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+func (s *recordingEventSink) types() []string {
+	got := s.snapshot()
+	out := make([]string, len(got))
+	for i, e := range got {
+		out[i] = e.EventType
+	}
+	return out
+}
+
+// ----- Complete path -----
+
+func TestOpenAIComplete_EmitsRequestAndResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// A small sleep makes the millisecond-resolution latency
+		// measurement deterministic. httptest loopback completes in
+		// <1 ms otherwise and the LatencyMS field rounds to 0 with
+		// omitempty stripping it from the JSON.
+		time.Sleep(2 * time.Millisecond)
+		resp := oaiResponse{
+			ID:    "chatcmpl-evt-1",
+			Model: "gpt-4o",
+			Choices: []oaiChoice{{
+				Index:        0,
+				Message:      oaiMessage{Role: "assistant", Content: "Hello!"},
+				FinishReason: "stop",
+			}},
+			Usage: oaiUsage{PromptTokens: 11, CompletionTokens: 7},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (llm_request + llm_response)", len(got))
+	}
+	if got[0].EventType != events.TypeLLMRequest {
+		t.Errorf("events[0] = %q, want %q", got[0].EventType, events.TypeLLMRequest)
+	}
+	if got[1].EventType != events.TypeLLMResponse {
+		t.Errorf("events[1] = %q, want %q", got[1].EventType, events.TypeLLMResponse)
+	}
+
+	var req events.LLMRequestPayload
+	if err := json.Unmarshal(got[0].Payload, &req); err != nil {
+		t.Fatalf("unmarshal request payload: %v", err)
+	}
+	if req.ModelID != "gpt-4o" || req.MessageCount != 1 {
+		t.Errorf("request payload mismatch: %+v", req)
+	}
+
+	var resp events.LLMResponsePayload
+	if err := json.Unmarshal(got[1].Payload, &resp); err != nil {
+		t.Fatalf("unmarshal response payload: %v", err)
+	}
+	if resp.RawContentExcerpt != "Hello!" {
+		t.Errorf("RawContentExcerpt = %q", resp.RawContentExcerpt)
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q, want %q (oaiChoice.FinishReason must propagate to event)", resp.FinishReason, "stop")
+	}
+	if resp.TokensIn != 11 || resp.TokensOut != 7 {
+		t.Errorf("tokens = %d/%d", resp.TokensIn, resp.TokensOut)
+	}
+	if resp.ProviderResponseID != "chatcmpl-evt-1" {
+		t.Errorf("ProviderResponseID = %q", resp.ProviderResponseID)
+	}
+	if got[1].DurationMS <= 0 {
+		t.Errorf("row DurationMS = %d, want >0 (latency wraps the HTTP call)", got[1].DurationMS)
+	}
+}
+
+func TestOpenAIComplete_EmitsRefusedOnContentFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID:    "chatcmpl-refused",
+			Model: "gpt-4o",
+			Choices: []oaiChoice{{
+				Index:        0,
+				Message:      oaiMessage{Role: "assistant", Content: "I can't help with that."},
+				FinishReason: "content_filter",
+			}},
+			Usage: oaiUsage{PromptTokens: 5, CompletionTokens: 6},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, _ = p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[1].EventType != events.TypeLLMRefused {
+		t.Errorf("events[1] = %q, want %q (content_filter must classify as refusal, not response)",
+			got[1].EventType, events.TypeLLMRefused)
+	}
+	var p2 events.LLMRefusedPayload
+	if err := json.Unmarshal(got[1].Payload, &p2); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p2.ContentSafetyHit != "content_filter" {
+		t.Errorf("ContentSafetyHit = %q", p2.ContentSafetyHit)
+	}
+	if p2.RefusalText != "I can't help with that." {
+		t.Errorf("RefusalText = %q", p2.RefusalText)
+	}
+}
+
+func TestOpenAIComplete_EmitsErrorOnNonOKStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"error":{"message":"upstream timeout","type":"server_error"}}`))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Complete must error on 502")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (request + error)", len(got))
+	}
+	if got[1].EventType != events.TypeLLMError {
+		t.Errorf("events[1] = %q, want %q", got[1].EventType, events.TypeLLMError)
+	}
+	var p2 events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &p2)
+	if p2.StatusCode != 502 {
+		t.Errorf("StatusCode = %d, want 502", p2.StatusCode)
+	}
+	if !strings.Contains(p2.ResponseBodyExcerpt, "upstream timeout") {
+		t.Errorf("ResponseBodyExcerpt = %q, want substring 'upstream timeout'", p2.ResponseBodyExcerpt)
+	}
+	if p2.Phase == "" {
+		t.Error("Phase must be set on llm_error (helps analytics group errors by location)")
+	}
+}
+
+func TestOpenAIComplete_EmitsErrorOnBodyReadFailure(t *testing.T) {
+	// io.ReadAll failure path is hard to trigger over a real server
+	// because httptest always lets the body finish. A custom transport
+	// hands back a Response whose Body errors on Read — exercising the
+	// "chat.read_response" phase that real upstreams hit when the wire
+	// drops mid-body (proxy timeout, TLS hiccup).
+	failingClient := &http.Client{Transport: roundTripperFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(&erroringReader{err: errors.New("simulated body read failure")}),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", "http://example.invalid", "test-key", nil,
+		WithOpenAIHTTPClient(failingClient),
+		WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Complete must propagate body-read error")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (request + body-read error); types=%v", len(got), sink.types())
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseChatReadResponse {
+		t.Errorf("Phase = %q, want %q", perr.Phase, phaseChatReadResponse)
+	}
+}
+
+func TestOpenAIComplete_EmitsErrorOnMalformedJSON(t *testing.T) {
+	// HTTP 200 with body that fails json.Unmarshal — the chat.unmarshal
+	// phase. Real upstreams hit this when proxies inject HTML error
+	// pages with 200 status, or when a buggy SDK serialises with NaN.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`not a valid json body`))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Complete must error on unparseable body")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseChatUnmarshal {
+		t.Errorf("Phase = %q, want %q", perr.Phase, phaseChatUnmarshal)
+	}
+	if perr.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200 (unmarshal errors carry the original status)", perr.StatusCode)
+	}
+}
+
+func TestOpenAIComplete_EmitsErrorOnAPIErrorIn200Body(t *testing.T) {
+	// HTTP 200 with a {"error":{...}} payload — OpenAI sometimes does
+	// this for quota / auth issues. The chat.api_error phase exists
+	// specifically so analytics keeps these distinct from 4xx/5xx.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error":{"message":"quota exceeded","type":"insufficient_quota","code":"q1"}}`))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Complete must propagate embedded-error body")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseChatAPIError {
+		t.Errorf("Phase = %q, want %q (api_error must be distinct from http_status)", perr.Phase, phaseChatAPIError)
+	}
+	if !strings.Contains(perr.ResponseBodyExcerpt, "quota exceeded") {
+		t.Errorf("ResponseBodyExcerpt = %q, want substring 'quota exceeded'", perr.ResponseBodyExcerpt)
+	}
+}
+
+func TestOpenAIComplete_EmitsErrorOnTransportFailure(t *testing.T) {
+	// Server is created and immediately closed: any subsequent request
+	// hits a dead listener, triggering a transport-level error.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Complete must error on transport failure")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (request + transport error)", len(got))
+	}
+	if got[1].EventType != events.TypeLLMError {
+		t.Errorf("events[1] = %q, want %q", got[1].EventType, events.TypeLLMError)
+	}
+	var p2 events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &p2)
+	if p2.Phase != phaseChatTransport {
+		t.Errorf("Phase = %q, want %q (transport phase must be distinct from http_status phase)",
+			p2.Phase, phaseChatTransport)
+	}
+}
+
+func TestOpenAIComplete_NativeToolCallsRawInPayload(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID:    "chatcmpl-tools",
+			Model: "gpt-4o",
+			Choices: []oaiChoice{{
+				Index: 0,
+				Message: oaiMessage{
+					Role: "assistant", Content: "",
+					ToolCalls: []oaiToolCall{{
+						ID:   "call_1",
+						Type: "function",
+						Function: oaiToolCallFunction{
+							Name:      "tickets.show",
+							Arguments: `{"id":"42"}`,
+						},
+					}},
+				},
+				FinishReason: "tool_calls",
+			}},
+			Usage: oaiUsage{PromptTokens: 8, CompletionTokens: 4},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "show 42"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	var resp events.LLMResponsePayload
+	_ = json.Unmarshal(sink.snapshot()[1].Payload, &resp)
+	if len(resp.NativeToolCallsRaw) == 0 {
+		t.Fatal("NativeToolCallsRaw must be non-empty when provider returned tool_calls")
+	}
+	if !json.Valid(resp.NativeToolCallsRaw) {
+		t.Errorf("NativeToolCallsRaw = %q, want valid inline JSON", string(resp.NativeToolCallsRaw))
+	}
+	// Inline-embedded, not escaped-string: the first byte must be '['
+	// (array open) — string-encoded would be '"'.
+	if resp.NativeToolCallsRaw[0] != '[' {
+		t.Errorf("NativeToolCallsRaw[0] = %q, want '[' (inline JSON, not escaped string)", resp.NativeToolCallsRaw[0])
+	}
+	// Round-trip: the embedded JSON must decode back into the same
+	// oaiToolCall shape the upstream sent. A regression that
+	// double-encoded or lost call_id / arguments would slip past the
+	// looser "starts with [" check but fail this assertion.
+	var roundTrip []oaiToolCall
+	if err := json.Unmarshal(resp.NativeToolCallsRaw, &roundTrip); err != nil {
+		t.Fatalf("NativeToolCallsRaw round-trip unmarshal: %v", err)
+	}
+	if len(roundTrip) != 1 {
+		t.Fatalf("round-trip tool calls = %d, want 1", len(roundTrip))
+	}
+	if roundTrip[0].ID != "call_1" {
+		t.Errorf("round-trip call_id = %q, want %q", roundTrip[0].ID, "call_1")
+	}
+	if roundTrip[0].Function.Name != "tickets.show" {
+		t.Errorf("round-trip function name = %q", roundTrip[0].Function.Name)
+	}
+	if roundTrip[0].Function.Arguments != `{"id":"42"}` {
+		t.Errorf("round-trip arguments = %q (must preserve verbatim provider JSON)", roundTrip[0].Function.Arguments)
+	}
+}
+
+// ----- Stream path -----
+
+// streamResponse builds an SSE response body that mirrors what OpenAI
+// sends for a streamed chat completion: a few content delta chunks, an
+// optional content_filter-bearing chunk, a usage-only chunk, and a
+// terminating [DONE] marker.
+func streamResponse(deltas []string, finishReason string, includeUsage bool) string {
+	var b strings.Builder
+	for _, d := range deltas {
+		chunk := map[string]any{
+			"id":    "chatcmpl-stream",
+			"model": "gpt-4o",
+			"choices": []map[string]any{{
+				"index":         0,
+				"delta":         map[string]string{"content": d},
+				"finish_reason": nil,
+			}},
+		}
+		raw, _ := json.Marshal(chunk)
+		b.WriteString("data: ")
+		b.Write(raw)
+		b.WriteString("\n\n")
+	}
+	if finishReason != "" {
+		chunk := map[string]any{
+			"id":    "chatcmpl-stream",
+			"model": "gpt-4o",
+			"choices": []map[string]any{{
+				"index":         0,
+				"delta":         map[string]string{},
+				"finish_reason": finishReason,
+			}},
+		}
+		raw, _ := json.Marshal(chunk)
+		b.WriteString("data: ")
+		b.Write(raw)
+		b.WriteString("\n\n")
+	}
+	if includeUsage {
+		chunk := map[string]any{
+			"id":      "chatcmpl-stream",
+			"model":   "gpt-4o",
+			"choices": []map[string]any{},
+			"usage":   map[string]int{"prompt_tokens": 12, "completion_tokens": 9},
+		}
+		raw, _ := json.Marshal(chunk)
+		b.WriteString("data: ")
+		b.Write(raw)
+		b.WriteString("\n\n")
+	}
+	b.WriteString("data: [DONE]\n\n")
+	return b.String()
+}
+
+func drainStream(t *testing.T, stream ResponseStream) {
+	t.Helper()
+	for {
+		chunk, err := stream.Recv()
+		if err != nil {
+			break
+		}
+		if chunk.Done {
+			break
+		}
+	}
+}
+
+func TestOpenAIStream_EmitsRequestThenResponseOnClose(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Small sleep makes the latency endpoint (last-chunk-arrival) strictly
+		// greater than the start timestamp at millisecond resolution.
+		// Otherwise loopback flushes too fast and DurationMS rounds to 0.
+		time.Sleep(2 * time.Millisecond)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse([]string{"hello, ", "world"}, "stop", true)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	// Sleep AFTER draining: latency must NOT include this gap because
+	// the endpoint is last-chunk-arrival, not Close(). If a future
+	// regression switches back to time.Since(start) in Close, this
+	// sleep would inflate DurationMS by >20 ms and the upper bound
+	// below would catch the drift.
+	time.Sleep(20 * time.Millisecond)
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (llm_request + llm_response on Close), types=%v", len(got), sink.types())
+	}
+	if got[0].EventType != events.TypeLLMRequest {
+		t.Errorf("events[0] = %q, want %q", got[0].EventType, events.TypeLLMRequest)
+	}
+	if got[1].EventType != events.TypeLLMResponse {
+		t.Errorf("events[1] = %q, want %q", got[1].EventType, events.TypeLLMResponse)
+	}
+	var resp events.LLMResponsePayload
+	_ = json.Unmarshal(got[1].Payload, &resp)
+	if resp.RawContentExcerpt != "hello, world" {
+		t.Errorf("RawContentExcerpt = %q (deltas must be reassembled)", resp.RawContentExcerpt)
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q", resp.FinishReason)
+	}
+	if resp.TokensIn != 12 || resp.TokensOut != 9 {
+		t.Errorf("tokens = %d/%d (usage-only chunk must propagate to event)", resp.TokensIn, resp.TokensOut)
+	}
+	if resp.ProviderResponseID != "chatcmpl-stream" {
+		t.Errorf("ProviderResponseID = %q", resp.ProviderResponseID)
+	}
+	// Latency endpoint is last-chunk-arrival, not Close. With a 2 ms
+	// server sleep + 20 ms post-drain wait, the measured latency must
+	// be at least the server sleep but well under the orchestrator
+	// drain window.
+	if got[1].DurationMS < 2 {
+		t.Errorf("row DurationMS = %d, want >=2 (server sleep)", got[1].DurationMS)
+	}
+	if got[1].DurationMS >= 20 {
+		t.Errorf("row DurationMS = %d, want <20 (latency must NOT include post-drain wait — bug if endpoint moved to Close)", got[1].DurationMS)
+	}
+}
+
+func TestOpenAIStream_EmitsErrorOnTransportFailure(t *testing.T) {
+	// Mirror of the Complete-side transport-failure test for the stream
+	// path. Distinct phase label so analytics can group transport
+	// failures by call type.
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Stream must error on transport failure")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (llm_request + stream transport error); types=%v", len(got), sink.types())
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseStreamTransport {
+		t.Errorf("Phase = %q, want %q", perr.Phase, phaseStreamTransport)
+	}
+}
+
+func TestOpenAIStream_EmitsRefusedOnContentFilter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse([]string{"I can't ", "help"}, "content_filter", true)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMRefused {
+		t.Errorf("events[1] = %q, want %q (content_filter on a streamed response classifies as refusal)",
+			got[1].EventType, events.TypeLLMRefused)
+	}
+	var refused events.LLMRefusedPayload
+	_ = json.Unmarshal(got[1].Payload, &refused)
+	if refused.RefusalText != "I can't help" {
+		t.Errorf("RefusalText = %q", refused.RefusalText)
+	}
+}
+
+func TestOpenAIStream_EmitsErrorOnHTTPStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	_, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err == nil {
+		t.Fatal("Stream must error on 500")
+	}
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (llm_request + llm_error); types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMError {
+		t.Errorf("events[1] = %q, want %q", got[1].EventType, events.TypeLLMError)
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseStreamHTTPStatus {
+		t.Errorf("Phase = %q, want %q (stream-side status error must be distinct from chat.http_status)",
+			perr.Phase, phaseStreamHTTPStatus)
+	}
+	if perr.StatusCode != 500 {
+		t.Errorf("StatusCode = %d", perr.StatusCode)
+	}
+}
+
+func TestOpenAIStream_EmitsErrorOnChunkError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(`data: {"error":{"message":"chunk explode","type":"server_error"}}` + "\n\n"))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Drain — Recv will surface the chunk error.
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMError {
+		t.Errorf("events[1] = %q, want %q (mid-stream errors emit llm_error from Close)",
+			got[1].EventType, events.TypeLLMError)
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseStreamRecv {
+		t.Errorf("Phase = %q, want %q", perr.Phase, phaseStreamRecv)
+	}
+}
+
+func TestOpenAIStream_DoubleCloseEmitsOnce(t *testing.T) {
+	// The closed-bool guard on oaiResponseStream is the sole "emit-once"
+	// guarantee. If Close is hit twice (orchestrator defer + caller
+	// defer), the second call must be a no-op for the event sink too.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse([]string{"ok"}, "stop", true)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	_ = stream.Close()
+	_ = stream.Close() // must not re-emit
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events on double Close, want 2; types=%v", len(got), sink.types())
+	}
+}
+
+func TestNewOpenAIProvider_NoSinkOptionDefaultsToNoOp(t *testing.T) {
+	// Constructing without WithOpenAISessionEventSink must NOT panic at
+	// emission time: the field defaults to emit.NoOpSink{}. Belt-and-
+	// braces — also confirms no nil-Sink reaches the helpers.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID: "x", Model: "gpt-4o",
+			Choices: []oaiChoice{{Message: oaiMessage{Role: "assistant", Content: "ok"}, FinishReason: "stop"}},
+			Usage:   oaiUsage{PromptTokens: 1, CompletionTokens: 1},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil)
+	if _, err := p.Complete(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	}); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+}
+
+func TestWithOpenAISessionEventSink_NilArgReplacedByNoOp(t *testing.T) {
+	// Defensive contract: WithOpenAISessionEventSink(nil) is valid and
+	// replaces the field with NoOpSink rather than leaving it nil.
+	p := NewOpenAIProvider("openai", "http://localhost", "key", nil, WithOpenAISessionEventSink(nil))
+	if p.eventSink == nil {
+		t.Error("eventSink must not be nil after WithOpenAISessionEventSink(nil); want NoOpSink")
+	}
+}
+
+// ----- Stream edge cases -----
+
+func TestOpenAIStream_RefusalWithEmptyContent(t *testing.T) {
+	// A model that issues a content_filter finish_reason with NO
+	// content deltas at all (it refused before any token streamed)
+	// must still produce an llm_refused event — with an empty
+	// RefusalText. Analytics consumers may filter on the type, not
+	// the text, so the absence of text is meaningful information.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse(nil, "content_filter", true)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMRefused {
+		t.Errorf("events[1] = %q, want llm_refused", got[1].EventType)
+	}
+	var refused events.LLMRefusedPayload
+	_ = json.Unmarshal(got[1].Payload, &refused)
+	if refused.RefusalText != "" {
+		t.Errorf("RefusalText = %q, want empty (no content deltas streamed before refusal)", refused.RefusalText)
+	}
+	if refused.ContentSafetyHit != "content_filter" {
+		t.Errorf("ContentSafetyHit = %q", refused.ContentSafetyHit)
+	}
+}
+
+func TestOpenAIStream_ContentDeltaThenErrorEmitsError(t *testing.T) {
+	// Content delta arrives first, then a chunk-level error mid-stream.
+	// emitStreamEnd must prefer the error path (llm_error with
+	// stream.recv phase) over the partial-content path (llm_response).
+	// Otherwise a transient mid-stream failure would be misattributed
+	// as a successful generation with truncated content.
+	body := strings.Builder{}
+	chunk := map[string]any{
+		"id":    "chatcmpl-stream",
+		"model": "gpt-4o",
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]string{"content": "partial answer"},
+			"finish_reason": nil,
+		}},
+	}
+	raw, _ := json.Marshal(chunk)
+	body.WriteString("data: ")
+	body.Write(raw)
+	body.WriteString("\n\ndata: {\"error\":{\"message\":\"mid-stream boom\",\"type\":\"server_error\"}}\n\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body.String()))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for {
+		_, recvErr := stream.Recv()
+		if recvErr != nil {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMError {
+		t.Errorf("events[1] = %q, want llm_error (mid-stream error must outrank partial content)", got[1].EventType)
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if perr.Phase != phaseStreamRecv {
+		t.Errorf("Phase = %q, want %q", perr.Phase, phaseStreamRecv)
+	}
+	if !strings.Contains(perr.ResponseBodyExcerpt, "mid-stream boom") {
+		t.Errorf("ResponseBodyExcerpt = %q, want substring 'mid-stream boom'", perr.ResponseBodyExcerpt)
+	}
+}
+
+func TestOpenAIStream_NoFinishReasonEmitsResponseWithEmpty(t *testing.T) {
+	// A clean stream (terminated by [DONE]) that never carries a
+	// finish_reason chunk and never carries a usage chunk should still
+	// emit llm_response (not llm_error) with FinishReason == "" and
+	// token counts == 0. This is the "finished response with missing
+	// metadata" mode — analytics needs to see it tagged correctly, not
+	// silently reclassified as an error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		// streamResponse always appends "data: [DONE]\n\n". Passing
+		// finishReason="" and includeUsage=false omits the
+		// metadata-bearing chunks but keeps the [DONE] terminator so
+		// the scanner exits cleanly (not via scanner-error).
+		_, _ = w.Write([]byte(streamResponse([]string{"partial"}, "", false)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMResponse {
+		t.Errorf("events[1] = %q, want llm_response (no finish_reason should NOT be classified as error)",
+			got[1].EventType)
+	}
+	var resp events.LLMResponsePayload
+	_ = json.Unmarshal(got[1].Payload, &resp)
+	if resp.FinishReason != "" {
+		t.Errorf("FinishReason = %q, want empty (no finish_reason chunk arrived)", resp.FinishReason)
+	}
+	if resp.RawContentExcerpt != "partial" {
+		t.Errorf("RawContentExcerpt = %q (deltas before truncation must persist)", resp.RawContentExcerpt)
+	}
+}
+
+func TestOpenAIStream_CloseWithoutRecvUsesNowFallback(t *testing.T) {
+	// Reaches the `if endpoint.IsZero() { endpoint = time.Now() }`
+	// fallback in emitStreamEnd: Stream() returns a stream, the
+	// orchestrator never reads any chunk (e.g. immediately abandoned
+	// because the outer turn cancelled), then Close is called. Without
+	// the fallback, latency would be the literal value 0 and analytics
+	// dashboards would see a phantom zero-latency row.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse([]string{"unused"}, "stop", true)))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Deliberately do NOT call Recv. Brief sleep so time.Now() at Close
+	// is provably after startTime at millisecond resolution.
+	time.Sleep(2 * time.Millisecond)
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2; types=%v", len(got), sink.types())
+	}
+	if got[1].EventType != events.TypeLLMResponse {
+		t.Errorf("events[1] = %q, want llm_response (no streamErr, no content_filter)", got[1].EventType)
+	}
+	if got[1].DurationMS < 2 {
+		t.Errorf("row DurationMS = %d, want >=2ms (fallback must use time.Now() so latency stays non-zero)",
+			got[1].DurationMS)
+	}
+}
+
+func TestOpenAIStream_FirstErrorWinsAcrossRecvRetries(t *testing.T) {
+	// The streamErr guard claims "first error wins: a caller that
+	// ignored the error and re-entered Recv must not overwrite the
+	// original cause". The straight-line orchestrator wouldn't retry
+	// after an error, but the invariant is load-bearing for the
+	// emitted llm_error payload's accuracy and must not regress.
+	body := strings.Builder{}
+	body.WriteString("data: {\"error\":{\"message\":\"first failure\",\"type\":\"server_error\"}}\n\n")
+	body.WriteString("data: {\"error\":{\"message\":\"second failure\",\"type\":\"server_error\"}}\n\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body.String()))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	// Drain both error chunks. A defensive caller normally exits the
+	// loop after the first error; this loop deliberately keeps reading
+	// to exercise the guard.
+	for i := 0; i < 2; i++ {
+		_, err := stream.Recv()
+		if err == nil {
+			break
+		}
+	}
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2 (request + first error)", len(got))
+	}
+	var perr events.LLMErrorPayload
+	_ = json.Unmarshal(got[1].Payload, &perr)
+	if !strings.Contains(perr.ResponseBodyExcerpt, "first failure") {
+		t.Errorf("ResponseBodyExcerpt = %q, want substring 'first failure' (guard must preserve the original cause)",
+			perr.ResponseBodyExcerpt)
+	}
+	if strings.Contains(perr.ResponseBodyExcerpt, "second failure") {
+		t.Errorf("ResponseBodyExcerpt = %q must NOT contain 'second failure' (guard regression — first error must win)",
+			perr.ResponseBodyExcerpt)
+	}
+}
+
+func TestOpenAIStream_FinishReasonAndDeltaInSameChunk(t *testing.T) {
+	// OpenAI can pack the final content delta AND finish_reason into a
+	// single chunk. The accumulator must capture both rather than
+	// treating "has finish_reason" as "no more content".
+	body := strings.Builder{}
+	chunk := map[string]any{
+		"id":    "chatcmpl-stream",
+		"model": "gpt-4o",
+		"choices": []map[string]any{{
+			"index":         0,
+			"delta":         map[string]string{"content": "all in one"},
+			"finish_reason": "stop",
+		}},
+	}
+	raw, _ := json.Marshal(chunk)
+	body.WriteString("data: ")
+	body.Write(raw)
+	body.WriteString("\n\ndata: [DONE]\n\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(body.String()))
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", nil, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model: "gpt-4o", Messages: []Message{{Role: RoleUser, Content: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	_ = stream.Close()
+
+	got := sink.snapshot()
+	var resp events.LLMResponsePayload
+	_ = json.Unmarshal(got[1].Payload, &resp)
+	if resp.RawContentExcerpt != "all in one" {
+		t.Errorf("RawContentExcerpt = %q (combined chunk must propagate both fields)", resp.RawContentExcerpt)
+	}
+	if resp.FinishReason != "stop" {
+		t.Errorf("FinishReason = %q", resp.FinishReason)
+	}
+}
+
+// ----- test helpers shared by the error-path tests above -----
+
+// roundTripperFunc adapts a closure into an http.RoundTripper so the
+// chat.read_response path can be exercised without a live server.
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+// erroringReader returns err on the first Read so io.ReadAll surfaces
+// it to the provider's body-read path.
+type erroringReader struct{ err error }
+
+func (r *erroringReader) Read(_ []byte) (int, error) { return 0, r.err }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -63,6 +63,14 @@ type CompletionResponse struct {
 	Content   string     `json:"content"`
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"` // native tool calls from LLM; nil = check Content for text-based calls
 	Usage     Usage      `json:"usage"`
+
+	// EventID is the session-event id of the llm_response event the
+	// provider emitted for this completion (empty when no event sink is
+	// configured, or when the response carried a refusal — see EmitLLMRefused).
+	// The orchestrator uses this as parent_id on subsequent
+	// tool_call_extracted events so the analytics graph links each tool
+	// dispatch back to the LLM round that produced it.
+	EventID string `json:"-"`
 }
 
 type StreamChunk struct {

--- a/internal/state/store/events/emit/emit.go
+++ b/internal/state/store/events/emit/emit.go
@@ -40,6 +40,7 @@ package emit
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -53,7 +54,14 @@ import (
 // Producers don't build this directly — Emit<Type> helpers fill it from
 // ctx + a typed args struct. The adapter in cmd/opentalon converts to
 // store.SessionEvent before Submit.
+//
+// ID is generated producer-side by send() so the value is available to
+// callers (via the helper return value) before the row hits the store.
+// The store accepts a pre-populated ID and skips its own generation; the
+// duplicated generator there is the fallback for any caller that builds
+// SessionEvent directly without going through emit.
 type Event struct {
+	ID         string
 	SessionID  string
 	EventType  string
 	ParentID   string
@@ -113,22 +121,27 @@ func ParentID(ctx context.Context) string {
 // ----- internal helper shared by every Emit<Type> -----
 
 // send marshals payload, stamps the canonical fields from ctx, and
-// hands the resulting Event to sink.Emit. A nil sink and the NoOpSink
-// zero-value are silent no-ops, so callers don't need to nil-check at
-// every emission site. Short-circuiting NoOpSink BEFORE json.Marshal
-// is important: it's the default when the orchestrator runs without a
-// state DB, and the hot path emits multiple events per LLM turn — we
-// don't want to pay marshalling cost just to discard the bytes.
+// hands the resulting Event to sink.Emit. Returns the generated event
+// id so callers can chain it as parent on subsequent emits via
+// WithParent(ctx, id). Returns "" if the event was dropped (nil sink,
+// NoOpSink, marshal failure, or id generator failure).
+//
+// A nil sink and the NoOpSink zero-value are silent no-ops, so callers
+// don't need to nil-check at every emission site. Short-circuiting
+// NoOpSink BEFORE json.Marshal is important: it's the default when the
+// orchestrator runs without a state DB, and the hot path emits multiple
+// events per LLM turn — we don't want to pay marshalling cost just to
+// discard the bytes.
 //
 // durationMS is split out from payload because the row-level column is
 // what analytics queries index — payloads that carry a latency_ms field
 // of their own pass the same value here so the column stays in sync.
-func send(ctx context.Context, sink Sink, eventType string, payload any, durationMS int64) {
+func send(ctx context.Context, sink Sink, eventType string, payload any, durationMS int64) string {
 	if sink == nil {
-		return
+		return ""
 	}
 	if _, ok := sink.(NoOpSink); ok {
-		return
+		return ""
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {
@@ -136,15 +149,36 @@ func send(ctx context.Context, sink Sink, eventType string, payload any, duratio
 			"event_type", eventType,
 			"error", err,
 		)
-		return
+		return ""
+	}
+	id, err := newEventID()
+	if err != nil {
+		slog.Warn("session event emit: id generation failed",
+			"event_type", eventType,
+			"error", err,
+		)
+		return ""
 	}
 	sink.Emit(ctx, Event{
+		ID:         id,
 		SessionID:  actor.SessionID(ctx),
 		EventType:  eventType,
 		ParentID:   ParentID(ctx),
 		DurationMS: durationMS,
 		Payload:    raw,
 	})
+	return id
+}
+
+// newEventID returns a 32-char hex id, matching the shape of the
+// fallback generator in store.session_events. Generating producer-side
+// lets callers thread the id as parent_id on subsequent emits.
+func newEventID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
 }
 
 // sha256Hex returns the lowercase-hex SHA256 of s. Used by helpers whose

--- a/internal/state/store/events/emit/emit.go
+++ b/internal/state/store/events/emit/emit.go
@@ -1,0 +1,149 @@
+// Package emit is the producer side of the session_events log.
+//
+// Subsystems (provider wrapper, orchestrator, tool dispatcher, parser,
+// planner, …) never marshal payloads or call the underlying writer
+// directly. Instead each event type has a typed helper here —
+// EmitLLMResponse, EmitToolCallExtracted, … — that takes a Sink and an
+// args struct, then encapsulates:
+//
+//   - schema-version stamping (Header.V from the matching <Type>Version
+//     constant in package events),
+//   - UTF-8 sanitization (events.SanitizeUTF8) for free-form bytes,
+//   - 4 KB excerpt capping (events.Excerpt) with the truncated flag,
+//   - SHA256 of raw content where the payload demands it,
+//   - JSON marshalling,
+//   - session-id lookup from ctx via actor.SessionID,
+//   - parent-event-id lookup from ctx via emit.ParentID.
+//
+// This is the compile-time + runtime gate that makes the producer side
+// of session_events "automatic and stable" per the design memo: the only
+// way to write an event is through these helpers, so the conventions
+// can't drift.
+//
+// Always-on by design — unlike provider.DebugEventSink, which uses a
+// DebugContextResolver callback to gate capture per-session via the
+// /debug flag, session_events has no per-session disable. Structured
+// events are the canonical audit trail for analytics, score worker, and
+// the Rails review UI: gating it per-session would defeat the purpose.
+// The runtime cost is a fixed Marshal + non-blocking channel send per
+// event; the writer drops on overflow rather than back-pressuring the
+// orchestrator hot path. A nil Sink (or NoOpSink, the default when no
+// state DB is configured) is the only off-switch.
+//
+// Why an emit.Event struct separate from store.SessionEvent — the
+// state/store package imports provider for message types, so any package
+// that needs to be imported by provider (this one, eventually) cannot
+// itself import store without creating a cycle. emit.Event is the
+// in-flight DTO; an adapter in cmd/opentalon/main.go converts it to
+// store.SessionEvent for the writer.
+package emit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/opentalon/opentalon/internal/actor"
+)
+
+// Event is one structured session event before persistence.
+//
+// Producers don't build this directly — Emit<Type> helpers fill it from
+// ctx + a typed args struct. The adapter in cmd/opentalon converts to
+// store.SessionEvent before Submit.
+type Event struct {
+	SessionID  string
+	EventType  string
+	ParentID   string
+	DurationMS int64
+	Payload    json.RawMessage
+}
+
+// Sink receives one structured event from a producer. Implementations
+// must not block: producers call Emit on the orchestrator hot path, and
+// the production implementation is an async buffered writer that drops
+// on overflow rather than back-pressuring.
+type Sink interface {
+	Emit(ctx context.Context, evt Event)
+}
+
+// NoOpSink discards every event. Use it as the zero-value default in
+// tests or in code paths that have no state store configured.
+type NoOpSink struct{}
+
+// Emit satisfies Sink.
+func (NoOpSink) Emit(context.Context, Event) {}
+
+// ----- parent-event context carrier -----
+
+type parentEventIDKey struct{}
+
+// WithParent returns a context that carries parentEventID as the parent
+// of any event emitted with it.
+//
+// Pattern: at a logical boundary (tool dispatch, planner step, …) the
+// caller captures the event_id it just emitted via Emit<Type> and wraps
+// the ctx with WithParent before passing it deeper. Helpers further down
+// the stack auto-populate Event.ParentID from this slot.
+//
+// Empty parentEventID is a no-op — the original context is returned
+// unchanged.
+func WithParent(ctx context.Context, parentEventID string) context.Context {
+	if parentEventID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, parentEventIDKey{}, parentEventID)
+}
+
+// ParentID returns the parent event_id stored on ctx, or "" when none.
+func ParentID(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	v := ctx.Value(parentEventIDKey{})
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// ----- internal helper shared by every Emit<Type> -----
+
+// send marshals payload, stamps the canonical fields from ctx, and
+// hands the resulting Event to sink.Emit. A nil sink is a silent no-op,
+// so callers don't need to nil-check at every emission site.
+//
+// durationMS is split out from payload because the row-level column is
+// what analytics queries index — payloads that carry a latency_ms field
+// of their own pass the same value here so the column stays in sync.
+func send(ctx context.Context, sink Sink, eventType string, payload any, durationMS int64) {
+	if sink == nil {
+		return
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		slog.Warn("session event emit: payload marshal failed",
+			"event_type", eventType,
+			"error", err,
+		)
+		return
+	}
+	sink.Emit(ctx, Event{
+		SessionID:  actor.SessionID(ctx),
+		EventType:  eventType,
+		ParentID:   ParentID(ctx),
+		DurationMS: durationMS,
+		Payload:    raw,
+	})
+}
+
+// sha256Hex returns the lowercase-hex SHA256 of s. Used by helpers whose
+// payload declares a *_sha256 field — keeps the digest computation out
+// of caller code so it cannot drift.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/state/store/events/emit/emit.go
+++ b/internal/state/store/events/emit/emit.go
@@ -113,14 +113,21 @@ func ParentID(ctx context.Context) string {
 // ----- internal helper shared by every Emit<Type> -----
 
 // send marshals payload, stamps the canonical fields from ctx, and
-// hands the resulting Event to sink.Emit. A nil sink is a silent no-op,
-// so callers don't need to nil-check at every emission site.
+// hands the resulting Event to sink.Emit. A nil sink and the NoOpSink
+// zero-value are silent no-ops, so callers don't need to nil-check at
+// every emission site. Short-circuiting NoOpSink BEFORE json.Marshal
+// is important: it's the default when the orchestrator runs without a
+// state DB, and the hot path emits multiple events per LLM turn — we
+// don't want to pay marshalling cost just to discard the bytes.
 //
 // durationMS is split out from payload because the row-level column is
 // what analytics queries index — payloads that carry a latency_ms field
 // of their own pass the same value here so the column stays in sync.
 func send(ctx context.Context, sink Sink, eventType string, payload any, durationMS int64) {
 	if sink == nil {
+		return
+	}
+	if _, ok := sink.(NoOpSink); ok {
 		return
 	}
 	raw, err := json.Marshal(payload)

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -1,0 +1,960 @@
+package emit
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// fakeSink records every emitted event in arrival order. Concurrent
+// safe so tests can fan out across goroutines if needed later.
+type fakeSink struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (f *fakeSink) Emit(_ context.Context, e Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+
+func (f *fakeSink) snapshot() []Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
+
+// ----- foundation -----
+
+func TestNoOpSinkNeverPanics(t *testing.T) {
+	// Belt-and-braces: the NoOpSink is the documented fallback for code
+	// paths with no state DB; it must accept any well-formed event
+	// without observable side effects.
+	NoOpSink{}.Emit(context.Background(), Event{
+		SessionID: "sess",
+		EventType: events.TypeTurnStart,
+		Payload:   json.RawMessage(`{}`),
+	})
+}
+
+func TestNilSinkIsSilentNoop(t *testing.T) {
+	// send() must short-circuit on nil so producers don't have to
+	// nil-check at every emission site. Treat this as a contract test.
+	EmitUserMessage(context.Background(), nil, "hi") // must not panic
+}
+
+func TestSendPopulatesContextFields(t *testing.T) {
+	sink := &fakeSink{}
+	ctx := actor.WithSessionID(context.Background(), "sess-abc")
+	ctx = WithParent(ctx, "parent-evt-1")
+
+	EmitUserMessage(ctx, sink, "hello")
+
+	got := sink.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1", len(got))
+	}
+	if got[0].SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q (must be sourced from actor.SessionID)", got[0].SessionID, "sess-abc")
+	}
+	if got[0].ParentID != "parent-evt-1" {
+		t.Errorf("ParentID = %q, want %q (must be sourced from emit.ParentID)", got[0].ParentID, "parent-evt-1")
+	}
+	if got[0].EventType != events.TypeUserMessage {
+		t.Errorf("EventType = %q, want %q", got[0].EventType, events.TypeUserMessage)
+	}
+}
+
+func TestWithParentEmptyIsNoop(t *testing.T) {
+	base := context.Background()
+	if WithParent(base, "") != base {
+		t.Error("WithParent with empty parentID must return the original ctx unchanged")
+	}
+}
+
+func TestParentIDNilCtxIsEmpty(t *testing.T) {
+	//nolint:staticcheck // intentional nil-ctx defensive path
+	if got := ParentID(nil); got != "" {
+		t.Errorf("ParentID(nil) = %q, want empty", got)
+	}
+}
+
+// ----- turn & user_message -----
+
+func TestEmitTurnStart_PayloadShape(t *testing.T) {
+	sink := &fakeSink{}
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	temp := 0.7
+	EmitTurnStart(ctx, sink, TurnStartArgs{
+		SystemPromptSHA256: "abc123",
+		ServerInstructions: []events.ServerInstructionRef{{Name: "instr", SHA256: "def456"}},
+		AvailableTools:     []events.ToolRef{{Name: "tickets.show", DescSHA256: "ghi789"}},
+		ModelID:            "gpt-x",
+		Temperature:        &temp,
+		ReasoningEffort:    "medium",
+	})
+
+	got := sink.snapshot()
+	if len(got) != 1 || got[0].EventType != events.TypeTurnStart {
+		t.Fatalf("unexpected events: %+v", got)
+	}
+	var p events.TurnStartPayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.V != events.TurnStartVersion {
+		t.Errorf("Header.V = %d, want %d", p.V, events.TurnStartVersion)
+	}
+	if p.SystemPromptSHA256 != "abc123" || p.ModelID != "gpt-x" || p.ReasoningEffort != "medium" {
+		t.Errorf("scalar fields mismatch: %+v", p)
+	}
+	if p.Temperature == nil || *p.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", p.Temperature)
+	}
+	if len(p.AvailableTools) != 1 || p.AvailableTools[0].Name != "tickets.show" {
+		t.Errorf("AvailableTools mismatch: %+v", p.AvailableTools)
+	}
+}
+
+func TestEmitUserMessage_ContentLengthMatchesStoredContent(t *testing.T) {
+	// The contract: ContentLength matches the BYTES of the stored Content
+	// field (post-sanitization), not the input. ASCII inputs are
+	// invariant under SanitizeUTF8 so the simple case still passes — but
+	// drift in the helper (e.g. computing length of the pre-sanitize
+	// input) would silently produce inconsistent rows on non-UTF-8 input.
+	sink := &fakeSink{}
+	content := "hello, world"
+	EmitUserMessage(context.Background(), sink, content)
+
+	got := sink.snapshot()
+	var p events.UserMessagePayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Content != content {
+		t.Errorf("Content = %q, want %q", p.Content, content)
+	}
+	if p.ContentLength != len(p.Content) {
+		t.Errorf("ContentLength = %d, want %d (must match stored Content byte length)", p.ContentLength, len(p.Content))
+	}
+}
+
+// ----- llm cluster (raw-capture invariants) -----
+
+func TestEmitLLMResponse_ExcerptAndSHA256(t *testing.T) {
+	sink := &fakeSink{}
+	long := strings.Repeat("A", events.ExcerptCap+128) // overshoot the cap
+	EmitLLMResponse(context.Background(), sink, LLMResponseArgs{
+		RawContent:         long,
+		NativeToolCallsRaw: json.RawMessage(`[{"id":"c1","name":"ticket.show","arguments":{"id":"42"}}]`),
+		FinishReason:       "stop",
+		LatencyMS:          1234,
+	})
+
+	got := sink.snapshot()
+	var p events.LLMResponsePayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !p.RawContentTruncated {
+		t.Error("truncated flag must be true when content exceeds ExcerptCap")
+	}
+	if len(p.RawContentExcerpt) != events.ExcerptCap {
+		t.Errorf("excerpt len = %d, want %d", len(p.RawContentExcerpt), events.ExcerptCap)
+	}
+	if p.RawContentSHA256 == "" {
+		t.Error("SHA256 must be populated by helper; callers must not compute")
+	}
+	// Inline embedding (json.RawMessage), not escaped-string form.
+	if !json.Valid(p.NativeToolCallsRaw) {
+		t.Errorf("NativeToolCallsRaw = %q, want valid inline JSON", string(p.NativeToolCallsRaw))
+	}
+	if p.LatencyMS != 1234 {
+		t.Errorf("LatencyMS = %d, want 1234", p.LatencyMS)
+	}
+	if got[0].DurationMS != 1234 {
+		t.Errorf("row DurationMS = %d, want 1234 (row column must mirror payload latency)", got[0].DurationMS)
+	}
+	if p.V != events.LLMResponseVersion {
+		t.Errorf("Header.V = %d, want %d", p.V, events.LLMResponseVersion)
+	}
+}
+
+func TestEmitLLMError_BodyExcerpted(t *testing.T) {
+	sink := &fakeSink{}
+	body := strings.Repeat("E", events.ExcerptCap+16)
+	EmitLLMError(context.Background(), sink, LLMErrorArgs{
+		Phase: "chat", StatusCode: 503, ResponseBodyText: body,
+	})
+	var p events.LLMErrorPayload
+	_ = json.Unmarshal(sink.snapshot()[0].Payload, &p)
+	if !p.ResponseBodyTruncated {
+		t.Error("ResponseBodyTruncated must be set for over-cap body")
+	}
+	if len(p.ResponseBodyExcerpt) != events.ExcerptCap {
+		t.Errorf("excerpt len = %d, want %d", len(p.ResponseBodyExcerpt), events.ExcerptCap)
+	}
+}
+
+func TestEmitLLMRefused_NotExcerptCapped(t *testing.T) {
+	// Refusals are deliberately not excerpt-capped per the payload doc —
+	// they are short by construction and we want the full refusal text
+	// for moderation analysis.
+	sink := &fakeSink{}
+	long := strings.Repeat("R", events.ExcerptCap+16)
+	EmitLLMRefused(context.Background(), sink, LLMRefusedArgs{
+		RefusalText: long, ContentSafetyHit: "hate",
+	})
+	var p events.LLMRefusedPayload
+	_ = json.Unmarshal(sink.snapshot()[0].Payload, &p)
+	if len(p.RefusalText) != events.ExcerptCap+16 {
+		t.Errorf("RefusalText length changed (helper should NOT excerpt refusals): got %d, want %d",
+			len(p.RefusalText), events.ExcerptCap+16)
+	}
+}
+
+// ----- tool cluster (parent linkage) -----
+
+func TestEmitToolCallExtractedThenResult_ParentLinkage(t *testing.T) {
+	sink := &fakeSink{}
+	ctx := actor.WithSessionID(context.Background(), "sess")
+
+	EmitToolCallExtracted(ctx, sink, ToolCallExtractedArgs{
+		CallID: "c1", Plugin: "tickets", Action: "show",
+		Arguments: map[string]string{"id": "42"}, Mode: ToolCallModeNative,
+	})
+
+	// The dispatcher would capture the extracted-event id and stamp it
+	// onto the child span via WithParent. Simulate that linkage.
+	extractedEvtID := "evt-extracted-1"
+	childCtx := WithParent(ctx, extractedEvtID)
+	EmitToolCallResult(childCtx, sink, ToolCallResultArgs{
+		CallID: "c1", Status: "ok", Response: `{"id":42}`, LatencyMS: 12,
+	})
+
+	got := sink.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].ParentID != "" {
+		t.Errorf("extracted ParentID = %q, want empty (root of span)", got[0].ParentID)
+	}
+	if got[1].ParentID != extractedEvtID {
+		t.Errorf("result ParentID = %q, want %q", got[1].ParentID, extractedEvtID)
+	}
+
+	var resPayload events.ToolCallResultPayload
+	_ = json.Unmarshal(got[1].Payload, &resPayload)
+	if resPayload.LatencyMS != 12 || got[1].DurationMS != 12 {
+		t.Errorf("latency/duration mismatch — payload=%d row=%d", resPayload.LatencyMS, got[1].DurationMS)
+	}
+}
+
+func TestEmitToolCallNotFound_Minimal(t *testing.T) {
+	sink := &fakeSink{}
+	EmitToolCallNotFound(context.Background(), sink, "nonexistent.action")
+	var p events.ToolCallNotFoundPayload
+	_ = json.Unmarshal(sink.snapshot()[0].Payload, &p)
+	if p.RequestedName != "nonexistent.action" {
+		t.Errorf("RequestedName = %q", p.RequestedName)
+	}
+}
+
+// ----- header.V coverage for every helper -----
+
+// Asserts the Header.V stamp for every Emit<Type> is the matching
+// <Type>Version constant. Catches a class of bug where a helper is
+// copy-pasted from another event type and the version field silently
+// stays wrong (consumers downstream depend on v to switch decoder).
+func TestAllEmitHelpers_StampMatchingVersion(t *testing.T) {
+	temp := 0.0
+	cases := []struct {
+		name     string
+		emit     func(ctx context.Context, s Sink)
+		wantType string
+		wantVer  int
+	}{
+		{"TurnStart", func(c context.Context, s Sink) { EmitTurnStart(c, s, TurnStartArgs{ModelID: "m", Temperature: &temp}) }, events.TypeTurnStart, events.TurnStartVersion},
+		{"UserMessage", func(c context.Context, s Sink) { EmitUserMessage(c, s, "u") }, events.TypeUserMessage, events.UserMessageVersion},
+		{"LLMRequest", func(c context.Context, s Sink) { EmitLLMRequest(c, s, LLMRequestArgs{ModelID: "m"}) }, events.TypeLLMRequest, events.LLMRequestVersion},
+		{"LLMResponse", func(c context.Context, s Sink) { EmitLLMResponse(c, s, LLMResponseArgs{RawContent: "r"}) }, events.TypeLLMResponse, events.LLMResponseVersion},
+		{"LLMError", func(c context.Context, s Sink) { EmitLLMError(c, s, LLMErrorArgs{Phase: "p"}) }, events.TypeLLMError, events.LLMErrorVersion},
+		{"LLMRefused", func(c context.Context, s Sink) { EmitLLMRefused(c, s, LLMRefusedArgs{RefusalText: "r"}) }, events.TypeLLMRefused, events.LLMRefusedVersion},
+		{"PlannerInvoked", func(c context.Context, s Sink) { EmitPlannerInvoked(c, s, "r") }, events.TypePlannerInvoked, events.PlannerInvokedVersion},
+		{"PlannerRequest", func(c context.Context, s Sink) { EmitPlannerRequest(c, s, PlannerRequestArgs{}) }, events.TypePlannerRequest, events.PlannerRequestVersion},
+		{"PlannerResponse", func(c context.Context, s Sink) { EmitPlannerResponse(c, s, PlannerResponseArgs{}) }, events.TypePlannerResponse, events.PlannerResponseVersion},
+		{"PlannerStep", func(c context.Context, s Sink) { EmitPlannerStep(c, s, PlannerStepArgs{}) }, events.TypePlannerStep, events.PlannerStepVersion},
+		{"ToolRetrieval", func(c context.Context, s Sink) { EmitToolRetrieval(c, s, ToolRetrievalArgs{}) }, events.TypeToolRetrieval, events.ToolRetrievalVersion},
+		{"SummarizationTriggered", func(c context.Context, s Sink) { EmitSummarizationTriggered(c, s, SummarizationTriggeredArgs{}) }, events.TypeSummarizationTriggered, events.SummarizationTriggeredVersion},
+		{"SummarizationCompleted", func(c context.Context, s Sink) { EmitSummarizationCompleted(c, s, SummarizationCompletedArgs{}) }, events.TypeSummarizationCompleted, events.SummarizationCompletedVersion},
+		{"ModelSwitch", func(c context.Context, s Sink) { EmitModelSwitch(c, s, ModelSwitchArgs{}) }, events.TypeModelSwitch, events.ModelSwitchVersion},
+		{"ConfirmationRequested", func(c context.Context, s Sink) { EmitConfirmationRequested(c, s, ConfirmationRequestedArgs{}) }, events.TypeConfirmationRequested, events.ConfirmationRequestedVersion},
+		{"ConfirmationResolved", func(c context.Context, s Sink) { EmitConfirmationResolved(c, s, ConfirmationResolvedArgs{}) }, events.TypeConfirmationResolved, events.ConfirmationResolvedVersion},
+		{"Retry", func(c context.Context, s Sink) { EmitRetry(c, s, RetryArgs{Phase: "p"}) }, events.TypeRetry, events.RetryVersion},
+		{"ToolCallExtracted", func(c context.Context, s Sink) {
+			EmitToolCallExtracted(c, s, ToolCallExtractedArgs{CallID: "c", Mode: ToolCallModeNative})
+		}, events.TypeToolCallExtracted, events.ToolCallExtractedVersion},
+		{"ToolCallResult", func(c context.Context, s Sink) { EmitToolCallResult(c, s, ToolCallResultArgs{CallID: "c"}) }, events.TypeToolCallResult, events.ToolCallResultVersion},
+		{"ToolCallParseFailed", func(c context.Context, s Sink) { EmitToolCallParseFailed(c, s, ToolCallParseFailedArgs{}) }, events.TypeToolCallParseFailed, events.ToolCallParseFailedVersion},
+		{"ToolCallArgsInvalid", func(c context.Context, s Sink) { EmitToolCallArgsInvalid(c, s, ToolCallArgsInvalidArgs{}) }, events.TypeToolCallArgsInvalid, events.ToolCallArgsInvalidVersion},
+		{"ToolCallNotFound", func(c context.Context, s Sink) { EmitToolCallNotFound(c, s, "x") }, events.TypeToolCallNotFound, events.ToolCallNotFoundVersion},
+		{"ScoreComputed", func(c context.Context, s Sink) { EmitScoreComputed(c, s, ScoreComputedArgs{}) }, events.TypeScoreComputed, events.ScoreComputedVersion},
+		{"Error", func(c context.Context, s Sink) { EmitError(c, s, "where", "msg") }, events.TypeError, events.ErrorVersion},
+	}
+
+	// All 24 event types must be exercised — keep this in lockstep with
+	// the constants in event_types.go. If you add a new event type and
+	// this count drops below it, add a row above.
+	const wantCases = 24
+	if len(cases) != wantCases {
+		t.Fatalf("len(cases) = %d, want %d — keep TestAllEmitHelpers in sync with event_types.go", len(cases), wantCases)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			tc.emit(context.Background(), sink)
+			got := sink.snapshot()
+			if len(got) != 1 {
+				t.Fatalf("got %d events, want 1", len(got))
+			}
+			if got[0].EventType != tc.wantType {
+				t.Errorf("EventType = %q, want %q", got[0].EventType, tc.wantType)
+			}
+			// Decode just the Header field to verify the version stamp.
+			var hdr struct {
+				V int `json:"v"`
+			}
+			if err := json.Unmarshal(got[0].Payload, &hdr); err != nil {
+				t.Fatalf("unmarshal header: %v", err)
+			}
+			if hdr.V != tc.wantVer {
+				t.Errorf("payload.v = %d, want %d", hdr.V, tc.wantVer)
+			}
+		})
+	}
+}
+
+// ----- mini-turn integration sequence -----
+
+func TestMiniTurn_EmitsCanonicalSequence(t *testing.T) {
+	// Walks through a representative orchestrator turn and asserts the
+	// event sequence shape that consumers (api-plugin, score worker,
+	// Rails UI) will rely on.
+	sink := &fakeSink{}
+	ctx := actor.WithSessionID(context.Background(), "sess-mini")
+
+	EmitTurnStart(ctx, sink, TurnStartArgs{ModelID: "gpt-x"})
+	EmitUserMessage(ctx, sink, "show me ticket 42")
+	EmitLLMRequest(ctx, sink, LLMRequestArgs{ModelID: "gpt-x", MessageCount: 2, HasTools: true})
+	EmitLLMResponse(ctx, sink, LLMResponseArgs{
+		RawContent: "calling tickets.show",
+		NativeToolCallsRaw: json.RawMessage(
+			`[{"id":"c1","name":"tickets.show","arguments":{"id":"42"}}]`),
+		FinishReason: "tool_calls", LatencyMS: 850,
+	})
+	EmitToolCallExtracted(ctx, sink, ToolCallExtractedArgs{
+		CallID: "c1", Plugin: "tickets", Action: "show",
+		Arguments: map[string]string{"id": "42"}, Mode: ToolCallModeNative,
+	})
+	dispatchCtx := WithParent(ctx, "evt-tool-extracted")
+	EmitToolCallResult(dispatchCtx, sink, ToolCallResultArgs{
+		CallID: "c1", Status: "ok", Response: `{"id":42,"status":"open"}`, LatencyMS: 67,
+	})
+
+	got := sink.snapshot()
+	wantTypes := []string{
+		events.TypeTurnStart,
+		events.TypeUserMessage,
+		events.TypeLLMRequest,
+		events.TypeLLMResponse,
+		events.TypeToolCallExtracted,
+		events.TypeToolCallResult,
+	}
+	if len(got) != len(wantTypes) {
+		t.Fatalf("got %d events, want %d", len(got), len(wantTypes))
+	}
+	for i, want := range wantTypes {
+		if got[i].EventType != want {
+			t.Errorf("event[%d].Type = %q, want %q", i, got[i].EventType, want)
+		}
+		if got[i].SessionID != "sess-mini" {
+			t.Errorf("event[%d].SessionID = %q, want %q", i, got[i].SessionID, "sess-mini")
+		}
+	}
+	// Last event is the tool result — must carry the parent linkage we
+	// stamped above. Everything else is root.
+	for i := 0; i < len(got)-1; i++ {
+		if got[i].ParentID != "" {
+			t.Errorf("event[%d] (%s) ParentID = %q, want empty", i, got[i].EventType, got[i].ParentID)
+		}
+	}
+	if got[len(got)-1].ParentID != "evt-tool-extracted" {
+		t.Errorf("tool_call_result ParentID = %q, want %q", got[len(got)-1].ParentID, "evt-tool-extracted")
+	}
+}
+
+// ----- raw-capture invariants (invalid-UTF-8 input) -----
+
+// invalidUTF8 carries two raw bytes (0xff, 0xfe) that are not valid
+// UTF-8 lead bytes. Postgres' UTF-8 column refuses these bytes verbatim,
+// so the helper must sanitize them to U+FFFD (UTF-8: 0xEF 0xBF 0xBD)
+// before the payload reaches the writer. Producers in the wild ARE the
+// realistic source (LLM streaming chunks truncated mid-multibyte, tool
+// outputs from non-UTF-8 sources) so this isn't a theoretical concern.
+const invalidUTF8Raw = "ok\xff\xfetail"
+const invalidUTF8Sanitized = "ok��tail"
+
+// captures the free-text field that each sanitization-bearing helper
+// commits to scrubbing. If a future change skips SanitizeUTF8 for any
+// of these, the test fails with a clear pointer to which helper drifted.
+func TestEmit_SanitizesAllFreeTextFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		emit    func(ctx context.Context, s Sink)
+		extract func(t *testing.T, payload []byte) string
+	}{
+		{
+			"UserMessage.Content",
+			func(c context.Context, s Sink) { EmitUserMessage(c, s, invalidUTF8Raw) },
+			func(t *testing.T, p []byte) string {
+				var v events.UserMessagePayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Content
+			},
+		},
+		{
+			"LLMResponse.RawContentExcerpt",
+			func(c context.Context, s Sink) {
+				EmitLLMResponse(c, s, LLMResponseArgs{RawContent: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.LLMResponsePayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.RawContentExcerpt
+			},
+		},
+		{
+			"LLMError.ResponseBodyExcerpt",
+			func(c context.Context, s Sink) {
+				EmitLLMError(c, s, LLMErrorArgs{Phase: "p", ResponseBodyText: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.LLMErrorPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.ResponseBodyExcerpt
+			},
+		},
+		{
+			"LLMRefused.RefusalText",
+			func(c context.Context, s Sink) {
+				EmitLLMRefused(c, s, LLMRefusedArgs{RefusalText: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.LLMRefusedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.RefusalText
+			},
+		},
+		{
+			"ToolCallResult.ResponseExcerpt",
+			func(c context.Context, s Sink) {
+				EmitToolCallResult(c, s, ToolCallResultArgs{CallID: "c", Response: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ToolCallResultPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.ResponseExcerpt
+			},
+		},
+		{
+			"ToolCallParseFailed.RawSnippet",
+			func(c context.Context, s Sink) {
+				EmitToolCallParseFailed(c, s, ToolCallParseFailedArgs{RawSnippet: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ToolCallParseFailedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.RawSnippet
+			},
+		},
+		{
+			"PlannerResponse.RawContentExcerpt",
+			func(c context.Context, s Sink) {
+				EmitPlannerResponse(c, s, PlannerResponseArgs{RawContent: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.PlannerResponsePayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.RawContentExcerpt
+			},
+		},
+		{
+			"ToolRetrieval.Query",
+			func(c context.Context, s Sink) {
+				EmitToolRetrieval(c, s, ToolRetrievalArgs{Query: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ToolRetrievalPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Query
+			},
+		},
+		{
+			"SummarizationCompleted.SummaryExcerpt",
+			func(c context.Context, s Sink) {
+				EmitSummarizationCompleted(c, s, SummarizationCompletedArgs{Summary: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.SummarizationCompletedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.SummaryExcerpt
+			},
+		},
+		{
+			"ConfirmationRequested.Prompt",
+			func(c context.Context, s Sink) {
+				EmitConfirmationRequested(c, s, ConfirmationRequestedArgs{Prompt: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ConfirmationRequestedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Prompt
+			},
+		},
+		{
+			"Retry.LastError",
+			func(c context.Context, s Sink) {
+				EmitRetry(c, s, RetryArgs{Phase: "p", LastError: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.RetryPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.LastError
+			},
+		},
+		{
+			"ScoreComputed.Reasoning",
+			func(c context.Context, s Sink) {
+				EmitScoreComputed(c, s, ScoreComputedArgs{Reasoning: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ScoreComputedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Reasoning
+			},
+		},
+		{
+			"Error.Message",
+			func(c context.Context, s Sink) { EmitError(c, s, "where", invalidUTF8Raw) },
+			func(t *testing.T, p []byte) string {
+				var v events.ErrorPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Message
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			tc.emit(context.Background(), sink)
+			got := tc.extract(t, sink.snapshot()[0].Payload)
+			if got != invalidUTF8Sanitized {
+				t.Errorf("field = %q, want %q (raw bytes 0xff/0xfe must become U+FFFD via SanitizeUTF8 before storage)",
+					got, invalidUTF8Sanitized)
+			}
+		})
+	}
+}
+
+// ----- excerpt + truncated flag parity -----
+
+// Helpers that excerpt MUST set the truncated flag on overflow. Symmetric
+// to TestEmitLLMResponse_ExcerptAndSHA256 / TestEmitLLMError_BodyExcerpted
+// but covering every helper that takes a sanitized + excerpted free-text
+// field — drift on any one would mean a forensic field silently loses its
+// "this was truncated" signal.
+func TestEmit_ExcerptAndTruncatedFlag_AllHelpers(t *testing.T) {
+	long := strings.Repeat("X", events.ExcerptCap+128)
+
+	cases := []struct {
+		name           string
+		emit           func(ctx context.Context, s Sink)
+		excerpt        func(payload []byte) (string, bool)
+		expectTruncate bool
+	}{
+		{
+			"ToolCallResult.Response",
+			func(c context.Context, s Sink) {
+				EmitToolCallResult(c, s, ToolCallResultArgs{CallID: "c", Response: long})
+			},
+			func(p []byte) (string, bool) {
+				var v events.ToolCallResultPayload
+				_ = json.Unmarshal(p, &v)
+				return v.ResponseExcerpt, v.ResponseTruncated
+			},
+			true,
+		},
+		{
+			"PlannerResponse.RawContent",
+			func(c context.Context, s Sink) {
+				EmitPlannerResponse(c, s, PlannerResponseArgs{RawContent: long})
+			},
+			func(p []byte) (string, bool) {
+				var v events.PlannerResponsePayload
+				_ = json.Unmarshal(p, &v)
+				return v.RawContentExcerpt, v.RawContentTruncated
+			},
+			true,
+		},
+		{
+			"SummarizationCompleted.Summary",
+			func(c context.Context, s Sink) {
+				EmitSummarizationCompleted(c, s, SummarizationCompletedArgs{Summary: long})
+			},
+			func(p []byte) (string, bool) {
+				var v events.SummarizationCompletedPayload
+				_ = json.Unmarshal(p, &v)
+				return v.SummaryExcerpt, v.SummaryTruncated
+			},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			tc.emit(context.Background(), sink)
+			excerpt, truncated := tc.excerpt(sink.snapshot()[0].Payload)
+			if len(excerpt) != events.ExcerptCap {
+				t.Errorf("excerpt len = %d, want %d", len(excerpt), events.ExcerptCap)
+			}
+			if truncated != tc.expectTruncate {
+				t.Errorf("truncated = %v, want %v", truncated, tc.expectTruncate)
+			}
+		})
+	}
+
+	// ToolCallParseFailed is special-cased — the helper discards the
+	// truncated flag because parse failures are short by construction.
+	// We still verify the excerpt is capped so an outlier giant snippet
+	// can't blow up the row size.
+	t.Run("ToolCallParseFailed.RawSnippet_capped_no_truncate_flag", func(t *testing.T) {
+		sink := &fakeSink{}
+		EmitToolCallParseFailed(context.Background(), sink, ToolCallParseFailedArgs{RawSnippet: long})
+		var p events.ToolCallParseFailedPayload
+		_ = json.Unmarshal(sink.snapshot()[0].Payload, &p)
+		if len(p.RawSnippet) != events.ExcerptCap {
+			t.Errorf("RawSnippet len = %d, want %d (cap must still apply even though the truncated flag is dropped)",
+				len(p.RawSnippet), events.ExcerptCap)
+		}
+	})
+}
+
+// ----- SHA256 invariant: digest over SANITIZED full content -----
+
+// The contract: RawContentSHA256 = sha256(SanitizeUTF8(RawContent)).
+// Not over the raw input (Postgres can't store invalid UTF-8), and not
+// over the excerpt (truncation would make the digest forensically
+// useless). The mid-tier test below pins this contract so a future
+// "simplification" that switches to one of the other two inputs fails
+// the build.
+func TestEmitLLMResponse_SHA256_OverSanitizedFullContent(t *testing.T) {
+	sink := &fakeSink{}
+	EmitLLMResponse(context.Background(), sink, LLMResponseArgs{RawContent: invalidUTF8Raw})
+
+	var p events.LLMResponsePayload
+	if err := json.Unmarshal(sink.snapshot()[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	wantSum := sha256.Sum256([]byte(invalidUTF8Sanitized))
+	wantHex := hex.EncodeToString(wantSum[:])
+	if p.RawContentSHA256 != wantHex {
+		t.Errorf("RawContentSHA256 = %q, want %q (digest must be over sanitized full content, not raw input nor excerpt)",
+			p.RawContentSHA256, wantHex)
+	}
+}
+
+// ----- DurationMS row-vs-payload mirroring (remaining latency helpers) -----
+
+// Symmetric to the LLMResponse / ToolCallResult mirror checks already in
+// place. If a future change forgets to pass args.LatencyMS as the
+// durationMS arg to send(), row-level analytics on these event types
+// silently lose the duration column.
+func TestEmit_RowDurationMirrorsPayloadLatency(t *testing.T) {
+	cases := []struct {
+		name    string
+		emit    func(ctx context.Context, s Sink)
+		latency int64
+		extract func(payload []byte) int64
+	}{
+		{
+			"PlannerResponse",
+			func(c context.Context, s Sink) {
+				EmitPlannerResponse(c, s, PlannerResponseArgs{RawContent: "r", LatencyMS: 432})
+			},
+			432,
+			func(p []byte) int64 {
+				var v events.PlannerResponsePayload
+				_ = json.Unmarshal(p, &v)
+				return v.LatencyMS
+			},
+		},
+		{
+			"SummarizationCompleted",
+			func(c context.Context, s Sink) {
+				EmitSummarizationCompleted(c, s, SummarizationCompletedArgs{Summary: "s", LatencyMS: 789})
+			},
+			789,
+			func(p []byte) int64 {
+				var v events.SummarizationCompletedPayload
+				_ = json.Unmarshal(p, &v)
+				return v.LatencyMS
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			tc.emit(context.Background(), sink)
+			got := sink.snapshot()[0]
+			if got.DurationMS != tc.latency {
+				t.Errorf("row DurationMS = %d, want %d", got.DurationMS, tc.latency)
+			}
+			if pl := tc.extract(got.Payload); pl != tc.latency {
+				t.Errorf("payload LatencyMS = %d, want %d", pl, tc.latency)
+			}
+		})
+	}
+}
+
+// ----- distinctive-field check (helper-body cross-contamination) -----
+
+// TestAllEmitHelpers_StampMatchingVersion catches the case where a
+// helper's Header.V drifts to a wrong constant — but it would NOT catch
+// the case where a helper's body got swapped wholesale with another's
+// (different event_type stamp, same V constant by coincidence) IF only
+// the Header.V invariant is asserted. This test asserts at least one
+// distinctive payload field per helper, so cross-contamination shows up
+// as an unmarshalled field that doesn't equal the value we just sent in.
+func TestAllEmitHelpers_PopulateDistinctiveField(t *testing.T) {
+	cases := []struct {
+		name   string
+		emit   func(ctx context.Context, s Sink)
+		assert func(t *testing.T, payload []byte)
+	}{
+		{
+			"TurnStart.ModelID",
+			func(c context.Context, s Sink) { EmitTurnStart(c, s, TurnStartArgs{ModelID: "distinctive-model"}) },
+			func(t *testing.T, p []byte) {
+				var v events.TurnStartPayload
+				_ = json.Unmarshal(p, &v)
+				if v.ModelID != "distinctive-model" {
+					t.Errorf("ModelID = %q", v.ModelID)
+				}
+			},
+		},
+		{
+			"LLMRequest.MessageCount",
+			func(c context.Context, s Sink) { EmitLLMRequest(c, s, LLMRequestArgs{MessageCount: 17}) },
+			func(t *testing.T, p []byte) {
+				var v events.LLMRequestPayload
+				_ = json.Unmarshal(p, &v)
+				if v.MessageCount != 17 {
+					t.Errorf("MessageCount = %d", v.MessageCount)
+				}
+			},
+		},
+		{
+			"LLMError.StatusCode",
+			func(c context.Context, s Sink) { EmitLLMError(c, s, LLMErrorArgs{Phase: "chat", StatusCode: 418}) },
+			func(t *testing.T, p []byte) {
+				var v events.LLMErrorPayload
+				_ = json.Unmarshal(p, &v)
+				if v.StatusCode != 418 {
+					t.Errorf("StatusCode = %d", v.StatusCode)
+				}
+			},
+		},
+		{
+			"LLMRefused.ContentSafetyHit",
+			func(c context.Context, s Sink) {
+				EmitLLMRefused(c, s, LLMRefusedArgs{RefusalText: "r", ContentSafetyHit: "self_harm"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.LLMRefusedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.ContentSafetyHit != "self_harm" {
+					t.Errorf("ContentSafetyHit = %q", v.ContentSafetyHit)
+				}
+			},
+		},
+		{
+			"PlannerInvoked.Reason",
+			func(c context.Context, s Sink) { EmitPlannerInvoked(c, s, "user_request") },
+			func(t *testing.T, p []byte) {
+				var v events.PlannerInvokedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Reason != "user_request" {
+					t.Errorf("Reason = %q", v.Reason)
+				}
+			},
+		},
+		{
+			"PlannerStep.StepKind",
+			func(c context.Context, s Sink) {
+				EmitPlannerStep(c, s, PlannerStepArgs{StepIndex: 3, StepKind: "decide_tool"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.PlannerStepPayload
+				_ = json.Unmarshal(p, &v)
+				if v.StepIndex != 3 || v.StepKind != "decide_tool" {
+					t.Errorf("StepIndex/Kind = %d/%q", v.StepIndex, v.StepKind)
+				}
+			},
+		},
+		{
+			"ToolRetrieval.TopK",
+			func(c context.Context, s Sink) { EmitToolRetrieval(c, s, ToolRetrievalArgs{Query: "q", TopK: 9}) },
+			func(t *testing.T, p []byte) {
+				var v events.ToolRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				if v.TopK != 9 {
+					t.Errorf("TopK = %d", v.TopK)
+				}
+			},
+		},
+		{
+			"SummarizationTriggered.MessageCount",
+			func(c context.Context, s Sink) {
+				EmitSummarizationTriggered(c, s, SummarizationTriggeredArgs{MessageCount: 42, Reason: "ctx_pressure"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.SummarizationTriggeredPayload
+				_ = json.Unmarshal(p, &v)
+				if v.MessageCount != 42 {
+					t.Errorf("MessageCount = %d", v.MessageCount)
+				}
+			},
+		},
+		{
+			"ModelSwitch.From_To",
+			func(c context.Context, s Sink) { EmitModelSwitch(c, s, ModelSwitchArgs{From: "a", To: "b"}) },
+			func(t *testing.T, p []byte) {
+				var v events.ModelSwitchPayload
+				_ = json.Unmarshal(p, &v)
+				if v.From != "a" || v.To != "b" {
+					t.Errorf("From/To = %q/%q", v.From, v.To)
+				}
+			},
+		},
+		{
+			"ConfirmationResolved.Choice",
+			func(c context.Context, s Sink) {
+				EmitConfirmationResolved(c, s, ConfirmationResolvedArgs{Choice: "approve", ToolCallID: "c1"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.ConfirmationResolvedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Choice != "approve" || v.ToolCallID != "c1" {
+					t.Errorf("Choice/ToolCallID = %q/%q", v.Choice, v.ToolCallID)
+				}
+			},
+		},
+		{
+			"Retry.Attempt",
+			func(c context.Context, s Sink) { EmitRetry(c, s, RetryArgs{Phase: "llm", Attempt: 5}) },
+			func(t *testing.T, p []byte) {
+				var v events.RetryPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Attempt != 5 || v.Phase != "llm" {
+					t.Errorf("Attempt/Phase = %d/%q", v.Attempt, v.Phase)
+				}
+			},
+		},
+		{
+			"ToolCallArgsInvalid.ValidationError",
+			func(c context.Context, s Sink) {
+				EmitToolCallArgsInvalid(c, s, ToolCallArgsInvalidArgs{
+					CallID: "c", Plugin: "p", Action: "a", ValidationError: "missing id",
+				})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.ToolCallArgsInvalidPayload
+				_ = json.Unmarshal(p, &v)
+				if v.ValidationError != "missing id" {
+					t.Errorf("ValidationError = %q", v.ValidationError)
+				}
+			},
+		},
+		{
+			"ScoreComputed.Score",
+			func(c context.Context, s Sink) {
+				EmitScoreComputed(c, s, ScoreComputedArgs{Score: 0.85, RubricVersion: "v3"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.ScoreComputedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Score != 0.85 || v.RubricVersion != "v3" {
+					t.Errorf("Score/Rubric = %v/%q", v.Score, v.RubricVersion)
+				}
+			},
+		},
+		{
+			"Error.Where",
+			func(c context.Context, s Sink) { EmitError(c, s, "orchestrator.turn", "msg") },
+			func(t *testing.T, p []byte) {
+				var v events.ErrorPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Where != "orchestrator.turn" {
+					t.Errorf("Where = %q", v.Where)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &fakeSink{}
+			tc.emit(context.Background(), sink)
+			tc.assert(t, sink.snapshot()[0].Payload)
+		})
+	}
+}

--- a/internal/state/store/events/emit/error.go
+++ b/internal/state/store/events/emit/error.go
@@ -1,0 +1,23 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// EmitError writes one generic error event. Prefer a typed variant
+// (EmitLLMError, EmitToolCallArgsInvalid, …) when one exists for the
+// failure mode in question; reach for EmitError only when no typed
+// variant fits.
+//
+// where is a short, stable, grep-friendly location tag
+// ("orchestrator.turn", "planner.dispatch", …); message is the
+// sanitized error text.
+func EmitError(ctx context.Context, sink Sink, where, message string) {
+	send(ctx, sink, events.TypeError, events.ErrorPayload{
+		Header:  events.Header{V: events.ErrorVersion},
+		Where:   where,
+		Message: events.SanitizeUTF8(message),
+	}, 0)
+}

--- a/internal/state/store/events/emit/error.go
+++ b/internal/state/store/events/emit/error.go
@@ -14,8 +14,8 @@ import (
 // where is a short, stable, grep-friendly location tag
 // ("orchestrator.turn", "planner.dispatch", …); message is the
 // sanitized error text.
-func EmitError(ctx context.Context, sink Sink, where, message string) {
-	send(ctx, sink, events.TypeError, events.ErrorPayload{
+func EmitError(ctx context.Context, sink Sink, where, message string) string {
+	return send(ctx, sink, events.TypeError, events.ErrorPayload{
 		Header:  events.Header{V: events.ErrorVersion},
 		Where:   where,
 		Message: events.SanitizeUTF8(message),

--- a/internal/state/store/events/emit/lifecycle.go
+++ b/internal/state/store/events/emit/lifecycle.go
@@ -15,8 +15,8 @@ type SummarizationTriggeredArgs struct {
 }
 
 // EmitSummarizationTriggered writes one summarization_triggered event.
-func EmitSummarizationTriggered(ctx context.Context, sink Sink, args SummarizationTriggeredArgs) {
-	send(ctx, sink, events.TypeSummarizationTriggered, events.SummarizationTriggeredPayload{
+func EmitSummarizationTriggered(ctx context.Context, sink Sink, args SummarizationTriggeredArgs) string {
+	return send(ctx, sink, events.TypeSummarizationTriggered, events.SummarizationTriggeredPayload{
 		Header:       events.Header{V: events.SummarizationTriggeredVersion},
 		MessageCount: args.MessageCount,
 		Reason:       args.Reason,
@@ -33,10 +33,10 @@ type SummarizationCompletedArgs struct {
 }
 
 // EmitSummarizationCompleted writes one summarization_completed event.
-func EmitSummarizationCompleted(ctx context.Context, sink Sink, args SummarizationCompletedArgs) {
+func EmitSummarizationCompleted(ctx context.Context, sink Sink, args SummarizationCompletedArgs) string {
 	sanitized := events.SanitizeUTF8(args.Summary)
 	excerpt, truncated := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypeSummarizationCompleted, events.SummarizationCompletedPayload{
+	return send(ctx, sink, events.TypeSummarizationCompleted, events.SummarizationCompletedPayload{
 		Header:           events.Header{V: events.SummarizationCompletedVersion},
 		SummaryExcerpt:   excerpt,
 		SummaryTruncated: truncated,
@@ -54,8 +54,8 @@ type ModelSwitchArgs struct {
 }
 
 // EmitModelSwitch writes one model_switch event.
-func EmitModelSwitch(ctx context.Context, sink Sink, args ModelSwitchArgs) {
-	send(ctx, sink, events.TypeModelSwitch, events.ModelSwitchPayload{
+func EmitModelSwitch(ctx context.Context, sink Sink, args ModelSwitchArgs) string {
+	return send(ctx, sink, events.TypeModelSwitch, events.ModelSwitchPayload{
 		Header: events.Header{V: events.ModelSwitchVersion},
 		From:   args.From,
 		To:     args.To,
@@ -73,8 +73,11 @@ type ConfirmationRequestedArgs struct {
 }
 
 // EmitConfirmationRequested writes one confirmation_requested event.
-func EmitConfirmationRequested(ctx context.Context, sink Sink, args ConfirmationRequestedArgs) {
-	send(ctx, sink, events.TypeConfirmationRequested, events.ConfirmationRequestedPayload{
+// Returns the event id so the caller can persist it alongside the
+// pending state and use it as parent_id on the matching resolved event
+// once the user replies in a later turn.
+func EmitConfirmationRequested(ctx context.Context, sink Sink, args ConfirmationRequestedArgs) string {
+	return send(ctx, sink, events.TypeConfirmationRequested, events.ConfirmationRequestedPayload{
 		Header:     events.Header{V: events.ConfirmationRequestedVersion},
 		Prompt:     events.SanitizeUTF8(args.Prompt),
 		Choices:    args.Choices,
@@ -89,8 +92,8 @@ type ConfirmationResolvedArgs struct {
 }
 
 // EmitConfirmationResolved writes one confirmation_resolved event.
-func EmitConfirmationResolved(ctx context.Context, sink Sink, args ConfirmationResolvedArgs) {
-	send(ctx, sink, events.TypeConfirmationResolved, events.ConfirmationResolvedPayload{
+func EmitConfirmationResolved(ctx context.Context, sink Sink, args ConfirmationResolvedArgs) string {
+	return send(ctx, sink, events.TypeConfirmationResolved, events.ConfirmationResolvedPayload{
 		Header:     events.Header{V: events.ConfirmationResolvedVersion},
 		Choice:     args.Choice,
 		ToolCallID: args.ToolCallID,
@@ -106,8 +109,8 @@ type RetryArgs struct {
 }
 
 // EmitRetry writes one retry event.
-func EmitRetry(ctx context.Context, sink Sink, args RetryArgs) {
-	send(ctx, sink, events.TypeRetry, events.RetryPayload{
+func EmitRetry(ctx context.Context, sink Sink, args RetryArgs) string {
+	return send(ctx, sink, events.TypeRetry, events.RetryPayload{
 		Header:    events.Header{V: events.RetryVersion},
 		Phase:     args.Phase,
 		Attempt:   args.Attempt,

--- a/internal/state/store/events/emit/lifecycle.go
+++ b/internal/state/store/events/emit/lifecycle.go
@@ -1,0 +1,116 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// SummarizationTriggeredArgs records why a summarization was kicked off
+// (context-window pressure, explicit user "clear", …) plus the message
+// count at trigger time.
+type SummarizationTriggeredArgs struct {
+	MessageCount int
+	Reason       string
+}
+
+// EmitSummarizationTriggered writes one summarization_triggered event.
+func EmitSummarizationTriggered(ctx context.Context, sink Sink, args SummarizationTriggeredArgs) {
+	send(ctx, sink, events.TypeSummarizationTriggered, events.SummarizationTriggeredPayload{
+		Header:       events.Header{V: events.SummarizationTriggeredVersion},
+		MessageCount: args.MessageCount,
+		Reason:       args.Reason,
+	}, 0)
+}
+
+// SummarizationCompletedArgs is the post-summarization snapshot. Summary
+// is sanitized + excerpted; KeptMessages is the count of original
+// messages that survived past the summary boundary.
+type SummarizationCompletedArgs struct {
+	Summary      string
+	KeptMessages int
+	LatencyMS    int64
+}
+
+// EmitSummarizationCompleted writes one summarization_completed event.
+func EmitSummarizationCompleted(ctx context.Context, sink Sink, args SummarizationCompletedArgs) {
+	sanitized := events.SanitizeUTF8(args.Summary)
+	excerpt, truncated := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypeSummarizationCompleted, events.SummarizationCompletedPayload{
+		Header:           events.Header{V: events.SummarizationCompletedVersion},
+		SummaryExcerpt:   excerpt,
+		SummaryTruncated: truncated,
+		KeptMessages:     args.KeptMessages,
+		LatencyMS:        args.LatencyMS,
+	}, args.LatencyMS)
+}
+
+// ModelSwitchArgs captures a runtime model swap inside a turn (e.g.
+// fallback after refusal, escalation for hard requests).
+type ModelSwitchArgs struct {
+	From   string
+	To     string
+	Reason string
+}
+
+// EmitModelSwitch writes one model_switch event.
+func EmitModelSwitch(ctx context.Context, sink Sink, args ModelSwitchArgs) {
+	send(ctx, sink, events.TypeModelSwitch, events.ModelSwitchPayload{
+		Header: events.Header{V: events.ModelSwitchVersion},
+		From:   args.From,
+		To:     args.To,
+		Reason: args.Reason,
+	}, 0)
+}
+
+// ConfirmationRequestedArgs records that the orchestrator is asking the
+// frontend / user for an explicit yes-or-no on a privileged action.
+// ToolCallID links to the proposed tool_call_extracted event.
+type ConfirmationRequestedArgs struct {
+	Prompt     string
+	Choices    []string
+	ToolCallID string
+}
+
+// EmitConfirmationRequested writes one confirmation_requested event.
+func EmitConfirmationRequested(ctx context.Context, sink Sink, args ConfirmationRequestedArgs) {
+	send(ctx, sink, events.TypeConfirmationRequested, events.ConfirmationRequestedPayload{
+		Header:     events.Header{V: events.ConfirmationRequestedVersion},
+		Prompt:     events.SanitizeUTF8(args.Prompt),
+		Choices:    args.Choices,
+		ToolCallID: args.ToolCallID,
+	}, 0)
+}
+
+// ConfirmationResolvedArgs records the user/frontend response.
+type ConfirmationResolvedArgs struct {
+	Choice     string
+	ToolCallID string
+}
+
+// EmitConfirmationResolved writes one confirmation_resolved event.
+func EmitConfirmationResolved(ctx context.Context, sink Sink, args ConfirmationResolvedArgs) {
+	send(ctx, sink, events.TypeConfirmationResolved, events.ConfirmationResolvedPayload{
+		Header:     events.Header{V: events.ConfirmationResolvedVersion},
+		Choice:     args.Choice,
+		ToolCallID: args.ToolCallID,
+	}, 0)
+}
+
+// RetryArgs describes one retry attempt inside a phase (LLM call,
+// planner call, tool dispatch, …). LastError is sanitized free text.
+type RetryArgs struct {
+	Phase     string
+	Attempt   int
+	LastError string
+}
+
+// EmitRetry writes one retry event.
+func EmitRetry(ctx context.Context, sink Sink, args RetryArgs) {
+	send(ctx, sink, events.TypeRetry, events.RetryPayload{
+		Header:    events.Header{V: events.RetryVersion},
+		Phase:     args.Phase,
+		Attempt:   args.Attempt,
+		LastError: events.SanitizeUTF8(args.LastError),
+	}, 0)
+}

--- a/internal/state/store/events/emit/llm.go
+++ b/internal/state/store/events/emit/llm.go
@@ -18,8 +18,8 @@ type LLMRequestArgs struct {
 
 // EmitLLMRequest writes one llm_request event. Emit immediately before
 // the provider HTTP call so the row predates llm_response chronologically.
-func EmitLLMRequest(ctx context.Context, sink Sink, args LLMRequestArgs) {
-	send(ctx, sink, events.TypeLLMRequest, events.LLMRequestPayload{
+func EmitLLMRequest(ctx context.Context, sink Sink, args LLMRequestArgs) string {
+	return send(ctx, sink, events.TypeLLMRequest, events.LLMRequestPayload{
 		Header:       events.Header{V: events.LLMRequestVersion},
 		ModelID:      args.ModelID,
 		MessageCount: args.MessageCount,
@@ -49,10 +49,12 @@ type LLMResponseArgs struct {
 // EmitLLMResponse writes one llm_response event. The helper computes
 // raw_content_sha256 over the SANITIZED full content (not the excerpt)
 // so the digest matches what a re-played raw HTTP body would hash to.
-func EmitLLMResponse(ctx context.Context, sink Sink, args LLMResponseArgs) {
+// Returns the event id so the provider can surface it on CompletionResponse,
+// letting the orchestrator parent subsequent tool_call_extracted events.
+func EmitLLMResponse(ctx context.Context, sink Sink, args LLMResponseArgs) string {
 	sanitized := events.SanitizeUTF8(args.RawContent)
 	excerpt, truncated := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypeLLMResponse, events.LLMResponsePayload{
+	return send(ctx, sink, events.TypeLLMResponse, events.LLMResponsePayload{
 		Header:              events.Header{V: events.LLMResponseVersion},
 		RawContentExcerpt:   excerpt,
 		RawContentTruncated: truncated,
@@ -77,10 +79,10 @@ type LLMErrorArgs struct {
 
 // EmitLLMError writes one llm_error event with an excerpted, UTF-8-clean
 // response body.
-func EmitLLMError(ctx context.Context, sink Sink, args LLMErrorArgs) {
+func EmitLLMError(ctx context.Context, sink Sink, args LLMErrorArgs) string {
 	sanitized := events.SanitizeUTF8(args.ResponseBodyText)
 	excerpt, truncated := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypeLLMError, events.LLMErrorPayload{
+	return send(ctx, sink, events.TypeLLMError, events.LLMErrorPayload{
 		Header:                events.Header{V: events.LLMErrorVersion},
 		Phase:                 args.Phase,
 		StatusCode:            args.StatusCode,
@@ -98,8 +100,8 @@ type LLMRefusedArgs struct {
 }
 
 // EmitLLMRefused writes one llm_refused event.
-func EmitLLMRefused(ctx context.Context, sink Sink, args LLMRefusedArgs) {
-	send(ctx, sink, events.TypeLLMRefused, events.LLMRefusedPayload{
+func EmitLLMRefused(ctx context.Context, sink Sink, args LLMRefusedArgs) string {
+	return send(ctx, sink, events.TypeLLMRefused, events.LLMRefusedPayload{
 		Header:           events.Header{V: events.LLMRefusedVersion},
 		RefusalText:      events.SanitizeUTF8(args.RefusalText),
 		ContentSafetyHit: args.ContentSafetyHit,

--- a/internal/state/store/events/emit/llm.go
+++ b/internal/state/store/events/emit/llm.go
@@ -1,0 +1,107 @@
+package emit
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// LLMRequestArgs is metadata about an outbound LLM call — never the full
+// body. The body, when /debug is active, lives in ai_debug_events.
+type LLMRequestArgs struct {
+	ModelID      string
+	MessageCount int
+	HasTools     bool
+	MaxTokens    int
+}
+
+// EmitLLMRequest writes one llm_request event. Emit immediately before
+// the provider HTTP call so the row predates llm_response chronologically.
+func EmitLLMRequest(ctx context.Context, sink Sink, args LLMRequestArgs) {
+	send(ctx, sink, events.TypeLLMRequest, events.LLMRequestPayload{
+		Header:       events.Header{V: events.LLMRequestVersion},
+		ModelID:      args.ModelID,
+		MessageCount: args.MessageCount,
+		HasTools:     args.HasTools,
+		MaxTokens:    args.MaxTokens,
+	}, 0)
+}
+
+// LLMResponseArgs captures everything observable at the provider edge
+// BEFORE the orchestrator parses native tool calls or text-based tool
+// syntax.
+//
+// RawContent is the exact provider-emitted body; the helper sanitizes
+// UTF-8, computes the full-content SHA256, and stores the 4 KB excerpt
+// with a truncated flag. NativeToolCallsRaw is the provider's ToolCalls
+// JSON inlined as-is so consumers don't double-unmarshal.
+type LLMResponseArgs struct {
+	RawContent         string
+	NativeToolCallsRaw json.RawMessage
+	FinishReason       string
+	TokensIn           int
+	TokensOut          int
+	LatencyMS          int64
+	ProviderResponseID string
+}
+
+// EmitLLMResponse writes one llm_response event. The helper computes
+// raw_content_sha256 over the SANITIZED full content (not the excerpt)
+// so the digest matches what a re-played raw HTTP body would hash to.
+func EmitLLMResponse(ctx context.Context, sink Sink, args LLMResponseArgs) {
+	sanitized := events.SanitizeUTF8(args.RawContent)
+	excerpt, truncated := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypeLLMResponse, events.LLMResponsePayload{
+		Header:              events.Header{V: events.LLMResponseVersion},
+		RawContentExcerpt:   excerpt,
+		RawContentTruncated: truncated,
+		RawContentSHA256:    sha256Hex(sanitized),
+		NativeToolCallsRaw:  args.NativeToolCallsRaw,
+		FinishReason:        args.FinishReason,
+		TokensIn:            args.TokensIn,
+		TokensOut:           args.TokensOut,
+		LatencyMS:           args.LatencyMS,
+		ProviderResponseID:  args.ProviderResponseID,
+	}, args.LatencyMS)
+}
+
+// LLMErrorArgs describes a provider-side failure (4xx/5xx, transport
+// error, malformed response). Phase identifies where it happened
+// ("chat", "embeddings", "moderation", …).
+type LLMErrorArgs struct {
+	Phase            string
+	StatusCode       int
+	ResponseBodyText string
+}
+
+// EmitLLMError writes one llm_error event with an excerpted, UTF-8-clean
+// response body.
+func EmitLLMError(ctx context.Context, sink Sink, args LLMErrorArgs) {
+	sanitized := events.SanitizeUTF8(args.ResponseBodyText)
+	excerpt, truncated := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypeLLMError, events.LLMErrorPayload{
+		Header:                events.Header{V: events.LLMErrorVersion},
+		Phase:                 args.Phase,
+		StatusCode:            args.StatusCode,
+		ResponseBodyExcerpt:   excerpt,
+		ResponseBodyTruncated: truncated,
+	}, 0)
+}
+
+// LLMRefusedArgs carries the refusal text plus, optionally, the content
+// safety category the provider returned. RefusalText is not excerpt-
+// capped — refusals are short by construction.
+type LLMRefusedArgs struct {
+	RefusalText      string
+	ContentSafetyHit string
+}
+
+// EmitLLMRefused writes one llm_refused event.
+func EmitLLMRefused(ctx context.Context, sink Sink, args LLMRefusedArgs) {
+	send(ctx, sink, events.TypeLLMRefused, events.LLMRefusedPayload{
+		Header:           events.Header{V: events.LLMRefusedVersion},
+		RefusalText:      events.SanitizeUTF8(args.RefusalText),
+		ContentSafetyHit: args.ContentSafetyHit,
+	}, 0)
+}

--- a/internal/state/store/events/emit/planner.go
+++ b/internal/state/store/events/emit/planner.go
@@ -1,0 +1,92 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// EmitPlannerInvoked writes one planner_invoked event with a short
+// human-readable reason ("user_request", "retry", "summarization_gap", …).
+func EmitPlannerInvoked(ctx context.Context, sink Sink, reason string) {
+	send(ctx, sink, events.TypePlannerInvoked, events.PlannerInvokedPayload{
+		Header: events.Header{V: events.PlannerInvokedVersion},
+		Reason: reason,
+	}, 0)
+}
+
+// PlannerRequestArgs is metadata about the planner's LLM call. Mirrors
+// LLMRequestArgs for symmetry — analytics consumers expect identical
+// shape across the two request types.
+type PlannerRequestArgs struct {
+	ModelID      string
+	MessageCount int
+}
+
+// EmitPlannerRequest writes one planner_request event.
+func EmitPlannerRequest(ctx context.Context, sink Sink, args PlannerRequestArgs) {
+	send(ctx, sink, events.TypePlannerRequest, events.PlannerRequestPayload{
+		Header:       events.Header{V: events.PlannerRequestVersion},
+		ModelID:      args.ModelID,
+		MessageCount: args.MessageCount,
+	}, 0)
+}
+
+// PlannerResponseArgs carries the planner's raw output for triage. The
+// helper sanitizes + excerpts RawContent in lockstep with LLMResponse so
+// downstream tooling can treat both uniformly.
+type PlannerResponseArgs struct {
+	RawContent string
+	LatencyMS  int64
+}
+
+// EmitPlannerResponse writes one planner_response event.
+func EmitPlannerResponse(ctx context.Context, sink Sink, args PlannerResponseArgs) {
+	sanitized := events.SanitizeUTF8(args.RawContent)
+	excerpt, truncated := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypePlannerResponse, events.PlannerResponsePayload{
+		Header:              events.Header{V: events.PlannerResponseVersion},
+		RawContentExcerpt:   excerpt,
+		RawContentTruncated: truncated,
+		LatencyMS:           args.LatencyMS,
+	}, args.LatencyMS)
+}
+
+// PlannerStepArgs describes one decision step inside the planner. Kind
+// is an open-vocab discriminator ("decide_tool", "decide_clarify", …);
+// callers should keep the value set small and stable so it's a useful
+// analytics dimension.
+type PlannerStepArgs struct {
+	StepIndex int
+	StepKind  string
+	Note      string
+}
+
+// EmitPlannerStep writes one planner_step event.
+func EmitPlannerStep(ctx context.Context, sink Sink, args PlannerStepArgs) {
+	send(ctx, sink, events.TypePlannerStep, events.PlannerStepPayload{
+		Header:    events.Header{V: events.PlannerStepVersion},
+		StepIndex: args.StepIndex,
+		StepKind:  args.StepKind,
+		Note:      args.Note,
+	}, 0)
+}
+
+// ToolRetrievalArgs carries one Weaviate (or other RAG backend) tool-
+// retrieval result set. Hits are stored in returned-rank order so a
+// consumer can compute position-based metrics without re-sorting.
+type ToolRetrievalArgs struct {
+	Query string
+	TopK  int
+	Hits  []events.ToolRetrievalHit
+}
+
+// EmitToolRetrieval writes one tool_retrieval event.
+func EmitToolRetrieval(ctx context.Context, sink Sink, args ToolRetrievalArgs) {
+	send(ctx, sink, events.TypeToolRetrieval, events.ToolRetrievalPayload{
+		Header: events.Header{V: events.ToolRetrievalVersion},
+		Query:  events.SanitizeUTF8(args.Query),
+		TopK:   args.TopK,
+		Hits:   args.Hits,
+	}, 0)
+}

--- a/internal/state/store/events/emit/planner.go
+++ b/internal/state/store/events/emit/planner.go
@@ -8,8 +8,11 @@ import (
 
 // EmitPlannerInvoked writes one planner_invoked event with a short
 // human-readable reason ("user_request", "retry", "summarization_gap", …).
-func EmitPlannerInvoked(ctx context.Context, sink Sink, reason string) {
-	send(ctx, sink, events.TypePlannerInvoked, events.PlannerInvokedPayload{
+// Returns the event id so the caller can parent the planner's internal
+// llm_request/response and the subsequent planner_request/response/step
+// events to this root via WithParent.
+func EmitPlannerInvoked(ctx context.Context, sink Sink, reason string) string {
+	return send(ctx, sink, events.TypePlannerInvoked, events.PlannerInvokedPayload{
 		Header: events.Header{V: events.PlannerInvokedVersion},
 		Reason: reason,
 	}, 0)
@@ -24,8 +27,8 @@ type PlannerRequestArgs struct {
 }
 
 // EmitPlannerRequest writes one planner_request event.
-func EmitPlannerRequest(ctx context.Context, sink Sink, args PlannerRequestArgs) {
-	send(ctx, sink, events.TypePlannerRequest, events.PlannerRequestPayload{
+func EmitPlannerRequest(ctx context.Context, sink Sink, args PlannerRequestArgs) string {
+	return send(ctx, sink, events.TypePlannerRequest, events.PlannerRequestPayload{
 		Header:       events.Header{V: events.PlannerRequestVersion},
 		ModelID:      args.ModelID,
 		MessageCount: args.MessageCount,
@@ -41,10 +44,10 @@ type PlannerResponseArgs struct {
 }
 
 // EmitPlannerResponse writes one planner_response event.
-func EmitPlannerResponse(ctx context.Context, sink Sink, args PlannerResponseArgs) {
+func EmitPlannerResponse(ctx context.Context, sink Sink, args PlannerResponseArgs) string {
 	sanitized := events.SanitizeUTF8(args.RawContent)
 	excerpt, truncated := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypePlannerResponse, events.PlannerResponsePayload{
+	return send(ctx, sink, events.TypePlannerResponse, events.PlannerResponsePayload{
 		Header:              events.Header{V: events.PlannerResponseVersion},
 		RawContentExcerpt:   excerpt,
 		RawContentTruncated: truncated,
@@ -63,8 +66,8 @@ type PlannerStepArgs struct {
 }
 
 // EmitPlannerStep writes one planner_step event.
-func EmitPlannerStep(ctx context.Context, sink Sink, args PlannerStepArgs) {
-	send(ctx, sink, events.TypePlannerStep, events.PlannerStepPayload{
+func EmitPlannerStep(ctx context.Context, sink Sink, args PlannerStepArgs) string {
+	return send(ctx, sink, events.TypePlannerStep, events.PlannerStepPayload{
 		Header:    events.Header{V: events.PlannerStepVersion},
 		StepIndex: args.StepIndex,
 		StepKind:  args.StepKind,
@@ -82,8 +85,8 @@ type ToolRetrievalArgs struct {
 }
 
 // EmitToolRetrieval writes one tool_retrieval event.
-func EmitToolRetrieval(ctx context.Context, sink Sink, args ToolRetrievalArgs) {
-	send(ctx, sink, events.TypeToolRetrieval, events.ToolRetrievalPayload{
+func EmitToolRetrieval(ctx context.Context, sink Sink, args ToolRetrievalArgs) string {
+	return send(ctx, sink, events.TypeToolRetrieval, events.ToolRetrievalPayload{
 		Header: events.Header{V: events.ToolRetrievalVersion},
 		Query:  events.SanitizeUTF8(args.Query),
 		TopK:   args.TopK,

--- a/internal/state/store/events/emit/score.go
+++ b/internal/state/store/events/emit/score.go
@@ -1,0 +1,27 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// ScoreComputedArgs is the rubric-driven session-quality score, written
+// by the (separate) score worker at session-end. Reasoning is free text
+// from the scoring LLM; numeric Score plus RubricVersion are the
+// analytics columns.
+type ScoreComputedArgs struct {
+	Score         float64
+	RubricVersion string
+	Reasoning     string
+}
+
+// EmitScoreComputed writes one score_computed event.
+func EmitScoreComputed(ctx context.Context, sink Sink, args ScoreComputedArgs) {
+	send(ctx, sink, events.TypeScoreComputed, events.ScoreComputedPayload{
+		Header:        events.Header{V: events.ScoreComputedVersion},
+		Score:         args.Score,
+		RubricVersion: args.RubricVersion,
+		Reasoning:     events.SanitizeUTF8(args.Reasoning),
+	}, 0)
+}

--- a/internal/state/store/events/emit/score.go
+++ b/internal/state/store/events/emit/score.go
@@ -17,8 +17,8 @@ type ScoreComputedArgs struct {
 }
 
 // EmitScoreComputed writes one score_computed event.
-func EmitScoreComputed(ctx context.Context, sink Sink, args ScoreComputedArgs) {
-	send(ctx, sink, events.TypeScoreComputed, events.ScoreComputedPayload{
+func EmitScoreComputed(ctx context.Context, sink Sink, args ScoreComputedArgs) string {
+	return send(ctx, sink, events.TypeScoreComputed, events.ScoreComputedPayload{
 		Header:        events.Header{V: events.ScoreComputedVersion},
 		Score:         args.Score,
 		RubricVersion: args.RubricVersion,

--- a/internal/state/store/events/emit/tool.go
+++ b/internal/state/store/events/emit/tool.go
@@ -26,9 +26,11 @@ type ToolCallExtractedArgs struct {
 	Mode      ToolCallMode
 }
 
-// EmitToolCallExtracted writes one tool_call_extracted event.
-func EmitToolCallExtracted(ctx context.Context, sink Sink, args ToolCallExtractedArgs) {
-	send(ctx, sink, events.TypeToolCallExtracted, events.ToolCallExtractedPayload{
+// EmitToolCallExtracted writes one tool_call_extracted event. Returns the
+// generated event id so the dispatcher can stamp it as the parent of the
+// matching tool_call_result via WithParent.
+func EmitToolCallExtracted(ctx context.Context, sink Sink, args ToolCallExtractedArgs) string {
+	return send(ctx, sink, events.TypeToolCallExtracted, events.ToolCallExtractedPayload{
 		Header:    events.Header{V: events.ToolCallExtractedVersion},
 		CallID:    args.CallID,
 		Plugin:    args.Plugin,
@@ -50,10 +52,10 @@ type ToolCallResultArgs struct {
 }
 
 // EmitToolCallResult writes one tool_call_result event.
-func EmitToolCallResult(ctx context.Context, sink Sink, args ToolCallResultArgs) {
+func EmitToolCallResult(ctx context.Context, sink Sink, args ToolCallResultArgs) string {
 	sanitized := events.SanitizeUTF8(args.Response)
 	excerpt, truncated := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypeToolCallResult, events.ToolCallResultPayload{
+	return send(ctx, sink, events.TypeToolCallResult, events.ToolCallResultPayload{
 		Header:            events.Header{V: events.ToolCallResultVersion},
 		CallID:            args.CallID,
 		Status:            args.Status,
@@ -77,10 +79,10 @@ type ToolCallParseFailedArgs struct {
 }
 
 // EmitToolCallParseFailed writes one tool_call_parse_failed event.
-func EmitToolCallParseFailed(ctx context.Context, sink Sink, args ToolCallParseFailedArgs) {
+func EmitToolCallParseFailed(ctx context.Context, sink Sink, args ToolCallParseFailedArgs) string {
 	sanitized := events.SanitizeUTF8(args.RawSnippet)
 	excerpt, _ := events.Excerpt(sanitized)
-	send(ctx, sink, events.TypeToolCallParseFailed, events.ToolCallParseFailedPayload{
+	return send(ctx, sink, events.TypeToolCallParseFailed, events.ToolCallParseFailedPayload{
 		Header:     events.Header{V: events.ToolCallParseFailedVersion},
 		RawSnippet: excerpt,
 		ParserUsed: args.ParserUsed,
@@ -99,8 +101,8 @@ type ToolCallArgsInvalidArgs struct {
 }
 
 // EmitToolCallArgsInvalid writes one tool_call_args_invalid event.
-func EmitToolCallArgsInvalid(ctx context.Context, sink Sink, args ToolCallArgsInvalidArgs) {
-	send(ctx, sink, events.TypeToolCallArgsInvalid, events.ToolCallArgsInvalidPayload{
+func EmitToolCallArgsInvalid(ctx context.Context, sink Sink, args ToolCallArgsInvalidArgs) string {
+	return send(ctx, sink, events.TypeToolCallArgsInvalid, events.ToolCallArgsInvalidPayload{
 		Header:          events.Header{V: events.ToolCallArgsInvalidVersion},
 		CallID:          args.CallID,
 		Plugin:          args.Plugin,
@@ -111,8 +113,8 @@ func EmitToolCallArgsInvalid(ctx context.Context, sink Sink, args ToolCallArgsIn
 
 // EmitToolCallNotFound writes one tool_call_not_found event when the
 // LLM names a plugin/action the dispatcher does not know about.
-func EmitToolCallNotFound(ctx context.Context, sink Sink, requestedName string) {
-	send(ctx, sink, events.TypeToolCallNotFound, events.ToolCallNotFoundPayload{
+func EmitToolCallNotFound(ctx context.Context, sink Sink, requestedName string) string {
+	return send(ctx, sink, events.TypeToolCallNotFound, events.ToolCallNotFoundPayload{
 		Header:        events.Header{V: events.ToolCallNotFoundVersion},
 		RequestedName: requestedName,
 	}, 0)

--- a/internal/state/store/events/emit/tool.go
+++ b/internal/state/store/events/emit/tool.go
@@ -1,0 +1,119 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// ToolCallMode discriminates how the orchestrator obtained a tool call.
+type ToolCallMode string
+
+const (
+	ToolCallModeNative ToolCallMode = "native"
+	ToolCallModeText   ToolCallMode = "text"
+)
+
+// ToolCallExtractedArgs is the orchestrator's decoded view of one tool
+// call — emitted after parsing but BEFORE plugin dispatch. CallID links
+// the corresponding tool_call_result via the session_events.parent_id
+// column (caller stamps WithParent for the dispatch span).
+type ToolCallExtractedArgs struct {
+	CallID    string
+	Plugin    string
+	Action    string
+	Arguments map[string]string
+	Mode      ToolCallMode
+}
+
+// EmitToolCallExtracted writes one tool_call_extracted event.
+func EmitToolCallExtracted(ctx context.Context, sink Sink, args ToolCallExtractedArgs) {
+	send(ctx, sink, events.TypeToolCallExtracted, events.ToolCallExtractedPayload{
+		Header:    events.Header{V: events.ToolCallExtractedVersion},
+		CallID:    args.CallID,
+		Plugin:    args.Plugin,
+		Action:    args.Action,
+		Arguments: args.Arguments,
+		Mode:      string(args.Mode),
+	}, 0)
+}
+
+// ToolCallResultArgs is the dispatch outcome. Status follows plugin
+// convention ("ok" or "error"). Response is sanitized + excerpted; the
+// parent linkage to tool_call_extracted is carried on ctx via
+// emit.WithParent at the dispatch site.
+type ToolCallResultArgs struct {
+	CallID    string
+	Status    string
+	Response  string
+	LatencyMS int64
+}
+
+// EmitToolCallResult writes one tool_call_result event.
+func EmitToolCallResult(ctx context.Context, sink Sink, args ToolCallResultArgs) {
+	sanitized := events.SanitizeUTF8(args.Response)
+	excerpt, truncated := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypeToolCallResult, events.ToolCallResultPayload{
+		Header:            events.Header{V: events.ToolCallResultVersion},
+		CallID:            args.CallID,
+		Status:            args.Status,
+		ResponseExcerpt:   excerpt,
+		ResponseTruncated: truncated,
+		LatencyMS:         args.LatencyMS,
+	}, args.LatencyMS)
+}
+
+// ToolCallParseFailedArgs captures text-based tool-call syntax that the
+// parser could not interpret. RawSnippet is the exact substring the
+// parser saw — sanitized only, not excerpted, because parse failures
+// are short by construction (the parser bails on the first bad token).
+//
+// If a snippet ever exceeds ExcerptCap we still excerpt it rather than
+// truncating arbitrarily; the truncated flag would surface that.
+type ToolCallParseFailedArgs struct {
+	RawSnippet string
+	ParserUsed string
+	ParseError string
+}
+
+// EmitToolCallParseFailed writes one tool_call_parse_failed event.
+func EmitToolCallParseFailed(ctx context.Context, sink Sink, args ToolCallParseFailedArgs) {
+	sanitized := events.SanitizeUTF8(args.RawSnippet)
+	excerpt, _ := events.Excerpt(sanitized)
+	send(ctx, sink, events.TypeToolCallParseFailed, events.ToolCallParseFailedPayload{
+		Header:     events.Header{V: events.ToolCallParseFailedVersion},
+		RawSnippet: excerpt,
+		ParserUsed: args.ParserUsed,
+		ParseError: args.ParseError,
+	}, 0)
+}
+
+// ToolCallArgsInvalidArgs is emitted when a tool call passed parsing but
+// failed plugin-side argument validation. CallID matches the extracted
+// event so a consumer can link them.
+type ToolCallArgsInvalidArgs struct {
+	CallID          string
+	Plugin          string
+	Action          string
+	ValidationError string
+}
+
+// EmitToolCallArgsInvalid writes one tool_call_args_invalid event.
+func EmitToolCallArgsInvalid(ctx context.Context, sink Sink, args ToolCallArgsInvalidArgs) {
+	send(ctx, sink, events.TypeToolCallArgsInvalid, events.ToolCallArgsInvalidPayload{
+		Header:          events.Header{V: events.ToolCallArgsInvalidVersion},
+		CallID:          args.CallID,
+		Plugin:          args.Plugin,
+		Action:          args.Action,
+		ValidationError: args.ValidationError,
+	}, 0)
+}
+
+// EmitToolCallNotFound writes one tool_call_not_found event when the
+// LLM names a plugin/action the dispatcher does not know about.
+func EmitToolCallNotFound(ctx context.Context, sink Sink, requestedName string) {
+	send(ctx, sink, events.TypeToolCallNotFound, events.ToolCallNotFoundPayload{
+		Header:        events.Header{V: events.ToolCallNotFoundVersion},
+		RequestedName: requestedName,
+	}, 0)
+}

--- a/internal/state/store/events/emit/turn.go
+++ b/internal/state/store/events/emit/turn.go
@@ -1,0 +1,47 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// TurnStartArgs carries the per-turn prompt/model context. Prompt bodies
+// are referenced by SHA256 — callers are responsible for upserting the
+// underlying content into prompt_snapshots before (or alongside) the
+// turn_start emission so a consumer can resolve the digest.
+type TurnStartArgs struct {
+	SystemPromptSHA256 string
+	ServerInstructions []events.ServerInstructionRef
+	AvailableTools     []events.ToolRef
+	ModelID            string
+	Temperature        *float64
+	ReasoningEffort    string
+}
+
+// EmitTurnStart writes a turn_start event for the current session.
+func EmitTurnStart(ctx context.Context, sink Sink, args TurnStartArgs) {
+	send(ctx, sink, events.TypeTurnStart, events.TurnStartPayload{
+		Header:             events.Header{V: events.TurnStartVersion},
+		SystemPromptSHA256: args.SystemPromptSHA256,
+		ServerInstructions: args.ServerInstructions,
+		AvailableTools:     args.AvailableTools,
+		ModelID:            args.ModelID,
+		Temperature:        args.Temperature,
+		ReasoningEffort:    args.ReasoningEffort,
+	}, 0)
+}
+
+// EmitUserMessage writes a user_message event carrying the raw user
+// content. The helper sanitizes UTF-8 first; ContentLength is the byte
+// length of what's actually stored (post-sanitization) so the payload
+// stays internally consistent — analytics counting bytes never see a
+// length that disagrees with the content field.
+func EmitUserMessage(ctx context.Context, sink Sink, content string) {
+	sanitized := events.SanitizeUTF8(content)
+	send(ctx, sink, events.TypeUserMessage, events.UserMessagePayload{
+		Header:        events.Header{V: events.UserMessageVersion},
+		Content:       sanitized,
+		ContentLength: len(sanitized),
+	}, 0)
+}

--- a/internal/state/store/events/emit/turn.go
+++ b/internal/state/store/events/emit/turn.go
@@ -20,8 +20,10 @@ type TurnStartArgs struct {
 }
 
 // EmitTurnStart writes a turn_start event for the current session.
-func EmitTurnStart(ctx context.Context, sink Sink, args TurnStartArgs) {
-	send(ctx, sink, events.TypeTurnStart, events.TurnStartPayload{
+// Returns the generated event id so callers can chain it as the parent
+// of the rest of the turn via WithParent.
+func EmitTurnStart(ctx context.Context, sink Sink, args TurnStartArgs) string {
+	return send(ctx, sink, events.TypeTurnStart, events.TurnStartPayload{
 		Header:             events.Header{V: events.TurnStartVersion},
 		SystemPromptSHA256: args.SystemPromptSHA256,
 		ServerInstructions: args.ServerInstructions,
@@ -37,9 +39,9 @@ func EmitTurnStart(ctx context.Context, sink Sink, args TurnStartArgs) {
 // length of what's actually stored (post-sanitization) so the payload
 // stays internally consistent — analytics counting bytes never see a
 // length that disagrees with the content field.
-func EmitUserMessage(ctx context.Context, sink Sink, content string) {
+func EmitUserMessage(ctx context.Context, sink Sink, content string) string {
 	sanitized := events.SanitizeUTF8(content)
-	send(ctx, sink, events.TypeUserMessage, events.UserMessagePayload{
+	return send(ctx, sink, events.TypeUserMessage, events.UserMessagePayload{
 		Header:        events.Header{V: events.UserMessageVersion},
 		Content:       sanitized,
 		ContentLength: len(sanitized),

--- a/internal/state/store/session_events_test.go
+++ b/internal/state/store/session_events_test.go
@@ -296,8 +296,8 @@ func TestEvents_ExcerptCapAndUTF8(t *testing.T) {
 
 // TestLLMResponsePayload_NativeToolCallsRawInlinesAsJSON pins the wire
 // format: NativeToolCallsRaw must embed as inline JSON, not as an escaped
-// string. This is the contract the api-plugin (TIM-868x follow-up) and
-// psql inspection rely on.
+// string. This is the contract downstream consumers (api-plugin, psql
+// inspection) rely on.
 func TestLLMResponsePayload_NativeToolCallsRawInlinesAsJSON(t *testing.T) {
 	raw := json.RawMessage(`[{"id":"call_1","name":"tickets.show","arguments":{"id":"42"}}]`)
 	p := events.LLMResponsePayload{


### PR DESCRIPTION
## Summary

Wires the producer side of the structured `session_events` log added in #239. After this PR, every subsystem (provider, orchestrator, planner, tool dispatcher, parser, lifecycle) emits typed events through a single `emit.Sink` interface — no caller marshals payloads or writes to the store directly.

22 of 24 declared event types are now emitted from real call paths. The remaining two (`model_switch`, `tool_retrieval`) have helpers in place but no producer yet — they're an explicit follow-up, not silent gaps.

## Design

**One `emit.Sink` interface, two adapters.**
- Producer code calls `emit.EmitXxx(ctx, sink, args)` — never the store directly.
- Production wires `Config.EventSink` to a `sessionSinkAdapter` over the async-buffered writer added in #239.
- Default is `emit.NoOpSink{}`, so subsystems can call emit helpers unconditionally without nil-checks; the no-op sink discards.

**Producer-side `event_id` + `parent_id` plumbing.**
Each `Emit*` helper returns the generated event id. Callers chain it as the parent of subsequent emits via `emit.WithParent(ctx, id)` at 5 boundaries:
- `turn_start` parents the whole turn
- `planner_invoked` parents the planner's request/response/step events
- `llm_response` parents `tool_call_extracted` (chains across multi-round agent loops)
- `tool_call_extracted` parents the matching `tool_call_result`
- `confirmation_requested` parents `confirmation_resolved` across turns (in-memory map + JSON persistence on `pendingToolCallMeta` for pod-restart durability)

**UTF-8 sanitization + 4 KB excerpt cap** centralized in helpers — invariant cannot drift from caller code.

**Synchronous `json.Marshal` before async dispatch** preserves the raw-capture invariant: the bytes the writer sees are exactly what was emitted, even if the caller mutates the args struct after the call.

## Commit structure (review commit-by-commit)

1. `a7208f2` — typed emit helpers for all 24 event types (no callers yet)
2. `35eed3f` — OpenAI provider emits `llm_request` / `llm_response` / `llm_error` / `llm_refused` at the HTTP boundary; surfaces event id on `CompletionResponse.EventID` for parent-id chaining
3. `15f7062` — orchestrator emits `turn_start` + `user_message`; persists system-prompt / server-instructions / tool descriptions in `prompt_snapshots` by sha256
4. `f8416ab` — tool dispatcher emits `tool_call_extracted` / `tool_call_result` / `tool_call_args_invalid` / `tool_call_not_found`
5. `e66467d` — `tool_call_parse_failed` emitted when text-based tool-call parsing fails
6. `bfbf234` — scrub downstream references from upstream test fixtures and comments (no behavior change)
7. `46f0c1a` — planner + summarization events (`planner_invoked`, `planner_request`, `planner_response`, `planner_step`, `summarization_triggered`, `summarization_completed`)
8. `d823b3c` — `retry`, `confirmation_requested`, `confirmation_resolved` (the last two with cross-turn linkage)
9. `f9e76bb` — parent_id wiring at the 5 boundaries above; producer-side event_id generation; stream `EventID()` optional-interface for streaming providers
10. `1f74b4f` — doc polish (`Config.EventSink` default semantics)

## Test coverage

- `internal/state/store/events/emit/emit_test.go` — every helper has unit tests asserting schema version stamp, sanitization, excerpt capping, sha256, and parent_id propagation from ctx
- `internal/orchestrator/orchestrator_session_events_test.go` — integration-style tests for each event type from real orchestrator code paths, plus 7 parent_id linkage tests
- Cross-package linkage test (`TestParentID_ToolCallExtractedParentsLLMResponse`) verifies the provider→orchestrator event-id handoff via the EventID-surfacing pattern
- `TestAllEmitHelpers_StampMatchingVersion` enforces that every helper stamps the correct `<Type>Version` constant

## Known follow-ups

These are deliberate non-goals for this PR. Filing tickets up to the maintainers' preference.

- **`model_switch` + `tool_retrieval` producers** — helpers + payload types exist; no callers yet. `model_switch` needs runtime model-swap logic; `tool_retrieval` lives in the (separate) Weaviate plugin
- **`score_computed` producer** — emitted by the (separate) score worker at session-end, not by the orchestrator
- **Sink graceful-shutdown interface** — `Flush()`/`Close()` could be added as an optional interface (type-assert in main.go's cleanup) without breaking the existing Sink. Today's writer drain via `writer.Stop()` is good enough for clean shutdowns but doesn't cover the orchestrator-side path
- **Async-writer overflow metrics** — drops are logged at powers of 2 (already in #239); a Prometheus counter would close the visibility gap. No metrics framework in the repo today
- **ULID/UUIDv7 event ids** — currently 16-byte hex. k-sortability would help analytics queries but isn't required for parent_id resolution
- **`(string, error)` return shape on emit helpers** — current shape returns `""` on marshal/id-gen failure (already logged at `slog.Warn`). Explicit error return would let callers decide propagation but is an API-wide change

## Risk

- New code paths run unconditionally — bug here can't break orchestration since emit failures fall through to `slog.Warn` and return `""`
- `pendingToolCallMeta` extended with `ConfirmationRequestedID string` JSON field — `json.Unmarshal` ignores unknown fields, old rows decode to `""`, no migration needed
- Backwards-compatible against any consumer of `CompletionResponse`: new `EventID string \`json:"-"\`` field is unmarshalled-out and zero-value when not set