### PR TITLE
feat: context_messages sliding window, bundle cache config, summarization off by default

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -273,7 +273,7 @@ func main() {
 	for name, p := range cfg.Plugins {
 		path := p.Plugin
 		if p.GitHub != "" && p.Ref != "" {
-			resolvedPath, err := bundle.EnsurePlugin(ctx, dataDir, name, p.GitHub, p.Ref)
+			resolvedPath, err := bundle.EnsurePlugin(ctx, dataDir, name, p.GitHub, p.Ref, p.Cache)
 			if err != nil {
 				slog.Warn("bundle plugin failed", "plugin", name, "error", err)
 				continue
@@ -564,7 +564,8 @@ func main() {
 		PermissionChecker:       permChecker,
 		PermissionPluginName:    permPluginName,
 		RuntimePromptPath:       runtimePromptPath,
-		SummarizeAfterMessages:  defaultInt(cfg.State.Session.SummarizeAfter, 5),
+		ContextMessages:         cfg.State.Session.ContextMessages, // 0 = all messages; >0 = send only last N messages to LLM
+		SummarizeAfterMessages:  cfg.State.Session.SummarizeAfter,  // 0 (default) = off; set to e.g. 10 to enable LLM summarization
 		MaxMessagesAfterSummary: defaultInt(cfg.State.Session.MaxMessagesAfterSummary, 5),
 		SummarizePrompt:         cfg.State.Session.SummarizePrompt,
 		SummarizeUpdatePrompt:   cfg.State.Session.SummarizeUpdatePrompt,
@@ -768,7 +769,7 @@ func main() {
 	for name, ch := range cfg.Channels {
 		pathRef := ch.Plugin
 		if ch.GitHub != "" && ch.Ref != "" {
-			resolvedPath, err := bundle.EnsureChannel(ctx, dataDir, name, ch.GitHub, ch.Ref)
+			resolvedPath, err := bundle.EnsureChannel(ctx, dataDir, name, ch.GitHub, ch.Ref, ch.Cache)
 			if err != nil {
 				slog.Warn("bundle channel failed", "channel", name, "error", err)
 				continue

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -97,6 +97,7 @@ orchestrator:
 channels:
   console:
     enabled: true
+    # cache: false    # when true, reuse cached binary from channels.lock (default false = always rebuild)
     # Local binary (after running: make setup), or grpc://host:port for remote
     plugin: "./channels/console-channel/console"
     # Or use GitHub refs — core auto-fetches, builds, and pins in channels.lock:
@@ -146,6 +147,7 @@ plugins:
   # Slash commands: /install skill, /show config, /commands, /set prompt, /clear
   opentalon-commands:
     enabled: true
+    # cache: false    # when true, reuse cached binary from plugins.lock (default false = always rebuild)
     insecure: false   # required: allows preparer to return invoke for opentalon actions
     github: "opentalon/opentalon-commands"
     ref: "master"
@@ -234,8 +236,9 @@ state:
   # session limits and optional summarization
   # session:
   #   max_messages: 50           # cap messages per conversation (0 = no cap)
+  #   context_messages: 10       # send only last N messages to LLM (0 = all; default 0)
   #   max_idle_days: 30          # delete sessions not updated in N days (0 = don't prune)
-  #   summarize_after_messages: 10   # run LLM summarization after N messages (0 = off)
+  #   summarize_after_messages: 10   # run LLM summarization after N messages (0 = off; default off)
   #   max_messages_after_summary: 6  # keep this many messages after summarization
   #   summarize_prompt: "Summarize the following conversation in a short paragraph."  # any language
   #   summarize_update_prompt: "Update the given conversation summary with the following new exchange. Keep the result to a short paragraph."

--- a/internal/bundle/fetch.go
+++ b/internal/bundle/fetch.go
@@ -389,7 +389,8 @@ func EnsureLuaPluginDir(ctx context.Context, stateDir, name, github, ref string)
 
 // EnsurePlugin ensures the plugin is present under stateDir/plugins/<name>/,
 // resolves ref to a commit, clones and builds if needed, updates plugins.lock, and returns the path to the binary.
-func EnsurePlugin(ctx context.Context, stateDir, name, github, ref string) (path string, err error) {
+// When cache is true the lock file is consulted and a matching entry is reused; when false the plugin is always rebuilt.
+func EnsurePlugin(ctx context.Context, stateDir, name, github, ref string, cache bool) (path string, err error) {
 	if github == "" || ref == "" {
 		return "", fmt.Errorf("github and ref are required")
 	}
@@ -399,14 +400,16 @@ func EnsurePlugin(ctx context.Context, stateDir, name, github, ref string) (path
 		return "", err
 	}
 
-	entry, locked := lock.Plugins[name]
-	if locked && entry.GitHub == github && entry.Ref == ref && entry.Resolved != "" && entry.Path != "" {
-		absPath := entry.Path
-		if !filepath.IsAbs(absPath) {
-			absPath = filepath.Join(stateDir, entry.Path)
-		}
-		if _, err := os.Stat(absPath); err == nil {
-			return absPath, nil
+	if cache {
+		entry, locked := lock.Plugins[name]
+		if locked && entry.GitHub == github && entry.Ref == ref && entry.Resolved != "" && entry.Path != "" {
+			absPath := entry.Path
+			if !filepath.IsAbs(absPath) {
+				absPath = filepath.Join(stateDir, entry.Path)
+			}
+			if _, err := os.Stat(absPath); err == nil {
+				return absPath, nil
+			}
 		}
 	}
 
@@ -444,7 +447,8 @@ func EnsurePlugin(ctx context.Context, stateDir, name, github, ref string) (path
 
 // EnsureChannel ensures the channel is present under stateDir/channels/<name>/,
 // resolves ref, clones and builds, updates channels.lock, and returns the path to the binary.
-func EnsureChannel(ctx context.Context, stateDir, name, github, ref string) (path string, err error) {
+// When cache is true the lock file is consulted and a matching entry is reused; when false the channel is always rebuilt.
+func EnsureChannel(ctx context.Context, stateDir, name, github, ref string, cache bool) (path string, err error) {
 	if github == "" || ref == "" {
 		return "", fmt.Errorf("github and ref are required")
 	}
@@ -454,14 +458,16 @@ func EnsureChannel(ctx context.Context, stateDir, name, github, ref string) (pat
 		return "", err
 	}
 
-	entry, locked := lock.Channels[name]
-	if locked && entry.GitHub == github && entry.Ref == ref && entry.Resolved != "" && entry.Path != "" {
-		absPath := entry.Path
-		if !filepath.IsAbs(absPath) {
-			absPath = filepath.Join(stateDir, entry.Path)
-		}
-		if _, err := os.Stat(absPath); err == nil {
-			return absPath, nil
+	if cache {
+		entry, locked := lock.Channels[name]
+		if locked && entry.GitHub == github && entry.Ref == ref && entry.Resolved != "" && entry.Path != "" {
+			absPath := entry.Path
+			if !filepath.IsAbs(absPath) {
+				absPath = filepath.Join(stateDir, entry.Path)
+			}
+			if _, err := os.Stat(absPath); err == nil {
+				return absPath, nil
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,10 +245,11 @@ type LogConfig struct {
 
 type PluginConfig struct {
 	Enabled     bool                   `yaml:"enabled"`
-	Insecure    *bool                  `yaml:"insecure"` // if true or omitted (default), preparer cannot run invoke; if false (trusted), can invoke
-	Plugin      string                 `yaml:"plugin"`   // path to binary or grpc://... (optional if github is set)
-	GitHub      string                 `yaml:"github"`   // e.g. "owner/repo" (bundler-style)
-	Ref         string                 `yaml:"ref"`      // branch, tag, or commit; resolved and pinned in plugins.lock
+	Cache       bool                   `yaml:"cache,omitempty"` // when true, reuse cached binary from plugins.lock (default false = always rebuild)
+	Insecure    *bool                  `yaml:"insecure"`        // if true or omitted (default), preparer cannot run invoke; if false (trusted), can invoke
+	Plugin      string                 `yaml:"plugin"`          // path to binary or grpc://... (optional if github is set)
+	GitHub      string                 `yaml:"github"`          // e.g. "owner/repo" (bundler-style)
+	Ref         string                 `yaml:"ref"`             // branch, tag, or commit; resolved and pinned in plugins.lock
 	Config      map[string]interface{} `yaml:"config,omitempty"`
 	DBAccess    bool                   `yaml:"db_access,omitempty"`    // opt-in: inject state-store credentials into plugin config
 	DialTimeout string                 `yaml:"dial_timeout,omitempty"` // e.g. "30s"; overrides the default 5s gRPC init timeout
@@ -274,9 +275,10 @@ type JobConfig struct {
 
 type ChannelConfig struct {
 	Enabled bool                   `yaml:"enabled"`
-	Plugin  string                 `yaml:"plugin"` // path to binary or grpc://... (optional if github is set)
-	GitHub  string                 `yaml:"github"` // e.g. "opentalon/slack-channel" (bundler-style)
-	Ref     string                 `yaml:"ref"`    // branch, tag, or commit; pinned in channels.lock
+	Cache   bool                   `yaml:"cache,omitempty"` // when true, reuse cached binary from channels.lock (default false = always rebuild)
+	Plugin  string                 `yaml:"plugin"`          // path to binary or grpc://... (optional if github is set)
+	GitHub  string                 `yaml:"github"`          // e.g. "opentalon/slack-channel" (bundler-style)
+	Ref     string                 `yaml:"ref"`             // branch, tag, or commit; pinned in channels.lock
 	Config  map[string]interface{} `yaml:"config"`
 }
 
@@ -406,6 +408,7 @@ type DBConfig struct {
 // SessionConfig limits session size and optional idle pruning.
 type SessionConfig struct {
 	MaxMessages             int    `yaml:"max_messages"`               // cap messages per session (0 = no cap)
+	ContextMessages         int    `yaml:"context_messages"`           // send only last N messages to LLM (0 = all; default 0)
 	MaxIdleDays             int    `yaml:"max_idle_days"`              // delete sessions not updated in N days (0 = don't prune)
 	SummarizeAfter          int    `yaml:"summarize_after_messages"`   // run summarization after N messages (0 = off)
 	MaxMessagesAfterSummary int    `yaml:"max_messages_after_summary"` // keep this many messages after summarization

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -139,6 +139,7 @@ type OrchestratorOpts struct {
 	PermissionPluginName    string
 	RuntimePromptPath       string                        // optional path to editable prompt file (e.g. data_dir/custom_prompt.txt); appended to system prompt
 	ContextArgProviders     map[string]ContextArgProvider // optional; if nil, default providers (e.g. session_id) are used
+	ContextMessages         int                           // send only last N messages to LLM (0 = all)
 	SummarizeAfterMessages  int                           // 0 = off
 	MaxMessagesAfterSummary int                           // keep this many messages after summarization
 	SummarizePrompt         string                        // empty = default English
@@ -206,6 +207,7 @@ type Orchestrator struct {
 	permissionPluginName    string                        // name of the permission plugin (skip permission check when executing it)
 	runtimePromptPath       string                        // optional; if set, buildSystemPrompt appends file contents
 	contextArgProviders     map[string]ContextArgProvider // name -> extract from context; used to inject args per action
+	contextMessages         int                           // send only last N messages to LLM (0 = all)
 	summarizeAfterMessages  int                           // 0 = off; after this many messages run summarization
 	maxMessagesAfterSummary int                           // keep this many messages after summarization
 	summarizePrompt         string                        // system prompt for initial summarization (config; empty = default English)
@@ -338,6 +340,7 @@ func NewWithRules(
 		permissionChecker:       opts.PermissionChecker,
 		permissionPluginName:    opts.PermissionPluginName,
 		runtimePromptPath:       opts.RuntimePromptPath,
+		contextMessages:         opts.ContextMessages,
 		summarizeAfterMessages:  opts.SummarizeAfterMessages,
 		maxMessagesAfterSummary: opts.MaxMessagesAfterSummary,
 		summarizePrompt:         opts.SummarizePrompt,
@@ -2704,6 +2707,13 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 			Content: "Previous conversation summary: " + sess.Summary,
 		})
 	}
+	// When context_messages is set, keep only the last N messages to avoid
+	// blowing the context window. This is a simple sliding window that
+	// preserves tool results (unlike LLM summarization which loses them).
+	convMessages := sess.Messages
+	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
+		convMessages = convMessages[len(convMessages)-o.contextMessages:]
+	}
 	// Strip [knowledge_context] from ALL user messages including the current turn.
 	// Server instructions are already in the system prompt via SystemPromptAddition,
 	// and the preparer's knowledge_context duplicates them. Stripping all turns
@@ -2712,7 +2722,7 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	// Also sanitize poisoned assistant messages from session history: remove
 	// hallucinated template variables and narrated tool calls that were saved
 	// before detection was in place. These teach the LLM bad patterns.
-	messages = appendStrippingAllKC(messages, sanitizeHistory(sess.Messages))
+	messages = appendStrippingAllKC(messages, sanitizeHistory(convMessages))
 
 	// For weaker / OSS models that tend to ignore system-prompt formatting
 	// instructions, repeat the channel format hint as a trailing system
@@ -2721,7 +2731,7 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	// round — the OUTPUT FORMAT section in the system prompt is sufficient
 	// there. Once tool results are present the model switches to answer
 	// mode and benefits from the nudge.
-	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(sess.Messages) {
+	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
 		messages = append(messages, provider.Message{
 			Role:    provider.RoleSystem,
 			Content: "[IMPORTANT — output format reminder] " + hint,
@@ -2731,7 +2741,7 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	// Only inject the "don't repeat" reminder when there's actual prior
 	// conversation (at least one assistant reply). On the first turn there's
 	// nothing to repeat.
-	if len(sess.Messages) > 2 {
+	if len(convMessages) > 2 {
 		messages = append(messages, provider.Message{
 			Role:    provider.RoleSystem,
 			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
@@ -2760,9 +2770,13 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 			Content: "Previous conversation summary: " + sess.Summary,
 		})
 	}
-	messages = appendStrippingAllKC(messages, sanitizeHistory(sess.Messages))
+	convMessages := sess.Messages
+	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
+		convMessages = convMessages[len(convMessages)-o.contextMessages:]
+	}
+	messages = appendStrippingAllKC(messages, sanitizeHistory(convMessages))
 
-	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(sess.Messages) {
+	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
 		messages = append(messages, provider.Message{
 			Role:    provider.RoleSystem,
 			Content: "[IMPORTANT — output format reminder] " + hint,
@@ -2775,7 +2789,7 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 	// Only inject the "don't repeat" reminder when there's actual prior
 	// conversation (at least one assistant reply). On the first turn there's
 	// nothing to repeat.
-	if len(sess.Messages) > 2 {
+	if len(convMessages) > 2 {
 		messages = append(messages, provider.Message{
 			Role:    provider.RoleSystem,
 			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",


### PR DESCRIPTION
## Summary
- **context_messages**: new session config (`context_messages: N`) sends only the last N messages to the LLM instead of the full history — simple sliding window that preserves tool results (unlike LLM summarization which loses them)
- **summarization default off**: `summarize_after_messages` now defaults to `0` (off) instead of `5`; opt-in via config
- **bundle cache config**: new `cache: bool` field on plugin and channel configs (default `false`); when false, GitHub-sourced plugins/channels are always re-cloned and rebuilt on startup instead of reusing the lock file entry

## Test plan
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] Build succeeds (`go build ./cmd/opentalon/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)