### PR TITLE
fix(commands): clear_session must preserve session identity

### DIFF
--- a/internal/commands/executor.go
+++ b/internal/commands/executor.go
@@ -475,11 +475,14 @@ func (e *Executor) clearSession(ctx context.Context, call orchestrator.ToolCall)
 	if sessionID == "" {
 		return orchestrator.ToolResult{CallID: call.ID, Error: "session_id not set (internal error)"}
 	}
-	// TODO: If the orchestrator maintains pending pipeline state per session, it should be cleared here (e.g. via a ClearSession hook).
-	if err := e.sessions.Delete(sessionID); err != nil {
-		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("delete session: %v", err)}
+	// Drop messages + summary in one transaction. The session row itself
+	// stays (entity_id, group_id, active_model, metadata preserved), and
+	// session_events is untouched — see SessionStoreInterface.ClearMessages.
+	// TODO: If the orchestrator maintains pending pipeline state per
+	// session, it should be cleared here too (e.g. via a ClearSession hook).
+	if err := e.sessions.ClearMessages(sessionID); err != nil {
+		return orchestrator.ToolResult{CallID: call.ID, Error: fmt.Sprintf("clear session: %v", err)}
 	}
-	e.sessions.Create(sessionID, "", "")
 
 	// Run configured on-clear plugin actions (e.g. weaviate refresh).
 	if e.runAction != nil {

--- a/internal/commands/executor_test.go
+++ b/internal/commands/executor_test.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"context"
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/config"
 	"github.com/opentalon/opentalon/internal/orchestrator"
+	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/state"
 )
 
@@ -89,6 +91,73 @@ func TestExecutor_SetPrompt_LengthLimit(t *testing.T) {
 	res := e.setPrompt(orchestrator.ToolCall{ID: "1", Args: map[string]string{"text": string(big)}})
 	if res.Error == "" {
 		t.Error("setPrompt with oversized text: expected Error")
+	}
+}
+
+// TestExecutor_ClearSession_PreservesIdentity is the executor-level regression
+// guard for the entity-stripping bug. The pre-fix handler did
+// sessions.Delete(id) + sessions.Create(id, "", "") which dropped the row's
+// identity fields and reset CreatedAt. The fix routes through ClearMessages,
+// which leaves the row intact. CreatedAt is the most accessible canary at
+// this layer (the in-memory Session struct does not project entity_id /
+// group_id — those live only on the DB-backed store; see
+// internal/state/store/session_test.go for the SQL-level assertion).
+func TestExecutor_ClearSession_PreservesIdentity(t *testing.T) {
+	reg := orchestrator.NewToolRegistry()
+	sessions := state.NewSessionStore("")
+	e := NewExecutor(reg, sessions, "", nil, "")
+
+	const sid = "sess-clear-id"
+	sess := sessions.Create(sid, "ent-X", "grp-Y")
+	sess.Metadata["debug"] = "true"
+	_ = sessions.SetModel(sid, "anthropic/claude-sonnet-4")
+	_ = sessions.AddMessage(sid, provider.Message{Role: provider.RoleUser, Content: "Hello"})
+	_ = sessions.AddMessage(sid, provider.Message{Role: provider.RoleAssistant, Content: "Hi"})
+	createdAt := sess.CreatedAt
+
+	res := e.clearSession(context.Background(), orchestrator.ToolCall{
+		ID:   "call-clr",
+		Args: map[string]string{"session_id": sid},
+	})
+	if res.Error != "" {
+		t.Fatalf("clearSession returned error: %q", res.Error)
+	}
+	if res.CallID != "call-clr" {
+		t.Errorf("CallID = %q, want call-clr", res.CallID)
+	}
+
+	got, err := sessions.Get(sid)
+	if err != nil {
+		t.Fatalf("session vanished after clear: %v", err)
+	}
+	if len(got.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0", len(got.Messages))
+	}
+	if got.Summary != "" {
+		t.Errorf("Summary = %q, want empty", got.Summary)
+	}
+	if got.ActiveModel != "anthropic/claude-sonnet-4" {
+		t.Errorf("ActiveModel = %q, want preserved", got.ActiveModel)
+	}
+	if got.Metadata["debug"] != "true" {
+		t.Errorf("Metadata[debug] = %q, want preserved", got.Metadata["debug"])
+	}
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt changed: was %v, now %v (the Delete+Create bug would reset this)", createdAt, got.CreatedAt)
+	}
+}
+
+func TestExecutor_ClearSession_MissingSessionID(t *testing.T) {
+	reg := orchestrator.NewToolRegistry()
+	sessions := state.NewSessionStore("")
+	e := NewExecutor(reg, sessions, "", nil, "")
+
+	res := e.clearSession(context.Background(), orchestrator.ToolCall{
+		ID:   "call-1",
+		Args: map[string]string{}, // no session_id
+	})
+	if res.Error == "" {
+		t.Errorf("clearSession with empty session_id: expected Error, got Content=%q", res.Content)
 	}
 }
 

--- a/internal/orchestrator/cached_session.go
+++ b/internal/orchestrator/cached_session.go
@@ -89,6 +89,13 @@ func (c *cachedSessionStore) SetSummary(id string, summary string, messages []pr
 	return nil
 }
 
+func (c *cachedSessionStore) ClearMessages(id string) error {
+	// Drop cache entry so the next Get reloads the cleared state from the
+	// inner store (messages emptied, summary cleared, identity preserved).
+	delete(c.cache, id)
+	return c.inner.ClearMessages(id)
+}
+
 func (c *cachedSessionStore) Delete(id string) error {
 	delete(c.cache, id)
 	return c.inner.Delete(id)

--- a/internal/orchestrator/cached_session_test.go
+++ b/internal/orchestrator/cached_session_test.go
@@ -80,6 +80,16 @@ func (s *stubSessionStore) SetMetadata(id, key, value string) error {
 	return nil
 }
 
+func (s *stubSessionStore) ClearMessages(id string) error {
+	sess := s.sessions[id]
+	if sess == nil {
+		return &sessionNotFoundError{id}
+	}
+	sess.Messages = nil
+	sess.Summary = ""
+	return nil
+}
+
 func (s *stubSessionStore) Delete(id string) error {
 	delete(s.sessions, id)
 	return nil

--- a/internal/orchestrator/concurrency_test.go
+++ b/internal/orchestrator/concurrency_test.go
@@ -240,6 +240,9 @@ func (s *blockingSetSummaryStore) Get(id string) (*state.Session, error) { retur
 func (s *blockingSetSummaryStore) Create(id, entityID, groupID string) *state.Session {
 	return s.inner.Create(id, entityID, groupID)
 }
+func (s *blockingSetSummaryStore) ClearMessages(id string) error {
+	return s.inner.ClearMessages(id)
+}
 func (s *blockingSetSummaryStore) Delete(id string) error { return s.inner.Delete(id) }
 func (s *blockingSetSummaryStore) SetModel(id string, m provider.ModelRef) error {
 	return s.inner.SetModel(id, m)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -179,7 +179,13 @@ type SessionStoreInterface interface {
 	SetModel(id string, model provider.ModelRef) error
 	SetSummary(id string, summary string, messages []provider.Message) error // for summarization; optional, may be no-op
 	SetMetadata(id, key, value string) error                                 // upsert a single metadata key; empty value removes it
-	Delete(id string) error                                                  // remove session (e.g. for clear_session command)
+	// ClearMessages drops Messages and Summary; preserves EntityID, GroupID,
+	// ActiveModel, Metadata, and CreatedAt; bumps UpdatedAt. The audit log
+	// (session_events) is untouched. Missing id is a no-op — destructive
+	// operations on this interface are idempotent. Used by the clear_session
+	// command to reset LLM context without losing the session's identity.
+	ClearMessages(id string) error
+	Delete(id string) error // remove session entirely (admin / retention; missing id no-op)
 }
 
 // sessionMutex is a per-session lock with reference counting for cleanup.

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -126,6 +126,24 @@ func (s *SessionStore) SetSummary(id string, summary string, messages []provider
 	return nil
 }
 
+// ClearMessages drops the conversation history of a session — messages and
+// the derived summary — while leaving the session row intact (ID, identity
+// fields, ActiveModel, Metadata, CreatedAt). Used by the clear_session
+// command to reset the LLM context without losing entity/group association
+// or audit events. No-op if the session is not present.
+func (s *SessionStore) ClearMessages(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return nil
+	}
+	sess.Messages = make([]provider.Message, 0)
+	sess.Summary = ""
+	sess.UpdatedAt = time.Now()
+	return nil
+}
+
 func (s *SessionStore) Delete(id string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/state/session_test.go
+++ b/internal/state/session_test.go
@@ -86,6 +86,48 @@ func TestSessionDelete(t *testing.T) {
 	}
 }
 
+func TestSessionClearMessagesPreservesIdentity(t *testing.T) {
+	store := NewSessionStore("")
+	sess := store.Create("sess1", "", "")
+	sess.Metadata["debug"] = "true"
+	_ = store.SetModel("sess1", "anthropic/claude-sonnet-4")
+	_ = store.AddMessage("sess1", provider.Message{Role: provider.RoleUser, Content: "Hello"})
+	_ = store.AddMessage("sess1", provider.Message{Role: provider.RoleAssistant, Content: "Hi"})
+	_ = store.SetSummary("sess1", "prior summary", []provider.Message{{Role: provider.RoleUser, Content: "kept"}})
+	createdAt := sess.CreatedAt
+
+	if err := store.ClearMessages("sess1"); err != nil {
+		t.Fatalf("ClearMessages: %v", err)
+	}
+
+	got, err := store.Get("sess1")
+	if err != nil {
+		t.Fatalf("session disappeared after clear: %v", err)
+	}
+	if len(got.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0", len(got.Messages))
+	}
+	if got.Summary != "" {
+		t.Errorf("Summary = %q, want empty", got.Summary)
+	}
+	if got.ActiveModel != "anthropic/claude-sonnet-4" {
+		t.Errorf("ActiveModel = %q, want preserved", got.ActiveModel)
+	}
+	if got.Metadata["debug"] != "true" {
+		t.Errorf("Metadata[debug] = %q, want preserved", got.Metadata["debug"])
+	}
+	if !got.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt changed: was %v, now %v", createdAt, got.CreatedAt)
+	}
+}
+
+func TestSessionClearMessagesUnknownSessionIsNoOp(t *testing.T) {
+	store := NewSessionStore("")
+	if err := store.ClearMessages("ghost"); err != nil {
+		t.Errorf("ClearMessages on unknown id should be a no-op, got: %v", err)
+	}
+}
+
 func TestSessionList(t *testing.T) {
 	store := NewSessionStore("")
 	store.Create("a", "", "")

--- a/internal/state/store/session.go
+++ b/internal/state/store/session.go
@@ -258,6 +258,35 @@ func (s *SessionStore) List() ([]string, error) {
 	return ids, rows.Err()
 }
 
+// ClearMessages drops the conversation history of a session — messages and
+// the derived summary — atomically. The session row itself stays (entity_id,
+// group_id, active_model, metadata, created_at all preserved), and the
+// session_events audit log is untouched. Used by the clear_session command
+// so /clear resets LLM context without orphaning the session's identity or
+// erasing telemetry.
+func (s *SessionStore) ClearMessages(id string) error {
+	ctx := context.Background()
+	d := s.db.Dialect()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	tx, err := s.db.SQLDB().BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("clear messages begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		d.Rebind(`DELETE FROM messages WHERE session_id = ?`), id); err != nil {
+		return fmt.Errorf("clear messages delete: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		d.Rebind(`UPDATE sessions SET summary = '', updated_at = ? WHERE id = ?`),
+		now, id); err != nil {
+		return fmt.Errorf("clear messages update: %w", err)
+	}
+	return tx.Commit()
+}
+
 // Delete removes a session and its messages.
 func (s *SessionStore) Delete(id string) error {
 	d := s.db.Dialect()

--- a/internal/state/store/session_test.go
+++ b/internal/state/store/session_test.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// TestSessionStore_ClearMessagesPreservesIdentityAndEvents verifies the
+// contract of the clear_session command after the entity-stripping fix:
+// the conversation history (messages + summary) is wiped, but the session
+// row itself — including entity_id, group_id, active_model, metadata, and
+// created_at — survives. session_events should also not be touched.
+func TestSessionStore_ClearMessagesPreservesIdentityAndEvents(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionStore(db, 0, 0)
+
+	const sid = "sess-clear"
+	store.Create(sid, "entity-X", "group-Y")
+
+	if err := store.AddMessage(sid, provider.Message{Role: provider.RoleUser, Content: "first"}); err != nil {
+		t.Fatalf("AddMessage[1]: %v", err)
+	}
+	if err := store.AddMessage(sid, provider.Message{Role: provider.RoleAssistant, Content: "reply"}); err != nil {
+		t.Fatalf("AddMessage[2]: %v", err)
+	}
+	if err := store.SetModel(sid, "anthropic/claude-sonnet-4"); err != nil {
+		t.Fatalf("SetModel: %v", err)
+	}
+	if err := store.SetMetadata(sid, "debug", "true"); err != nil {
+		t.Fatalf("SetMetadata: %v", err)
+	}
+	if err := store.SetSummary(sid, "prior summary", []provider.Message{
+		{Role: provider.RoleUser, Content: "summary-anchor"},
+	}); err != nil {
+		t.Fatalf("SetSummary: %v", err)
+	}
+
+	// Seed the audit log — ClearMessages must NOT touch session_events.
+	// This guards against a future refactor that accidentally also wipes
+	// the audit trail (Issue #244 policy bullet 3).
+	eventStore := NewSessionEventStore(db)
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if err := eventStore.Insert(ctx, SessionEvent{
+			SessionID: sid,
+			EventType: events.TypeUserMessage,
+			Payload: payloadJSON(t, events.UserMessagePayload{
+				Header: events.Header{V: 1}, Content: "hi", ContentLength: 2,
+			}),
+		}); err != nil {
+			t.Fatalf("seed event[%d]: %v", i, err)
+		}
+	}
+	eventsBefore, err := eventStore.ListForSession(ctx, sid, 0, 0)
+	if err != nil {
+		t.Fatalf("ListForSession before clear: %v", err)
+	}
+	if len(eventsBefore) != 3 {
+		t.Fatalf("seeded %d events, got %d back", 3, len(eventsBefore))
+	}
+
+	before, err := store.Get(sid)
+	if err != nil {
+		t.Fatalf("Get before clear: %v", err)
+	}
+	createdAt := before.CreatedAt
+
+	if err := store.ClearMessages(sid); err != nil {
+		t.Fatalf("ClearMessages: %v", err)
+	}
+
+	after, err := store.Get(sid)
+	if err != nil {
+		t.Fatalf("Get after clear (session row should still exist): %v", err)
+	}
+	if len(after.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0 (history should be dropped)", len(after.Messages))
+	}
+	if after.Summary != "" {
+		t.Errorf("Summary = %q, want empty (summary is derived from messages)", after.Summary)
+	}
+	if after.ActiveModel != "anthropic/claude-sonnet-4" {
+		t.Errorf("ActiveModel = %q, want preserved", after.ActiveModel)
+	}
+	if after.Metadata["debug"] != "true" {
+		t.Errorf("Metadata[debug] = %q, want preserved", after.Metadata["debug"])
+	}
+	if !after.CreatedAt.Equal(createdAt) {
+		t.Errorf("CreatedAt changed: was %v, now %v (session identity must not move)", createdAt, after.CreatedAt)
+	}
+
+	// Verify the row still carries the original entity/group association.
+	// (Get does not project entity_id/group_id, so query the raw column.)
+	d := db.Dialect()
+	var entityID, groupID string
+	if err := db.SQLDB().QueryRow(
+		d.Rebind(`SELECT entity_id, group_id FROM sessions WHERE id = ?`), sid,
+	).Scan(&entityID, &groupID); err != nil {
+		t.Fatalf("query session row: %v", err)
+	}
+	if entityID != "entity-X" {
+		t.Errorf("entity_id = %q, want entity-X — the original entity-stripping bug", entityID)
+	}
+	if groupID != "group-Y" {
+		t.Errorf("group_id = %q, want group-Y — the original entity-stripping bug", groupID)
+	}
+
+	// session_events must survive — clearing the conversation history is a
+	// context-management op, not an audit-log erasure (Issue #244 policy).
+	eventsAfter, err := eventStore.ListForSession(ctx, sid, 0, 0)
+	if err != nil {
+		t.Fatalf("ListForSession after clear: %v", err)
+	}
+	if len(eventsAfter) != len(eventsBefore) {
+		t.Errorf("session_events len = %d after clear, want %d (audit trail must survive)",
+			len(eventsAfter), len(eventsBefore))
+	}
+}
+
+// TestSessionStore_ClearMessagesIsIdempotent verifies a second ClearMessages
+// on an already-empty session is harmless.
+func TestSessionStore_ClearMessagesIsIdempotent(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionStore(db, 0, 0)
+
+	const sid = "sess-empty"
+	store.Create(sid, "entity-X", "group-Y")
+
+	if err := store.ClearMessages(sid); err != nil {
+		t.Fatalf("first ClearMessages: %v", err)
+	}
+	if err := store.ClearMessages(sid); err != nil {
+		t.Fatalf("second ClearMessages: %v", err)
+	}
+	after, err := store.Get(sid)
+	if err != nil {
+		t.Fatalf("Get after double clear: %v", err)
+	}
+	if len(after.Messages) != 0 {
+		t.Errorf("Messages len = %d, want 0", len(after.Messages))
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #244. The `/clear` slash command (action `clear_session`) used to do
`sessions.Delete(id) + sessions.Create(id, "", "")`, which dropped the
`sessions` row's `entity_id`, `group_id`, `active_model`, `metadata`, and
reset `created_at`. New events stamped on the cleared session inherited the
nulled identity, so any consumer filtering by `entity_id` or `group_id`
silently lost visibility — costs, audit, per-tenant UIs all under-attributed.

The fix replaces the delete-and-recreate dance with a new
`SessionStoreInterface` method:

```go
ClearMessages(id string) error
```

which, in a single transaction, drops the `messages` rows and clears the
`summary` column for the session while leaving the `sessions` row untouched.
The audit log (`session_events`) is **not** touched — `/clear` is a
context-management operation, not a data-erasure operation. Separate
concerns deserve separate APIs.

## Policy after this PR

- `messages` rows: **deleted**
- `sessions` row: **untouched** (identity preserved — `entity_id`, `group_id`,
  `active_model`, `metadata`, `created_at`)
- `session_events` rows: **untouched** (audit trail preserved)

Data erasure (e.g. GDPR-style "delete my history") is intentionally **not**
in scope of `/clear`. That requires a separate, explicit admin/compliance
path.

## Why a new method, not a `Reset(id)`-style patch

A read-before-create patch in `clearSession` (Get → Delete → Create with
preserved fields) still has a race window between Delete and Create during
which the row does not exist, and it forces every future column added to
`sessions` to be re-passed at the call site. A first-class store method
that only touches the messages preserves identity structurally, scales to
new columns automatically, and is one transaction with no gap.

## Implementation

| File | Change |
| --- | --- |
| `internal/orchestrator/orchestrator.go` | `+ClearMessages(id) error` on `SessionStoreInterface`, enumerating the preserved fields in the doc comment. |
| `internal/state/session.go` | In-memory impl: clears `Messages` + `Summary`, bumps `UpdatedAt`. Missing id is a no-op. |
| `internal/state/store/session.go` | DB impl: `BeginTx` + `DELETE FROM messages WHERE session_id=?` + `UPDATE sessions SET summary='', updated_at=? WHERE id=?` + `Commit`. Mirrors `SetSummary`. |
| `internal/orchestrator/cached_session.go` | Cache invalidation passthrough. |
| `internal/commands/executor.go` | `clearSession` becomes `sessions.ClearMessages(id)`. Identity-stripping `Create(id, "", "")` is gone. |
| Three `*_test.go` files updated for the new interface method. |

## Tests added

- `internal/state/store/session_test.go` (new file)
  - `TestSessionStore_ClearMessagesPreservesIdentityAndEvents` — seeds three
    `session_events` rows, calls `ClearMessages`, then asserts via raw SQL
    that `entity_id` and `group_id` survive on the `sessions` row **and**
    that the seeded `session_events` rows are still present. This is the
    direct regression guard for the bug reported in #244.
  - `TestSessionStore_ClearMessagesIsIdempotent` — second clear on an empty
    session is harmless.
- `internal/state/session_test.go`
  - `TestSessionClearMessagesPreservesIdentity` — in-memory equivalent.
  - `TestSessionClearMessagesUnknownSessionIsNoOp` — destructive idempotency.
- `internal/commands/executor_test.go`
  - `TestExecutor_ClearSession_PreservesIdentity` — executor-layer regression
    using `CreatedAt` as the canary (the old `Delete+Create` reset it; the
    new path preserves it).
  - `TestExecutor_ClearSession_MissingSessionID` — error path unchanged.

## Out of scope (follow-ups)

These came out of review but are pre-existing and orthogonal:

- The `commands.Executor` holds the raw `o.sessions`, not the request-scoped
  `cachedSessionStore` built by `Orchestrator.Run`. `ClearMessages` calls
  therefore bypass the per-request cache. Pre-existing on every executor
  tool call, not specific to `/clear`; deserves its own design pass.
- `Orchestrator.pendingPipelines` / `pendingToolCalls` /
  `pendingConfirmationIDs` are per-session in-memory maps not touched by
  `/clear`. Pre-existing TODO in `clearSession`.
- `DebugEventCounter.CountForSession`'s "events captured so far" wording
  now spans `/clear` boundaries (session id stays the same). Pre-existing
  wording; worth deciding whether the message should scope to "since last
  clear" or document the cumulative semantics explicitly.

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] All 6 new tests pass green; verified with `go test -run 'ClearSession|ClearMessages' -v`.
- [x] Manual verification on a live deployment: after `/clear`, a fresh
      turn writes new events that carry the original `entity_id` /
      `group_id`, and the `sessions` row keeps its identity columns.