### PR TITLE
feat(provider+events): stamp per-call cost on llm_response

### DIFF
--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -113,6 +113,28 @@ func (p *OpenAIProvider) ID() string { return p.id }
 
 func (p *OpenAIProvider) Models() []ModelInfo { return p.models }
 
+// costForTokens computes input/output cost for tokensIn/tokensOut against
+// this provider's configured per-million-token rate for modelID. Returns
+// (0, 0) when modelID is not in p.models — emit helpers stamp
+// LLMResponsePayload with omitempty so a zero cost simply leaves the
+// fields out rather than recording a misleading "free call". Mirrors
+// the silent-zero behaviour of usageRecorderAdapter.RecordUsage in
+// cmd/opentalon/main.go so the two pricing paths stay consistent.
+//
+// Currency is unitless: ModelInfo.Cost values are stamped as-is, the
+// operator's deployment convention sets the unit. Centralising the math
+// here keeps the streaming and non-streaming emit sites from drifting.
+func (p *OpenAIProvider) costForTokens(modelID string, tokensIn, tokensOut int) (float64, float64) {
+	for _, m := range p.models {
+		if m.ID != modelID {
+			continue
+		}
+		return float64(tokensIn) * m.Cost.Input / 1_000_000,
+			float64(tokensOut) * m.Cost.Output / 1_000_000
+	}
+	return 0, 0
+}
+
 func (p *OpenAIProvider) SupportsFeature(f Feature) bool {
 	for _, m := range p.models {
 		if m.SupportsFeature(f) {
@@ -256,7 +278,13 @@ type oaiResponseStream struct {
 	finishReason string
 	tokensIn     int
 	tokensOut    int
-	streamErr    error // non-nil → Close emits llm_error instead of llm_response/llm_refused
+	// costFn computes (inputCost, outputCost) from final token counts at
+	// end-of-stream. Captured as a closure rather than a back-pointer to
+	// the provider so the stream stays decoupled from OpenAIProvider for
+	// targeted tests. nil when no pricing should be computed (test fakes
+	// that skip provider construction).
+	costFn    func(tokensIn, tokensOut int) (float64, float64)
+	streamErr error // non-nil → Close emits llm_error instead of llm_response/llm_refused
 
 	// lastEventID is the session-event id of the llm_response event emitted
 	// at end-of-stream; empty for refusal/error paths and when no sink is
@@ -487,12 +515,15 @@ func (p *OpenAIProvider) Complete(ctx context.Context, req *CompletionRequest) (
 		// Refusals don't lead to tool dispatch, so a parent_id link from
 		// tool_call_extracted is not meaningful here anyway.
 	} else {
+		costIn, costOut := p.costForTokens(oaiReq.Model, oaiResp.Usage.PromptTokens, oaiResp.Usage.CompletionTokens)
 		eventID = emit.EmitLLMResponse(ctx, p.eventSink, emit.LLMResponseArgs{
 			RawContent:         content,
 			NativeToolCallsRaw: nativeToolCallsRaw,
 			FinishReason:       finishReason,
 			TokensIn:           oaiResp.Usage.PromptTokens,
 			TokensOut:          oaiResp.Usage.CompletionTokens,
+			CostInput:          costIn,
+			CostOutput:         costOut,
 			LatencyMS:          latencyMS,
 			ProviderResponseID: oaiResp.ID,
 		})
@@ -608,6 +639,9 @@ func (p *OpenAIProvider) Stream(ctx context.Context, req *CompletionRequest) (Re
 		emitCtx:   ctx,
 		eventSink: p.eventSink,
 		startTime: start,
+		costFn: func(in, out int) (float64, float64) {
+			return p.costForTokens(oaiReq.Model, in, out)
+		},
 	}
 	// Wire end-of-stream capture only when this session opted in. Sessions
 	// without /debug get the lighter struct without the buffer.
@@ -768,11 +802,17 @@ func (s *oaiResponseStream) emitStreamEnd() {
 		})
 		return
 	}
+	var costIn, costOut float64
+	if s.costFn != nil {
+		costIn, costOut = s.costFn(s.tokensIn, s.tokensOut)
+	}
 	s.lastEventID = emit.EmitLLMResponse(s.emitCtx, s.eventSink, emit.LLMResponseArgs{
 		RawContent:         content,
 		FinishReason:       s.finishReason,
 		TokensIn:           s.tokensIn,
 		TokensOut:          s.tokensOut,
+		CostInput:          costIn,
+		CostOutput:         costOut,
 		LatencyMS:          latencyMS,
 		ProviderResponseID: s.responseID,
 	})

--- a/internal/provider/openai_session_events_test.go
+++ b/internal/provider/openai_session_events_test.go
@@ -1029,6 +1029,140 @@ func TestOpenAIStream_FinishReasonAndDeltaInSameChunk(t *testing.T) {
 	}
 }
 
+// ----- Cost computation -----
+
+// TestOpenAIComplete_EmitsCostFromModelConfig verifies the non-streaming
+// path computes per-call cost from the provider's per-million-token rates
+// and stamps it on the llm_response payload at call time. Frozen-pricing
+// is load-bearing: api-plugin /events/stats sums these fields directly so
+// later config changes must not retroactively re-price historical rows.
+func TestOpenAIComplete_EmitsCostFromModelConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID:    "chatcmpl-cost",
+			Model: "gpt-4o",
+			Choices: []oaiChoice{{
+				Index:        0,
+				Message:      oaiMessage{Role: "assistant", Content: "ok"},
+				FinishReason: "stop",
+			}},
+			Usage: oaiUsage{PromptTokens: 1_000_000, CompletionTokens: 2_000_000},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	// 2.50 EUR / 1M input, 10.00 EUR / 1M output. Round numbers across a
+	// million-token call so the expectation reads as multiplied rates and
+	// any drift to "per-thousand" / "per-token" math is loud.
+	models := []ModelInfo{{ID: "gpt-4o", Cost: ModelCost{Input: 2.5, Output: 10}}}
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", models, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	got := sink.snapshot()
+	var resp events.LLMResponsePayload
+	if err := json.Unmarshal(got[1].Payload, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.CostInput != 2.5 {
+		t.Errorf("CostInput = %v, want 2.5 (1M tokens * 2.50/M)", resp.CostInput)
+	}
+	if resp.CostOutput != 20 {
+		t.Errorf("CostOutput = %v, want 20 (2M tokens * 10/M)", resp.CostOutput)
+	}
+}
+
+// TestOpenAIComplete_EmitsZeroCostForUnknownModel verifies that a model
+// missing from the provider's catalogue leaves both cost fields at zero.
+// omitempty then strips them from the JSON: consumers must treat absent
+// fields as unpriced rather than as a free call.
+func TestOpenAIComplete_EmitsZeroCostForUnknownModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		resp := oaiResponse{
+			ID:    "chatcmpl-uncatalogued",
+			Model: "unknown-model",
+			Choices: []oaiChoice{{
+				Index:        0,
+				Message:      oaiMessage{Role: "assistant", Content: "ok"},
+				FinishReason: "stop",
+			}},
+			Usage: oaiUsage{PromptTokens: 100, CompletionTokens: 50},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	sink := &recordingEventSink{}
+	// Provider built with a catalogue that does NOT contain "unknown-model".
+	models := []ModelInfo{{ID: "gpt-4o", Cost: ModelCost{Input: 2.5, Output: 10}}}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", models, WithOpenAISessionEventSink(sink))
+	_, err := p.Complete(context.Background(), &CompletionRequest{
+		Model:    "unknown-model",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	got := sink.snapshot()
+	if resp := got[1].Payload; !strings.Contains(string(resp), `"tokens_in":100`) {
+		t.Fatalf("sanity: tokens_in missing from payload %s", string(resp))
+	}
+	if strings.Contains(string(got[1].Payload), `"cost_input"`) || strings.Contains(string(got[1].Payload), `"cost_output"`) {
+		t.Errorf("unknown model must omit cost fields, got payload: %s", string(got[1].Payload))
+	}
+}
+
+// TestOpenAIStream_EmitsCostFromModelConfig is the streaming twin of
+// TestOpenAIComplete_EmitsCostFromModelConfig — verifies the closure
+// captured on the stream resolves pricing at end-of-stream and stamps
+// the same cost fields on the llm_response payload.
+func TestOpenAIStream_EmitsCostFromModelConfig(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(streamResponse([]string{"ok"}, "stop", true)))
+	}))
+	defer server.Close()
+
+	models := []ModelInfo{{ID: "gpt-4o", Cost: ModelCost{Input: 5, Output: 15}}}
+	sink := &recordingEventSink{}
+	p := NewOpenAIProvider("openai", server.URL, "test-key", models, WithOpenAISessionEventSink(sink))
+	stream, err := p.Stream(context.Background(), &CompletionRequest{
+		Model:    "gpt-4o",
+		Messages: []Message{{Role: RoleUser, Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	drainStream(t, stream)
+	if err := stream.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got := sink.snapshot()
+	var resp events.LLMResponsePayload
+	_ = json.Unmarshal(got[1].Payload, &resp)
+	// streamResponse seeds PromptTokens=12, CompletionTokens=9 (see helper)
+	// → 12 * 5/1M + 9 * 15/1M
+	wantIn := float64(resp.TokensIn) * 5 / 1_000_000
+	wantOut := float64(resp.TokensOut) * 15 / 1_000_000
+	if resp.CostInput != wantIn {
+		t.Errorf("CostInput = %v, want %v (TokensIn=%d * 5/M)", resp.CostInput, wantIn, resp.TokensIn)
+	}
+	if resp.CostOutput != wantOut {
+		t.Errorf("CostOutput = %v, want %v (TokensOut=%d * 15/M)", resp.CostOutput, wantOut, resp.TokensOut)
+	}
+}
+
 // ----- test helpers shared by the error-path tests above -----
 
 // roundTripperFunc adapts a closure into an http.RoundTripper so the

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -151,6 +151,51 @@ func TestEmitUserMessage_ContentLengthMatchesStoredContent(t *testing.T) {
 
 // ----- llm cluster (raw-capture invariants) -----
 
+// TestEmitLLMResponse_CostFieldsPassThrough verifies the cost fields on
+// LLMResponseArgs land on LLMResponsePayload unchanged. The helper does
+// no math of its own — pricing is the caller's responsibility (the
+// provider wrapper) so historical events stay frozen at their call-time
+// rates even after the model catalogue is reconfigured.
+func TestEmitLLMResponse_CostFieldsPassThrough(t *testing.T) {
+	sink := &fakeSink{}
+	EmitLLMResponse(context.Background(), sink, LLMResponseArgs{
+		RawContent: "ok",
+		TokensIn:   1000,
+		TokensOut:  500,
+		CostInput:  0.0025,
+		CostOutput: 0.005,
+	})
+
+	var p events.LLMResponsePayload
+	if err := json.Unmarshal(sink.snapshot()[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.CostInput != 0.0025 {
+		t.Errorf("CostInput = %v, want 0.0025", p.CostInput)
+	}
+	if p.CostOutput != 0.005 {
+		t.Errorf("CostOutput = %v, want 0.005", p.CostOutput)
+	}
+}
+
+// TestEmitLLMResponse_ZeroCostOmitted verifies that a zero-cost emit (the
+// common case for unconfigured models) leaves the cost fields out of the
+// JSON entirely — so consumers can distinguish "unpriced" (absent) from
+// "priced at zero" (present and 0) without ambiguity.
+func TestEmitLLMResponse_ZeroCostOmitted(t *testing.T) {
+	sink := &fakeSink{}
+	EmitLLMResponse(context.Background(), sink, LLMResponseArgs{
+		RawContent: "ok",
+		TokensIn:   10,
+		TokensOut:  5,
+	})
+
+	raw := string(sink.snapshot()[0].Payload)
+	if strings.Contains(raw, `"cost_input"`) || strings.Contains(raw, `"cost_output"`) {
+		t.Errorf("zero cost must be omitted from payload, got: %s", raw)
+	}
+}
+
 func TestEmitLLMResponse_ExcerptAndSHA256(t *testing.T) {
 	sink := &fakeSink{}
 	long := strings.Repeat("A", events.ExcerptCap+128) // overshoot the cap

--- a/internal/state/store/events/emit/llm.go
+++ b/internal/state/store/events/emit/llm.go
@@ -36,12 +36,23 @@ func EmitLLMRequest(ctx context.Context, sink Sink, args LLMRequestArgs) string 
 // UTF-8, computes the full-content SHA256, and stores the 4 KB excerpt
 // with a truncated flag. NativeToolCallsRaw is the provider's ToolCalls
 // JSON inlined as-is so consumers don't double-unmarshal.
+//
+// CostInput / CostOutput are the cost of this call, computed by the
+// caller (the provider wrapper) from token counts and the per-million
+// rates on the matching ModelInfo. Computing here rather than at read
+// time freezes pricing at call time so later config changes do not
+// retroactively re-price historical events. Currency is whatever
+// ModelInfo.Cost is denominated in — see LLMResponsePayload doc. Zero
+// values are passed through unchanged; the payload uses omitempty so
+// unpriced models simply leave the fields out.
 type LLMResponseArgs struct {
 	RawContent         string
 	NativeToolCallsRaw json.RawMessage
 	FinishReason       string
 	TokensIn           int
 	TokensOut          int
+	CostInput          float64
+	CostOutput         float64
 	LatencyMS          int64
 	ProviderResponseID string
 }
@@ -63,6 +74,8 @@ func EmitLLMResponse(ctx context.Context, sink Sink, args LLMResponseArgs) strin
 		FinishReason:        args.FinishReason,
 		TokensIn:            args.TokensIn,
 		TokensOut:           args.TokensOut,
+		CostInput:           args.CostInput,
+		CostOutput:          args.CostOutput,
 		LatencyMS:           args.LatencyMS,
 		ProviderResponseID:  args.ProviderResponseID,
 	}, args.LatencyMS)

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -178,6 +178,18 @@ const LLMRequestVersion = 1
 // directly into the parent payload: `{"native_tool_calls_raw":[{...}]}`
 // instead of an escaped-string form. This matters for psql inspection and
 // for the api-plugin which would otherwise need a double unmarshal.
+//
+// CostInput / CostOutput — cost of this call, computed by the provider
+// wrapper at call time from token counts and the per-million rates
+// configured on the matching ModelInfo. Frozen at call time so later
+// config changes (or model retirement) do not retroactively re-price
+// historical events. Fields are unitless floats; the currency is
+// whatever ModelInfo.Cost is denominated in — operators document the
+// convention at deployment level (matching the existing store.UsageRecord
+// {InputCost, OutputCost} convention in internal/state/store/usage.go).
+// Both fields use omitempty: a zero value means "model not in the
+// catalogue at emit time", not "free" — analytics should treat absent
+// fields as unpriced rather than summing them as zero-cost calls.
 type LLMResponsePayload struct {
 	Header
 	RawContentExcerpt   string          `json:"raw_content_excerpt"`
@@ -187,6 +199,8 @@ type LLMResponsePayload struct {
 	FinishReason        string          `json:"finish_reason,omitempty"`
 	TokensIn            int             `json:"tokens_in,omitempty"`
 	TokensOut           int             `json:"tokens_out,omitempty"`
+	CostInput           float64         `json:"cost_input,omitempty"`
+	CostOutput          float64         `json:"cost_output,omitempty"`
 	LatencyMS           int64           `json:"latency_ms,omitempty"`
 	ProviderResponseID  string          `json:"provider_response_id,omitempty"`
 }


### PR DESCRIPTION
## Summary

OpenAI provider wrapper (Complete + Stream paths) now computes `cost_input` / `cost_output` from token counts and the per-million-token rates on the matching `ModelInfo`, then stamps them on the `llm_response` session event payload at call time.

Cost is frozen at call time so historical events keep their original pricing even after the model catalogue is reconfigured. The upcoming api-plugin `/events/stats` endpoint can sum these payload fields directly — no JOIN to a pricing table needed.

## Why

Precondition for the api-plugin `/events/stats` aggregation work (next PR). Computing pricing at read time would either (a) re-price history on every config change, or (b) require an immutable pricing snapshot table — both heavier than stamping the row once at emit time.

## Design notes

- **Unitless cost fields.** `ModelInfo.Cost` values are stamped as-is; the currency convention is documented at deployment level, matching the existing `store.UsageRecord{InputCost, OutputCost}` pattern in `internal/state/store/usage.go`.
- **Silent-zero for unknown models.** `costForTokens` returns `(0, 0)` when the model is missing from the provider's catalogue. `omitempty` drops the fields from JSON — consumers treat absent as "unpriced", not "zero-cost". Same contract as the existing `usageRecorderAdapter.RecordUsage` in `cmd/opentalon/main.go`.
- **Closure on the stream struct.** The streaming path stores a `costFn func(in, out int) (float64, float64)` instead of a back-pointer to the provider, keeping the stream decoupled and testable.

## Scope

- OpenAI provider only (`internal/provider/openai.go` Complete + Stream).
- `llm_refused` / `llm_error` payloads stay as-is — those events don't carry token counts today either; wiring cost there would require extending those schemas. Follow-up.
- Anthropic provider is not yet emitting any session events; cost wiring will follow that work.

## Test plan

- [x] `go test ./internal/state/store/events/emit/ ./internal/provider/` — green
- [x] `go test ./...` — full suite green
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l` — clean
- [x] New tests cover: passthrough at emit layer, zero-cost omission, non-streaming cost from model config, unknown model omits fields, streaming cost from model config