### PR TITLE
feat(orchestrator): stamp sessions.active_model on first llm_response

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1583,6 +1583,15 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 
 		if modelUsed == "" {
 			modelUsed = resp.Model
+			// Stamp sessions.active_model with the model that produced the
+			// first response of this Run. Without this stamp the column is
+			// only ever written at Create (as ""), leaving downstream
+			// session-review tools to scrape model_id out of llm_request
+			// events. Fire-and-forget — a stale stamp is harmless and the
+			// active_model column is denormalised cache, not source of truth.
+			if resp.Model != "" {
+				_ = sessions.SetModel(sessionID, provider.ModelRef(resp.Model))
+			}
 		}
 		totalInputTokens += resp.Usage.InputTokens
 		totalOutputTokens += resp.Usage.OutputTokens


### PR DESCRIPTION
## Summary

The `sessions.active_model` column has been set to `""` at session Create and never written again. `SessionStore.SetModel` exists with full test coverage and is in the orchestrator's `SessionStoreInterface`, but no production caller ever invokes it — so the column is dead state. Downstream session-review tooling has to scrape `model_id` out of the most recent `llm_request` event instead of reading the column.

This wires the missing producer call.

## Change

In `Orchestrator.Run`, piggyback on the existing `if modelUsed == ""` guard so the stamp happens **at most once per Run** (matches `modelUsed`'s own semantic — first response of the Run wins). Fire-and-forget: `active_model` is denormalised cache (not source of truth), and a stale stamp is harmless. Empty-model and missing-sessionID edge cases skip the write.

\`\`\`go
if modelUsed == \"\" {
    modelUsed = resp.Model
    if resp.Model != \"\" {
        _ = sessions.SetModel(sessionID, provider.ModelRef(resp.Model))
    }
}
\`\`\`

9 LOC added, no signature or interface changes, no test changes needed (existing SessionStore.SetModel tests cover the persistence path).

## Test plan

- [x] \`go test ./internal/orchestrator/...\` passes (~17s)
- [x] Local e2e: fresh websocket-channel session that previously landed with \`active_model=\"\"\` now lands with the real model id (e.g. \"gpt-oss-120b\") on the first response (verified via psql)
- [ ] CI green