### PR TITLE
fix(orchestrator): preserve current-turn [knowledge_context]

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1106,7 +1106,10 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			MessageCount: 2,  // planner hardcodes system+user, see pipeline.Planner.Plan
 		})
 		plannerStart := time.Now()
-		planResult, err := o.planner.Plan(plannerCtx, stripKnowledgeContext(content), capabilitiesToPlannerInfo(plannerCaps), convContext)
+		// Pass the raw content (including any [knowledge_context] block the
+		// preparer injected for the current turn) so the planner sees the
+		// retrieved knowledge alongside the user's request.
+		planResult, err := o.planner.Plan(plannerCtx, content, capabilitiesToPlannerInfo(plannerCaps), convContext)
 		plannerLatency := time.Since(plannerStart).Milliseconds()
 		var plannerRaw string
 		if err != nil {
@@ -2729,15 +2732,17 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
 		convMessages = convMessages[len(convMessages)-o.contextMessages:]
 	}
-	// Strip [knowledge_context] from ALL user messages including the current turn.
-	// Server instructions are already in the system prompt via SystemPromptAddition,
-	// and the preparer's knowledge_context duplicates them. Stripping all turns
-	// prevents both per-turn duplication and redundancy with the system prompt.
+	// Strip [knowledge_context] from HISTORICAL user messages only. The
+	// current turn's user message is preserved verbatim so preparer-injected
+	// RAG content actually reaches the LLM. Historical turns are still
+	// stripped to avoid per-turn accumulation and redundancy with the
+	// system prompt (server-instruction articles are already filtered out
+	// plugin-side via filterOutMCPItems).
 	//
 	// Also sanitize poisoned assistant messages from session history: remove
 	// hallucinated template variables and narrated tool calls that were saved
 	// before detection was in place. These teach the LLM bad patterns.
-	messages = appendStrippingAllKC(messages, sanitizeHistory(convMessages))
+	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
 
 	// For weaker / OSS models that tend to ignore system-prompt formatting
 	// instructions, repeat the channel format hint as a trailing system
@@ -2789,7 +2794,7 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
 		convMessages = convMessages[len(convMessages)-o.contextMessages:]
 	}
-	messages = appendStrippingAllKC(messages, sanitizeHistory(convMessages))
+	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
 
 	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
 		messages = append(messages, provider.Message{
@@ -4043,23 +4048,48 @@ func (a *plannerLLMAdapter) Complete(ctx context.Context, req *pipeline.Completi
 }
 
 // capabilitiesToPlannerInfo converts orchestrator PluginCapability to pipeline CapabilityInfo.
-// appendStrippingAllKC appends session messages to dst, stripping
-// [knowledge_context] blocks from every user message. Server instructions
-// are already in the system prompt via SystemPromptAddition, so the
-// preparer-injected knowledge_context is redundant. Stripping all turns
-// prevents both historical accumulation and current-turn duplication.
+// appendStrippingHistoricalKC appends session messages to dst, stripping
+// [knowledge_context] blocks from historical user messages but preserving
+// the current turn's user message intact so preparer-injected RAG content
+// reaches the LLM. The current turn is identified as the last user message
+// in the slice.
+//
+// Historical strip is still applied because past-turn [knowledge_context]
+// blocks would otherwise accumulate across turns and bloat the context
+// window. Server-instruction articles never appear here in the first place
+// — the weaviate-plugin filters them out via filterOutMCPItems before
+// injection.
 //
 // Also deduplicates knowledge article plugin outputs: when ask_knowledge
 // returns the same MCP server instructions block repeatedly (~5KB each),
 // subsequent occurrences are replaced with a short stub to save context.
-func appendStrippingAllKC(dst []provider.Message, msgs []provider.Message) []provider.Message {
+// Dedup applies to all user messages including the current turn.
+func appendStrippingHistoricalKC(dst []provider.Message, msgs []provider.Message) []provider.Message {
 	seenKnowledge := make(map[uint64]bool)
 	seenToolResults := make(map[uint64]bool)
-	for _, m := range msgs {
+	// Identify the current-turn user message. Native-tools mode stores tool
+	// results as RoleTool, so the last RoleUser is always the real user
+	// question. Text-tools mode wraps tool results as RoleUser with a
+	// "[plugin_output]" prefix; skip those so we land on the actual user
+	// message that the preparer enriched with [knowledge_context].
+	lastUserIdx := -1
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i].Role != provider.RoleUser {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(msgs[i].Content), "[plugin_output]") {
+			continue
+		}
+		lastUserIdx = i
+		break
+	}
+	for i, m := range msgs {
 		if m.Role == provider.RoleUser {
-			stripped := stripKnowledgeContext(m.Content)
-			if stripped != m.Content {
-				m = provider.Message{Role: m.Role, Content: stripped, Files: m.Files}
+			if i != lastUserIdx {
+				stripped := stripKnowledgeContext(m.Content)
+				if stripped != m.Content {
+					m = provider.Message{Role: m.Role, Content: stripped, Files: m.Files}
+				}
 			}
 			// Deduplicate knowledge article plugin outputs.
 			m = deduplicateKnowledgeOutput(m, seenKnowledge)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3503,7 +3503,7 @@ func TestDeduplicateKnowledgeOutput(t *testing.T) {
 	}
 
 	var dst []provider.Message
-	deduped := appendStrippingAllKC(dst, msgs)
+	deduped := appendStrippingHistoricalKC(dst, msgs)
 
 	// First knowledge output should be preserved.
 	if !strings.Contains(deduped[2].Content, "## Knowledge Articles") {
@@ -3524,5 +3524,101 @@ func TestDeduplicateKnowledgeOutput(t *testing.T) {
 	// Non-knowledge plugin outputs should be untouched.
 	if !strings.Contains(deduped[4].Content, "Items: 370 total") {
 		t.Error("non-knowledge plugin output should be preserved")
+	}
+}
+
+func TestAppendStrippingHistoricalKC_PreservesCurrentTurn(t *testing.T) {
+	const kcBlock = "[knowledge_context]\n## Article: Onboarding\nbody text here\n[/knowledge_context]\n"
+	historicalUser := kcBlock + "old question"
+	currentUser := kcBlock + "new question"
+
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: historicalUser},
+		{Role: provider.RoleAssistant, Content: "old answer"},
+		{Role: provider.RoleUser, Content: currentUser},
+	}
+
+	out := appendStrippingHistoricalKC(nil, msgs)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(out))
+	}
+
+	if strings.Contains(out[0].Content, "[knowledge_context]") {
+		t.Errorf("historical user message should have KC stripped, got: %q", out[0].Content)
+	}
+	if !strings.Contains(out[0].Content, "old question") {
+		t.Errorf("historical user message should preserve user text, got: %q", out[0].Content)
+	}
+
+	if out[1].Content != "old answer" {
+		t.Errorf("assistant message should be untouched, got: %q", out[1].Content)
+	}
+
+	if !strings.Contains(out[2].Content, "[knowledge_context]") {
+		t.Errorf("current-turn user message must keep its [knowledge_context] block, got: %q", out[2].Content)
+	}
+	if !strings.Contains(out[2].Content, "## Article: Onboarding") {
+		t.Errorf("current-turn user message must keep the KC body, got: %q", out[2].Content)
+	}
+	if !strings.Contains(out[2].Content, "new question") {
+		t.Errorf("current-turn user message must keep the user's actual question, got: %q", out[2].Content)
+	}
+}
+
+func TestAppendStrippingHistoricalKC_SingleUserTurnPreserved(t *testing.T) {
+	const kcBlock = "[knowledge_context]\nfirst-turn knowledge\n[/knowledge_context]\n"
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleUser, Content: kcBlock + "hello"},
+	}
+
+	out := appendStrippingHistoricalKC(nil, msgs)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(out))
+	}
+	if !strings.Contains(out[1].Content, "[knowledge_context]") {
+		t.Errorf("single user turn is the current turn and must keep its KC, got: %q", out[1].Content)
+	}
+}
+
+func TestAppendStrippingHistoricalKC_TextToolsLoopPreservesUserTurn(t *testing.T) {
+	// Text-tools mode: tool results are stored as RoleUser wrapped in
+	// [plugin_output]. After at least one tool round, the slice looks like
+	// [user_with_KC, assistant_call, user_tool_result]. The "current turn"
+	// for KC-preservation is still the original user_with_KC at index 0,
+	// not the tool-result echo at index 2.
+	const kcBlock = "[knowledge_context]\n## Article: Inventory rules\n[/knowledge_context]\n"
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: kcBlock + "list my items"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] inventory.list-items"},
+		{Role: provider.RoleUser, Content: "[plugin_output]\nItems: 42\n[/plugin_output]"},
+	}
+
+	out := appendStrippingHistoricalKC(nil, msgs)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(out))
+	}
+	if !strings.Contains(out[0].Content, "[knowledge_context]") {
+		t.Errorf("original user message must keep its KC even after a tool round, got: %q", out[0].Content)
+	}
+	if !strings.Contains(out[0].Content, "list my items") {
+		t.Errorf("original user message must keep its user text, got: %q", out[0].Content)
+	}
+	if !strings.Contains(out[2].Content, "[plugin_output]") {
+		t.Errorf("tool result envelope must be preserved, got: %q", out[2].Content)
+	}
+}
+
+func TestAppendStrippingHistoricalKC_NoUserMessages(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "system"},
+		{Role: provider.RoleAssistant, Content: "hi"},
+	}
+	out := appendStrippingHistoricalKC(nil, msgs)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(out))
+	}
+	if out[0].Content != "system" || out[1].Content != "hi" {
+		t.Errorf("non-user messages should pass through unchanged, got: %+v", out)
 	}
 }


### PR DESCRIPTION
## Summary

The orchestrator stripped `[knowledge_context]...[/knowledge_context]` blocks from every user message before any LLM call — including the **current turn's** freshly preparer-injected block. The preparer's retrieved knowledge therefore never reached any consumer (planner or agent loop); RAG ran on every turn but was a dead-letter LLM-side.

Closes #248.

## What changes

- `appendStrippingAllKC` → `appendStrippingHistoricalKC`: strips KC only from historical user messages, preserves the current turn (= last RoleUser in the slice) verbatim.
- Text-tools-mode tool-result wrappers are stored as `RoleUser` with a `[plugin_output]` prefix. The new logic skips those when locating the current turn so the real user question is preserved across agent-loop rounds.
- Drops the explicit `stripKnowledgeContext()` wrapper around `Plan()`'s `content` argument at `orchestrator.go:1109` — the planner now sees the same KC-enriched input as the agent loop.
- Dedup of large knowledge / tool-result blocks (`deduplicateKnowledgeOutput` / `deduplicateLargeToolResult`) is preserved; it operates on `[plugin_output]` blocks and is independent of KC stripping.

## Test plan

- `go vet ./internal/orchestrator/...` — clean
- `go test ./internal/orchestrator/...` — full suite green (17.5s)
- New unit tests in `appendStrippingHistoricalKC_*`:
  - `PreservesCurrentTurn` — historical user stripped, current preserved
  - `SingleUserTurnPreserved` — first turn is the current turn
  - `TextToolsLoopPreservesUserTurn` — original user_with_KC preserved when a `[plugin_output]` tool-result is the literal last `RoleUser`
  - `NoUserMessages` — pass-through
- E2E against a local stack (Weaviate + embedder + OpenTalon Core via console-channel) confirmed the LLM raw HTTP body now contains `[knowledge_context]` blocks in the current-turn user message; pre-fix that was 0.

## Out of scope (handled in the RFC)

Per #248 this is the narrow Phase 1 fix. The larger refactor (session-aware dedup, 3-tier tool visibility, comprehensive preparer-phase event instrumentation) is tracked in #249.