### PR TITLE
feat(orchestrator): RFC #249 Phases 2-4 — preparer instrumentation, session-aware knowledge dedup, 3-tier tool visibility + get_tool_details meta-tool

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -41,6 +41,14 @@ import (
 	chanpkg "github.com/opentalon/opentalon/pkg/channel"
 )
 
+// Compile-time assertion that the DB-backed SessionStore satisfies the
+// orchestrator's optional InjectionStateStore interface. Lives here
+// because neither the store package nor the orchestrator package can
+// reference the other without a cycle — main.go is the wiring point
+// where both are already imported, so it's the right place to pin the
+// contract. RFC #249 Phase 3.
+var _ orchestrator.InjectionStateStore = (*store.SessionStore)(nil)
+
 func main() {
 	fmt.Fprintln(os.Stderr, "OpenTalon starting...")
 	configPath := flag.String("config", "", "path to config file")
@@ -149,6 +157,12 @@ func main() {
 	var sessionEventStore *store.SessionEventStore
 	var sessionEventWriter *store.SessionEventWriter
 	var sessionEventsRetentionCancel context.CancelFunc
+	// injectionStateStore is the orchestrator-side handle for the
+	// RFC #249 Phase 3 dedup helpers — the DB-backed SessionStore
+	// satisfies it, the in-memory fallback does not. Stays nil when
+	// the state DB is unavailable; dedup decision logic short-circuits
+	// to instrumentation_only in that case.
+	var injectionStateStore orchestrator.InjectionStateStore
 	if dataDir != "" || cfg.State.DB.Driver == "postgres" {
 		db, err := store.Open(cfg.State.DB, dataDir)
 		if err != nil {
@@ -162,6 +176,7 @@ func main() {
 				slog.Warn("session prune failed", "error", err)
 			}
 			sessions = sessStore
+			injectionStateStore = sessStore
 			groupPluginStore = store.NewGroupPluginStore(db)
 			usageStore = store.NewUsageStore(db)
 			entityStore = store.NewEntityStore(db)
@@ -590,6 +605,17 @@ func main() {
 			Dir:    cfg.Orchestrator.Knowledge.Dir,
 		},
 		ShowToolCalls: cfg.Orchestrator.ShowToolCalls,
+		KnowledgeDedup: orchestrator.KnowledgeDedupConfig{
+			Enabled:                cfg.Orchestrator.Preparer.KnowledgeDedup.Enabled,
+			ReinjectScoreThreshold: cfg.Orchestrator.Preparer.KnowledgeDedup.ReinjectScoreThreshold,
+			ReinjectTopKForce:      cfg.Orchestrator.Preparer.KnowledgeDedup.ReinjectTopKForce,
+			CapPerTurn:             cfg.Orchestrator.Preparer.KnowledgeDedup.CapPerTurn,
+		},
+		// The DB-backed SessionStore satisfies InjectionStateStore via
+		// its GetInjectionState / UpdateInjectionState methods (Phase 3,
+		// migration 010). When state DB is not configured the variable
+		// stays nil and dedup short-circuits to instrumentation_only.
+		InjectionStateStore: injectionStateStore,
 		Subprocess: orchestrator.SubprocessConfig{
 			Enabled:       cfg.Orchestrator.Subprocess.Enabled,
 			MaxDepth:      cfg.Orchestrator.Subprocess.MaxDepth,

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -616,6 +616,16 @@ func main() {
 		// migration 010). When state DB is not configured the variable
 		// stays nil and dedup short-circuits to instrumentation_only.
 		InjectionStateStore: injectionStateStore,
+		ToolTiers: orchestrator.ToolTiersConfig{
+			Enabled:              cfg.Orchestrator.Preparer.ToolTiers.Enabled,
+			Tier1Cap:             cfg.Orchestrator.Preparer.ToolTiers.Tier1Cap,
+			Tier2Cap:             cfg.Orchestrator.Preparer.ToolTiers.Tier2Cap,
+			EnableGetToolDetails: cfg.Orchestrator.Preparer.ToolTiers.EnableGetToolDetails,
+		},
+		ToolErrorHandling: orchestrator.ToolErrorHandlingConfig{
+			LoopCapPerTurn:          cfg.Orchestrator.Preparer.ToolErrorHandling.LoopCapPerTurn,
+			StickyDemotionThreshold: cfg.Orchestrator.Preparer.ToolErrorHandling.StickyDemotionThreshold,
+		},
 		Subprocess: orchestrator.SubprocessConfig{
 			Enabled:       cfg.Orchestrator.Subprocess.Enabled,
 			MaxDepth:      cfg.Orchestrator.Subprocess.MaxDepth,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -102,6 +102,14 @@ orchestrator:
   #     reinject_score_threshold: 0.85       # current-turn score override against "already known"
   #     reinject_top_k_force: 3              # always re-inject top-N candidates regardless of known state
   #     cap_per_turn: 5                      # hard ceiling on delta knowledge articles injected per turn
+  #   tool_tiers:
+  #     enabled: false                       # master switch; false = pre-Phase-4 single-tier (all RAG-matched tools with full schemas)
+  #     tier1_cap: 10                        # max Tier-1 tools (full schemas in `tools`)
+  #     tier2_cap: 15                        # max Tier-2 tools (name + 1-line summary in system prompt)
+  #     enable_get_tool_details: false       # expose the get_tool_details meta-tool for LLM-driven Tier-3→Tier-1 promotion (implies enabled: true)
+  #   tool_error_handling:
+  #     loop_cap_per_turn: 2                 # consecutive identical-tool errors per turn before "tool X failed N times" system msg
+  #     sticky_demotion_threshold: 3         # consecutive session-level errors before known_tools demotion (self-healed on success)
 
 channels:
   console:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -93,6 +93,15 @@ orchestrator:
   #   plugin: weaviate                   # plugin for knowledge article ingestion
   #   action: ingest                     # action name for single-article ingestion
   #   dir: ./knowledge                   # optional: scan .md files at startup
+  # Preparer-phase behaviour (RFC #249). Phase 2 events fire regardless;
+  # the flags here gate the Phase 3+ decision logic. Each pillar can be
+  # rolled out independently for A/B comparison via the events log.
+  # preparer:
+  #   knowledge_dedup:
+  #     enabled: false                       # master switch; false = legacy per-turn re-inject + Phase 2 instrumentation only
+  #     reinject_score_threshold: 0.85       # current-turn score override against "already known"
+  #     reinject_top_k_force: 3              # always re-inject top-N candidates regardless of known state
+  #     cap_per_turn: 5                      # hard ceiling on delta knowledge articles injected per turn
 
 channels:
   console:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -331,13 +331,10 @@ type OrchestratorConfig struct {
 // behaviour flags. Each pillar (knowledge dedup, tool tiers, tool
 // error handling) is independently togglable so phases can be
 // A/B-tested in production without coupled rollout risk.
-//
-// Phase 3 wires KnowledgeDedup only; ToolTiers and ToolErrorHandling
-// land in Phase 4 and are intentionally absent from this struct until
-// then so the YAML surface stays in lock-step with what the orchestrator
-// actually reads.
 type PreparerOrchestratorConfig struct {
-	KnowledgeDedup KnowledgeDedupConfig `yaml:"knowledge_dedup,omitempty"`
+	KnowledgeDedup    KnowledgeDedupConfig    `yaml:"knowledge_dedup,omitempty"`
+	ToolTiers         ToolTiersConfig         `yaml:"tool_tiers,omitempty"`
+	ToolErrorHandling ToolErrorHandlingConfig `yaml:"tool_error_handling,omitempty"`
 }
 
 // KnowledgeDedupConfig configures the per-session content_sha-keyed
@@ -360,6 +357,41 @@ type KnowledgeDedupConfig struct {
 	ReinjectScoreThreshold float64 `yaml:"reinject_score_threshold,omitempty"` // default 0.85 when zero
 	ReinjectTopKForce      int     `yaml:"reinject_top_k_force,omitempty"`     // default 3 when zero
 	CapPerTurn             int     `yaml:"cap_per_turn,omitempty"`             // default 5 when zero
+}
+
+// ToolTiersConfig configures the per-turn three-tier tool visibility
+// model (RFC #249 Phase 4). Tier 0 holds always_include actions plus
+// the get_tool_details meta-tool with full schemas; Tier 1 holds the
+// RAG-top-K relevant tools (also with full schemas) capped at Tier1Cap
+// with LRU eviction; Tier 2 surfaces the next slice as name + one-line
+// summary in the system prompt; Tier 3 fans out the remaining tools as
+// names-only grouped by plugin. The get_tool_details meta-tool promotes
+// any Tier 2/3 tool back into Tier 1 on demand.
+//
+// EnableGetToolDetails toggles the meta-tool independently of the
+// master Enabled flag so a deployment can ship the tier rendering
+// without yet exposing the LLM-driven promotion path. Setting it true
+// implies Enabled=true at the orchestrator (see runtime normalization).
+type ToolTiersConfig struct {
+	Enabled              bool `yaml:"enabled"`                           // master switch; default false
+	Tier1Cap             int  `yaml:"tier1_cap,omitempty"`               // max Tier-1 tools with full schemas; default 10 when zero
+	Tier2Cap             int  `yaml:"tier2_cap,omitempty"`               // max Tier-2 tools surfaced as name + 1-line summary; default 15 when zero
+	EnableGetToolDetails bool `yaml:"enable_get_tool_details,omitempty"` // expose the get_tool_details meta-tool for Tier-3→Tier-1 promotion; default false
+}
+
+// ToolErrorHandlingConfig configures the runaway-tool-failure
+// protections from RFC #249 Phase 4. LoopCapPerTurn bounds how many
+// consecutive identical-tool errors the orchestrator tolerates in a
+// single turn before injecting a system message nudging the LLM toward
+// a different approach. StickyDemotionThreshold tracks consecutive
+// errors across the whole session and flips the tool's Demoted bit in
+// known_tools when the count crosses; a subsequent successful call
+// clears the flag (self-healing). Both fields default to the RFC
+// values via runtime normalization when zero so tests can leave the
+// struct empty.
+type ToolErrorHandlingConfig struct {
+	LoopCapPerTurn          int `yaml:"loop_cap_per_turn,omitempty"`         // consecutive identical-tool errors per turn before system-msg injection; default 2 when zero
+	StickyDemotionThreshold int `yaml:"sticky_demotion_threshold,omitempty"` // consecutive session-level errors before known_tools demotion; default 3 when zero
 }
 
 // PipelineOrchestratorConfig enables structured multi-step pipeline execution.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -324,6 +324,42 @@ type OrchestratorConfig struct {
 	Knowledge             KnowledgeConfig              `yaml:"knowledge,omitempty"`       // knowledge-augmented RAG configuration
 	Subprocess            SubprocessOrchestratorConfig `yaml:"subprocess,omitempty"`      // subprocess (sub-agent) support
 	ShowToolCalls         string                       `yaml:"show_tool_calls,omitempty"` // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	Preparer              PreparerOrchestratorConfig   `yaml:"preparer,omitempty"`        // RFC #249 preparer-phase behaviour (knowledge dedup, tool tiers, error handling)
+}
+
+// PreparerOrchestratorConfig groups the RFC #249 preparer-phase
+// behaviour flags. Each pillar (knowledge dedup, tool tiers, tool
+// error handling) is independently togglable so phases can be
+// A/B-tested in production without coupled rollout risk.
+//
+// Phase 3 wires KnowledgeDedup only; ToolTiers and ToolErrorHandling
+// land in Phase 4 and are intentionally absent from this struct until
+// then so the YAML surface stays in lock-step with what the orchestrator
+// actually reads.
+type PreparerOrchestratorConfig struct {
+	KnowledgeDedup KnowledgeDedupConfig `yaml:"knowledge_dedup,omitempty"`
+}
+
+// KnowledgeDedupConfig configures the per-session content_sha-keyed
+// knowledge dedup logic (RFC #249 Phase 3). When Enabled is false
+// (the safe default), the orchestrator falls through to the legacy
+// per-turn re-inject behaviour and only emits the Phase-2
+// instrumentation_only preparer_decision events.
+//
+// ReinjectScoreThreshold is the "bury defense" override: a knowledge
+// article already in known_knowledge is re-injected when the current
+// turn's score exceeds this value, on the theory that a strong current
+// match outweighs the cache-stable prefix concern. ReinjectTopKForce
+// is the floor: the top-N candidates of the current retrieval always
+// inject so the LLM never starves on truly relevant context. CapPerTurn
+// hard-bounds the delta size so a query that hits many candidates
+// can't tank the prompt budget — the dedup logic skips overflow
+// candidates with reason "cap_exceeded".
+type KnowledgeDedupConfig struct {
+	Enabled                bool    `yaml:"enabled"`                            // master switch; default false
+	ReinjectScoreThreshold float64 `yaml:"reinject_score_threshold,omitempty"` // default 0.85 when zero
+	ReinjectTopKForce      int     `yaml:"reinject_top_k_force,omitempty"`     // default 3 when zero
+	CapPerTurn             int     `yaml:"cap_per_turn,omitempty"`             // default 5 when zero
 }
 
 // PipelineOrchestratorConfig enables structured multi-step pipeline execution.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -990,3 +990,55 @@ health:
 		t.Errorf("Health.Addr = %q, want :7777", cfg.Health.Addr)
 	}
 }
+
+func TestParsePreparerKnowledgeDedup(t *testing.T) {
+	// Round-trips the RFC #249 Phase 3 YAML block: catches drift between
+	// the operator-facing key names and Go struct tags. The orchestrator-
+	// side normalization to RFC defaults is exercised separately under
+	// internal/orchestrator/knowledge_dedup_config_test.go — here we just
+	// verify the bytes-in / struct-out shape.
+	yaml := `
+orchestrator:
+  preparer:
+    knowledge_dedup:
+      enabled: true
+      reinject_score_threshold: 0.92
+      reinject_top_k_force: 4
+      cap_per_turn: 7
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Orchestrator.Preparer.KnowledgeDedup
+	if !got.Enabled {
+		t.Errorf("Enabled = false, want true")
+	}
+	if got.ReinjectScoreThreshold != 0.92 {
+		t.Errorf("ReinjectScoreThreshold = %v, want 0.92", got.ReinjectScoreThreshold)
+	}
+	if got.ReinjectTopKForce != 4 {
+		t.Errorf("ReinjectTopKForce = %d, want 4", got.ReinjectTopKForce)
+	}
+	if got.CapPerTurn != 7 {
+		t.Errorf("CapPerTurn = %d, want 7", got.CapPerTurn)
+	}
+}
+
+func TestParsePreparerKnowledgeDedupAbsentLeavesZeroValues(t *testing.T) {
+	// Confirms an absent `preparer:` block parses to the zero-valued
+	// struct so the orchestrator's default-normalization takes over.
+	// Regression guard against accidentally requiring the block.
+	yaml := `
+orchestrator:
+  rules: []
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Orchestrator.Preparer.KnowledgeDedup
+	if got.Enabled || got.ReinjectScoreThreshold != 0 || got.ReinjectTopKForce != 0 || got.CapPerTurn != 0 {
+		t.Errorf("absent preparer block must parse to zero KnowledgeDedupConfig, got %+v", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1042,3 +1042,84 @@ orchestrator:
 		t.Errorf("absent preparer block must parse to zero KnowledgeDedupConfig, got %+v", got)
 	}
 }
+
+func TestParsePreparerToolTiers(t *testing.T) {
+	// Same purpose as TestParsePreparerKnowledgeDedup but for the
+	// Phase-4 tier flags — verifies the operator-facing YAML keys
+	// match the Go struct tags, no more, no less. Default-normalization
+	// is exercised in internal/orchestrator/tool_tiers_config_test.go.
+	yaml := `
+orchestrator:
+  preparer:
+    tool_tiers:
+      enabled: true
+      tier1_cap: 12
+      tier2_cap: 18
+      enable_get_tool_details: true
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Orchestrator.Preparer.ToolTiers
+	if !got.Enabled {
+		t.Errorf("Enabled = false, want true")
+	}
+	if got.Tier1Cap != 12 {
+		t.Errorf("Tier1Cap = %d, want 12", got.Tier1Cap)
+	}
+	if got.Tier2Cap != 18 {
+		t.Errorf("Tier2Cap = %d, want 18", got.Tier2Cap)
+	}
+	if !got.EnableGetToolDetails {
+		t.Errorf("EnableGetToolDetails = false, want true")
+	}
+}
+
+func TestParsePreparerToolErrorHandling(t *testing.T) {
+	// Round-trips the Phase-4 tool-error YAML block. The orchestrator-
+	// side default-normalization is covered in
+	// internal/orchestrator/tool_tiers_config_test.go — here we only
+	// guard the YAML→struct mapping.
+	yaml := `
+orchestrator:
+  preparer:
+    tool_error_handling:
+      loop_cap_per_turn: 4
+      sticky_demotion_threshold: 6
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := cfg.Orchestrator.Preparer.ToolErrorHandling
+	if got.LoopCapPerTurn != 4 {
+		t.Errorf("LoopCapPerTurn = %d, want 4", got.LoopCapPerTurn)
+	}
+	if got.StickyDemotionThreshold != 6 {
+		t.Errorf("StickyDemotionThreshold = %d, want 6", got.StickyDemotionThreshold)
+	}
+}
+
+func TestParsePreparerToolTiersAbsentLeavesZeroValues(t *testing.T) {
+	// Regression guard: an absent preparer.tool_tiers /
+	// preparer.tool_error_handling block must parse to zero values so
+	// the orchestrator's normalization step owns the RFC defaults
+	// uniformly across YAML-driven and test-authored opts.
+	yaml := `
+orchestrator:
+  rules: []
+`
+	cfg, err := Parse([]byte(yaml))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tt := cfg.Orchestrator.Preparer.ToolTiers
+	if tt.Enabled || tt.Tier1Cap != 0 || tt.Tier2Cap != 0 || tt.EnableGetToolDetails {
+		t.Errorf("absent tool_tiers block must parse to zero ToolTiersConfig, got %+v", tt)
+	}
+	eh := cfg.Orchestrator.Preparer.ToolErrorHandling
+	if eh.LoopCapPerTurn != 0 || eh.StickyDemotionThreshold != 0 {
+		t.Errorf("absent tool_error_handling block must parse to zero ToolErrorHandlingConfig, got %+v", eh)
+	}
+}

--- a/internal/orchestrator/knowledge_context.go
+++ b/internal/orchestrator/knowledge_context.go
@@ -1,0 +1,217 @@
+package orchestrator
+
+import (
+	"strings"
+)
+
+// [knowledge_context] block parsing and rendering — RFC #249 Phase 3.
+//
+// The block format is the only Plugin→LLM bridge for retrieved RAG
+// knowledge: the orchestrator splices a `[knowledge_context]…[/knowledge_context]`
+// envelope into the current-turn user message, the LLM treats it as
+// part of its question, and historical-message strip removes the
+// envelope (but never the user text around it) on subsequent turns.
+//
+// Phase 3 extends the opening tag with optional `id="..."` and
+// `sha="..."` attributes so the orchestrator's lazy reconciliation
+// step can scan the visible message stream and tie each block back
+// to a known_knowledge entry without storing redundant copies of
+// the bodies. Plugins that haven't migrated to the candidate-list
+// shape keep emitting bare `[knowledge_context]` opening tags; the
+// parser recognizes both forms.
+//
+// Helpers live in their own file so the parser/strip/render logic is
+// readable in one place and easy to test in isolation.
+
+const (
+	kcOpenPrefix = "[knowledge_context"
+	kcCloseTag   = "[/knowledge_context]"
+)
+
+// parsedKCBlock is one [knowledge_context]…[/knowledge_context] block
+// extracted from a message string. ArticleID and ContentSHA256 are
+// populated when the opening tag carried the Phase-3 id="…" and
+// sha="…" attributes; both fields stay empty for legacy untagged
+// blocks. Start/End are byte offsets into the source string —
+// inclusive at Start, exclusive at End — so callers can splice
+// around the block without re-running the parser.
+type parsedKCBlock struct {
+	ArticleID     string
+	ContentSHA256 string
+	Body          string // text between opening `]` and `[/knowledge_context]`, not trimmed
+	Start         int    // offset of the opening `[`
+	End           int    // offset one past the closing `]`
+}
+
+// kcInjection is one article to render into a [knowledge_context]
+// block. The Phase-3 dedup logic (later commit) builds the input
+// slice from KnowledgeCandidate after the dedup decision; for
+// Phase 4+ extensions any additional metadata that needs to appear
+// inside the envelope would be added here.
+type kcInjection struct {
+	ArticleID     string
+	ContentSHA256 string
+	Body          string
+}
+
+// parseKnowledgeContextBlocks returns every [knowledge_context] block
+// found in s, in document order. Both the legacy untagged form and
+// the Phase-3 tagged form are recognized; the parser stops at the
+// first malformed opening (no closing `]` for the opening tag or no
+// `[/knowledge_context]` afterwards). Returns nil when there's
+// nothing to parse.
+//
+// Known limitation: a body that contains the literal string
+// `[/knowledge_context]` will be truncated at that point — the parser
+// has no escape mechanism for closing tags inside bodies. RAG-retrieved
+// knowledge articles practically never contain this string (it's an
+// orchestrator-internal wire token, not user-authored content), and
+// the Phase-3 reconciliation step catches the resulting drift on the
+// next turn. If a future plugin starts emitting bodies that mention
+// the closing tag, switch the renderer to length-prefixed bodies.
+//
+// The parser is intentionally non-allocating for the common
+// "no KC block here" path: the strings.Index call short-circuits and
+// returns immediately, the slice header on `nil` costs nothing.
+func parseKnowledgeContextBlocks(s string) []parsedKCBlock {
+	if !strings.Contains(s, kcOpenPrefix) {
+		return nil
+	}
+	var blocks []parsedKCBlock
+	cursor := 0
+	for cursor < len(s) {
+		rel := strings.Index(s[cursor:], kcOpenPrefix)
+		if rel < 0 {
+			break
+		}
+		absStart := cursor + rel
+		// The opening tag ends at the first `]` after the prefix.
+		// Anything between prefix and `]` is the optional attribute
+		// region; legacy bare openings are simply `[knowledge_context]`.
+		tagBodyStart := absStart + len(kcOpenPrefix)
+		closeBracketRel := strings.Index(s[tagBodyStart:], "]")
+		if closeBracketRel < 0 {
+			break // unterminated opening — give up
+		}
+		tagBodyEnd := tagBodyStart + closeBracketRel
+		bodyStart := tagBodyEnd + 1 // skip past the `]`
+		closeRel := strings.Index(s[bodyStart:], kcCloseTag)
+		if closeRel < 0 {
+			break // unmatched opening — give up
+		}
+		bodyEnd := bodyStart + closeRel
+		blocks = append(blocks, parsedKCBlock{
+			ArticleID:     extractKCAttr(s[tagBodyStart:tagBodyEnd], "id"),
+			ContentSHA256: extractKCAttr(s[tagBodyStart:tagBodyEnd], "sha"),
+			Body:          s[bodyStart:bodyEnd],
+			Start:         absStart,
+			End:           bodyEnd + len(kcCloseTag),
+		})
+		cursor = bodyEnd + len(kcCloseTag)
+	}
+	return blocks
+}
+
+// renderKnowledgeContextBlock builds the orchestrator-side string the
+// current-turn user message will carry. One envelope per article, in
+// input order, separated by a blank line so the LLM sees the blocks
+// as distinct. Empty slice returns the empty string so callers can
+// concatenate the output without conditionals.
+//
+// Article IDs and SHAs are sanitized to drop any embedded `"` so the
+// parser can rely on simple name="value" matching. In practice IDs
+// are RAG-source slugs and SHAs are hex — neither carries quotes —
+// but the sanitization keeps the contract robust against future
+// plugins that might forward less constrained identifiers.
+func renderKnowledgeContextBlock(articles []kcInjection) string {
+	if len(articles) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for i, a := range articles {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString(kcOpenPrefix)
+		if id := sanitizeKCAttr(a.ArticleID); id != "" {
+			b.WriteString(` id="`)
+			b.WriteString(id)
+			b.WriteString(`"`)
+		}
+		if sha := sanitizeKCAttr(a.ContentSHA256); sha != "" {
+			b.WriteString(` sha="`)
+			b.WriteString(sha)
+			b.WriteString(`"`)
+		}
+		b.WriteString("]\n")
+		b.WriteString(a.Body)
+		b.WriteString("\n")
+		b.WriteString(kcCloseTag)
+	}
+	return b.String()
+}
+
+// stripKnowledgeContext removes every [knowledge_context]…[/knowledge_context]
+// block (legacy or tagged form, single or multiple) from s and trims
+// surrounding whitespace. Used by the historical-strip path and the
+// planner's pre-prompt sanitization to keep KC bodies from
+// accumulating across turns.
+func stripKnowledgeContext(s string) string {
+	blocks := parseKnowledgeContextBlocks(s)
+	if len(blocks) == 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	last := 0
+	for _, blk := range blocks {
+		b.WriteString(s[last:blk.Start])
+		last = blk.End
+	}
+	b.WriteString(s[last:])
+	return strings.TrimSpace(b.String())
+}
+
+// extractKCAttr pulls the value of name="value" out of the opening-tag
+// body. Tolerant of attribute order and surrounding whitespace.
+// Empty string when the attribute is absent.
+//
+// The boundary check (whitespace before the attribute name) prevents
+// `sha=` from matching the tail of a longer attribute like `extrasha=`;
+// when an apparent match fails the boundary check the scan resumes
+// past it so a legitimate later occurrence is still found.
+func extractKCAttr(tagBody, name string) string {
+	needle := name + `="`
+	cursor := 0
+	for cursor < len(tagBody) {
+		rel := strings.Index(tagBody[cursor:], needle)
+		if rel < 0 {
+			return ""
+		}
+		idx := cursor + rel
+		if idx > 0 {
+			prev := tagBody[idx-1]
+			if prev != ' ' && prev != '\t' {
+				cursor = idx + 1
+				continue
+			}
+		}
+		valStart := idx + len(needle)
+		end := strings.Index(tagBody[valStart:], `"`)
+		if end < 0 {
+			return ""
+		}
+		return tagBody[valStart : valStart+end]
+	}
+	return ""
+}
+
+// sanitizeKCAttr drops embedded `"` so the rendered attribute string
+// stays parseable. Other whitespace and special characters survive —
+// the parser only treats `"` as significant.
+func sanitizeKCAttr(s string) string {
+	if !strings.ContainsRune(s, '"') {
+		return s
+	}
+	return strings.ReplaceAll(s, `"`, "")
+}

--- a/internal/orchestrator/knowledge_context_test.go
+++ b/internal/orchestrator/knowledge_context_test.go
@@ -1,0 +1,310 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseKnowledgeContextBlocks_LegacyBareOpening(t *testing.T) {
+	const msg = "before\n[knowledge_context]\nbody one\n[/knowledge_context]\nafter"
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	got := blocks[0]
+	if got.ArticleID != "" || got.ContentSHA256 != "" {
+		t.Errorf("legacy form must yield empty id/sha, got %+v", got)
+	}
+	if strings.TrimSpace(got.Body) != "body one" {
+		t.Errorf("body mismatch: %q", got.Body)
+	}
+	if msg[got.Start:got.End] != "[knowledge_context]\nbody one\n[/knowledge_context]" {
+		t.Errorf("Start/End slice mismatch: %q", msg[got.Start:got.End])
+	}
+}
+
+func TestParseKnowledgeContextBlocks_TaggedOpening(t *testing.T) {
+	const msg = `[knowledge_context id="kb_recurring-tickets" sha="9f3a"]
+recurring tickets body
+[/knowledge_context]`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	got := blocks[0]
+	if got.ArticleID != "kb_recurring-tickets" {
+		t.Errorf("ArticleID = %q, want kb_recurring-tickets", got.ArticleID)
+	}
+	if got.ContentSHA256 != "9f3a" {
+		t.Errorf("ContentSHA256 = %q, want 9f3a", got.ContentSHA256)
+	}
+	if strings.TrimSpace(got.Body) != "recurring tickets body" {
+		t.Errorf("body mismatch: %q", got.Body)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_MultipleBlocks(t *testing.T) {
+	const msg = `intro
+[knowledge_context id="kb_a" sha="aaa"]
+first body
+[/knowledge_context]
+middle
+[knowledge_context]
+second legacy body
+[/knowledge_context]
+trailer`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(blocks))
+	}
+	if blocks[0].ArticleID != "kb_a" || blocks[0].ContentSHA256 != "aaa" {
+		t.Errorf("first block: %+v", blocks[0])
+	}
+	if blocks[1].ArticleID != "" || blocks[1].ContentSHA256 != "" {
+		t.Errorf("second block (legacy) must have empty id/sha, got %+v", blocks[1])
+	}
+	if strings.TrimSpace(blocks[1].Body) != "second legacy body" {
+		t.Errorf("second body: %q", blocks[1].Body)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_AttributeOrderIndependent(t *testing.T) {
+	const msg = `[knowledge_context sha="abc" id="kb_x"]
+body
+[/knowledge_context]`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].ArticleID != "kb_x" || blocks[0].ContentSHA256 != "abc" {
+		t.Errorf("attribute extraction failed: %+v", blocks[0])
+	}
+}
+
+func TestParseKnowledgeContextBlocks_MissingAttribute(t *testing.T) {
+	const msg = `[knowledge_context id="kb_only"]
+body without sha
+[/knowledge_context]`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].ArticleID != "kb_only" {
+		t.Errorf("ArticleID = %q, want kb_only", blocks[0].ArticleID)
+	}
+	if blocks[0].ContentSHA256 != "" {
+		t.Errorf("ContentSHA256 must stay empty when attribute absent, got %q", blocks[0].ContentSHA256)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_MalformedReturnsParsedPrefix(t *testing.T) {
+	// Unmatched opening at the end shouldn't lose earlier well-formed blocks.
+	const msg = `[knowledge_context]
+first
+[/knowledge_context]
+[knowledge_context id="kb_dangling"
+truncated body without close`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1 (the dangling block is dropped), have %+v", len(blocks), blocks)
+	}
+	if strings.TrimSpace(blocks[0].Body) != "first" {
+		t.Errorf("first block body mismatch: %q", blocks[0].Body)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_NoOpeningReturnsNil(t *testing.T) {
+	if blocks := parseKnowledgeContextBlocks("plain text"); blocks != nil {
+		t.Errorf("expected nil for KC-free string, got %+v", blocks)
+	}
+	if blocks := parseKnowledgeContextBlocks(""); blocks != nil {
+		t.Errorf("expected nil for empty string, got %+v", blocks)
+	}
+}
+
+func TestExtractKCAttr_RejectsSubstringMatches(t *testing.T) {
+	// Without a word-boundary check, "sha" would falsely match the
+	// trailing characters of e.g. `extrasha="..."`. Guard against that
+	// regression — the boundary check requires whitespace before the
+	// attribute name.
+	body := `extrasha="bogus" sha="real"`
+	if got := extractKCAttr(body, "sha"); got != "real" {
+		t.Errorf("extractKCAttr(sha) = %q, want real", got)
+	}
+}
+
+func TestRenderKnowledgeContextBlock_RoundTripsThroughParser(t *testing.T) {
+	in := []kcInjection{
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Body: "first body"},
+		{ArticleID: "kb_b", ContentSHA256: "bbb", Body: "second body"},
+	}
+	rendered := renderKnowledgeContextBlock(in)
+	if rendered == "" {
+		t.Fatal("renderKnowledgeContextBlock produced empty string for non-empty input")
+	}
+	blocks := parseKnowledgeContextBlocks(rendered)
+	if len(blocks) != 2 {
+		t.Fatalf("round-trip produced %d blocks, want 2", len(blocks))
+	}
+	for i, want := range in {
+		got := blocks[i]
+		if got.ArticleID != want.ArticleID || got.ContentSHA256 != want.ContentSHA256 {
+			t.Errorf("block %d: id/sha mismatch — got %+v, want %+v", i, got, want)
+		}
+		if strings.TrimSpace(got.Body) != want.Body {
+			t.Errorf("block %d: body = %q, want %q", i, got.Body, want.Body)
+		}
+	}
+}
+
+func TestRenderKnowledgeContextBlock_EmptyInput(t *testing.T) {
+	if got := renderKnowledgeContextBlock(nil); got != "" {
+		t.Errorf("nil input must render to empty string, got %q", got)
+	}
+	if got := renderKnowledgeContextBlock([]kcInjection{}); got != "" {
+		t.Errorf("empty slice must render to empty string, got %q", got)
+	}
+}
+
+func TestRenderKnowledgeContextBlock_SkipsEmptyAttributes(t *testing.T) {
+	// A legacy-style injection (no id/sha) must render as the bare
+	// `[knowledge_context]` form so downstream tooling unaware of the
+	// Phase-3 attributes still sees a recognizable envelope.
+	rendered := renderKnowledgeContextBlock([]kcInjection{{Body: "legacy"}})
+	if !strings.HasPrefix(rendered, "[knowledge_context]\n") {
+		t.Errorf("missing-attribute injection must render bare opening, got %q", rendered)
+	}
+}
+
+func TestRenderKnowledgeContextBlock_SanitizesEmbeddedQuotes(t *testing.T) {
+	rendered := renderKnowledgeContextBlock([]kcInjection{{
+		ArticleID:     `kb_"injected"`,
+		ContentSHA256: `sha"with"quote`,
+		Body:          "body",
+	}})
+	// Embedded quotes must be dropped so the parser's name="value"
+	// matching still works. Confirm by round-tripping.
+	blocks := parseKnowledgeContextBlocks(rendered)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1 — render: %q", len(blocks), rendered)
+	}
+	if strings.Contains(blocks[0].ArticleID, `"`) || strings.Contains(blocks[0].ContentSHA256, `"`) {
+		t.Errorf("sanitization left embedded quotes: %+v", blocks[0])
+	}
+}
+
+func TestStripKnowledgeContext_LegacyBare(t *testing.T) {
+	const msg = "[knowledge_context]\nbody\n[/knowledge_context]\nuser question"
+	if got := stripKnowledgeContext(msg); got != "user question" {
+		t.Errorf("strip(legacy) = %q, want %q", got, "user question")
+	}
+}
+
+func TestStripKnowledgeContext_Tagged(t *testing.T) {
+	const msg = `[knowledge_context id="kb_x" sha="abc"]
+tagged body
+[/knowledge_context]
+user question`
+	if got := stripKnowledgeContext(msg); got != "user question" {
+		t.Errorf("strip(tagged) = %q, want %q", got, "user question")
+	}
+}
+
+func TestStripKnowledgeContext_MultipleBlocks(t *testing.T) {
+	const msg = `[knowledge_context]
+first
+[/knowledge_context]
+middle text
+[knowledge_context id="kb_b" sha="bbb"]
+second
+[/knowledge_context]
+trailing question`
+	got := stripKnowledgeContext(msg)
+	want := "middle text\n\ntrailing question"
+	if got != want {
+		t.Errorf("strip(multi) = %q, want %q", got, want)
+	}
+}
+
+func TestStripKnowledgeContext_NoBlockIsPassthrough(t *testing.T) {
+	const msg = "plain user message"
+	if got := stripKnowledgeContext(msg); got != msg {
+		t.Errorf("passthrough mutated: got %q, want %q", got, msg)
+	}
+}
+
+func TestStripKnowledgeContext_BlockOnlyTrimsToEmpty(t *testing.T) {
+	const msg = "[knowledge_context]\nbody\n[/knowledge_context]"
+	if got := stripKnowledgeContext(msg); got != "" {
+		t.Errorf("KC-only message must strip to empty, got %q", got)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_ToleratesExtraSpacingInOpeningTag(t *testing.T) {
+	// The wire format the renderer produces is single-spaced, but a
+	// future plugin might emit `[knowledge_context  id="x"  sha="y"  ]`
+	// with extra whitespace. The parser must accept it so backwards-compat
+	// with non-canonical encodings doesn't break reconciliation.
+	const msg = `[knowledge_context  id="kb_loose"   sha="abc"   ]
+body
+[/knowledge_context]`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].ArticleID != "kb_loose" || blocks[0].ContentSHA256 != "abc" {
+		t.Errorf("extra-spacing extraction failed: %+v", blocks[0])
+	}
+}
+
+func TestParseKnowledgeContextBlocks_EmptyBody(t *testing.T) {
+	// `[knowledge_context]…[/knowledge_context]` with a zero-byte body
+	// is a legitimate construction (e.g. the renderer caller passed
+	// an empty article body by mistake). The parser must accept it
+	// rather than treat it as malformed.
+	const msg = "[knowledge_context id=\"kb_empty\" sha=\"e\"][/knowledge_context]"
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].Body != "" {
+		t.Errorf("empty body expected, got %q", blocks[0].Body)
+	}
+	if blocks[0].ArticleID != "kb_empty" {
+		t.Errorf("ArticleID = %q, want kb_empty", blocks[0].ArticleID)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_AdjacentBlocksWithoutSeparator(t *testing.T) {
+	// Two blocks back-to-back with zero whitespace between the closing
+	// of the first and the opening of the second. Production code emits
+	// "\n\n" between them, but the parser shouldn't require it.
+	const msg = `[knowledge_context id="kb_a" sha="aaa"]first[/knowledge_context][knowledge_context id="kb_b" sha="bbb"]second[/knowledge_context]`
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 2 {
+		t.Fatalf("got %d blocks, want 2", len(blocks))
+	}
+	if blocks[0].ArticleID != "kb_a" || blocks[1].ArticleID != "kb_b" {
+		t.Errorf("adjacent-block ids: got %q / %q, want kb_a / kb_b", blocks[0].ArticleID, blocks[1].ArticleID)
+	}
+	if blocks[0].Body != "first" || blocks[1].Body != "second" {
+		t.Errorf("adjacent-block bodies: got %q / %q, want first / second", blocks[0].Body, blocks[1].Body)
+	}
+}
+
+func TestParseKnowledgeContextBlocks_BodyContainingLiteralCloseTag(t *testing.T) {
+	// Documents the known parser limitation: a body that mentions
+	// `[/knowledge_context]` literally truncates at that point.
+	// RAG-retrieved articles practically never do this, and the
+	// reconciliation step catches the resulting drift next turn — but
+	// the test pins the behaviour so a future "escape closing tag"
+	// fix doesn't silently change observable semantics.
+	const msg = "[knowledge_context id=\"kb_meta\" sha=\"abc\"]body before [/knowledge_context] trailing"
+	blocks := parseKnowledgeContextBlocks(msg)
+	if len(blocks) != 1 {
+		t.Fatalf("got %d blocks, want 1", len(blocks))
+	}
+	if blocks[0].Body != "body before " {
+		t.Errorf("body should truncate at first close tag, got %q", blocks[0].Body)
+	}
+}

--- a/internal/orchestrator/knowledge_dedup.go
+++ b/internal/orchestrator/knowledge_dedup.go
@@ -119,16 +119,17 @@ func applyKnowledgeDedup(
 			injectReason = events.PreparerDecisionReasonTopKForce
 		}
 
-		if injectReason == "" {
+		switch {
+		case injectReason == "":
 			out.Skipped = append(out.Skipped, c)
 			out.SkippedReasons = append(out.SkippedReasons, events.PreparerDecisionReasonAlreadyKnown)
-		} else if injectCount >= cfg.CapPerTurn {
+		case injectCount >= cfg.CapPerTurn:
 			// The candidate WOULD have injected but the per-turn cap
 			// kicked in. Record under Skipped so the event consumer
 			// sees the budget-pressure signal.
 			out.Skipped = append(out.Skipped, c)
 			out.SkippedReasons = append(out.SkippedReasons, events.PreparerDecisionReasonCapExceeded)
-		} else {
+		default:
 			out.Injected = append(out.Injected, c)
 			out.InjectedReasons = append(out.InjectedReasons, injectReason)
 			injectCount++

--- a/internal/orchestrator/knowledge_dedup.go
+++ b/internal/orchestrator/knowledge_dedup.go
@@ -1,0 +1,282 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// RFC #249 Phase 3 dedup decision logic.
+//
+// Pure functions over the candidate list + persisted state + config —
+// no orchestrator pointer receivers, no plugin calls, no I/O. The
+// preparer loop calls applyKnowledgeDedup once per user turn with the
+// aggregate candidate list from all preparers; the resulting decision
+// (a) drives the [knowledge_context] block the LLM sees, (b) feeds
+// the preparer_decision event payload, and (c) carries the updated
+// InjectionState the caller persists back to the session row.
+//
+// Keeping the logic separate from the I/O makes the test surface
+// trivial: every dedup path (new / score_override / top_k_force /
+// already_known / cap_exceeded) is exercised against a static
+// candidate slice without a session store mock. The reason vocabulary
+// itself lives next to the event payload types in
+// internal/state/store/events.event_types.go as PreparerDecisionReason*
+// constants so consumers (api-plugin, Timly review UI) share one
+// source of truth with the producer side.
+
+// knowledgeDedupDecision is the result of one dedup pass. The slices
+// preserve candidate order so the rendered [knowledge_context] block
+// matches the plugin's ranking, and so the preparer_decision event
+// faithfully reflects what the LLM actually saw.
+type knowledgeDedupDecision struct {
+	// Injected is the subset of candidates that should be spliced into
+	// the current turn's [knowledge_context] block, in input order.
+	Injected []KnowledgeCandidate
+	// InjectedReasons is parallel to Injected: one of dedupReasonNew /
+	// dedupReasonScoreOverride / dedupReasonTopKForce per entry.
+	InjectedReasons []string
+	// Skipped lists candidates the orchestrator chose NOT to inject;
+	// SkippedReasons parallels it with the explanation.
+	Skipped        []KnowledgeCandidate
+	SkippedReasons []string
+	// ScoreOverrides records the (article, score, threshold) tuples
+	// for candidates that re-injected via the score-override path.
+	// Used for preparer_decision payload diagnostics.
+	ScoreOverrides []events.PreparerDecisionScoreOverride
+	// UpdatedState is the post-decision InjectionState — the caller
+	// persists this back via SessionStore.UpdateInjectionState.
+	// known_knowledge is the union of the pre-call state and every
+	// candidate the preparer surfaced (whether injected or skipped),
+	// matching the RFC's "the LLM knows about rejected-because-known
+	// ones too" rule.
+	UpdatedState state.InjectionState
+}
+
+// InjectedBytes is the sum of Content lengths across the Injected set
+// — feeds preparer_decision.knowledge.injected_bytes.
+func (d *knowledgeDedupDecision) InjectedBytes() int {
+	total := 0
+	for _, c := range d.Injected {
+		total += len(c.Content)
+	}
+	return total
+}
+
+// applyKnowledgeDedup runs the RFC #249 dedup algorithm over the
+// preparer-aggregate candidate list. The algorithm:
+//
+//  1. A candidate is selected for injection when its ContentSHA256
+//     is not yet in existing.KnownKnowledge ("new"), OR its current
+//     score exceeds cfg.ReinjectScoreThreshold ("score_override"),
+//     OR its slice index is below cfg.ReinjectTopKForce ("top_k_force").
+//  2. The selected set is capped at cfg.CapPerTurn; overflow is moved
+//     to Skipped with reason "cap_exceeded".
+//  3. Every candidate (injected or skipped) is added to UpdatedState's
+//     known_knowledge, deduplicating on ContentSHA256 so a plugin
+//     returning the same SHA twice within a turn only produces one
+//     entry.
+//
+// The slice index drives the top-K-force decision instead of the
+// candidate's PositionInResults field: this matches the plugin
+// contract that the candidate slice is already ranked by score
+// (which is how RAG retrieval orders its output), and avoids the
+// 0-vs-1-indexed ambiguity that the omitempty PositionInResults
+// field would otherwise introduce.
+func applyKnowledgeDedup(
+	candidates []KnowledgeCandidate,
+	existing state.InjectionState,
+	cfg KnowledgeDedupConfig,
+	currentTurn int,
+) knowledgeDedupDecision {
+	known := make(map[string]bool, len(existing.KnownKnowledge))
+	for _, k := range existing.KnownKnowledge {
+		known[k.ContentSHA256] = true
+	}
+
+	out := knowledgeDedupDecision{
+		UpdatedState: state.InjectionState{
+			KnownKnowledge: append([]state.KnownKnowledgeEntry(nil), existing.KnownKnowledge...),
+			KnownTools:     existing.KnownTools, // Phase 4 territory; preserve forward-compat
+		},
+	}
+	injectCount := 0
+	for i, c := range candidates {
+		seen := known[c.ContentSHA256]
+
+		// Pick the inject reason — first match wins. Falls through to
+		// "already known + below thresholds" → goes to Skipped.
+		var injectReason string
+		switch {
+		case !seen:
+			injectReason = events.PreparerDecisionReasonNew
+		case c.Score > cfg.ReinjectScoreThreshold:
+			injectReason = events.PreparerDecisionReasonScoreOverride
+		case i < cfg.ReinjectTopKForce:
+			injectReason = events.PreparerDecisionReasonTopKForce
+		}
+
+		if injectReason == "" {
+			out.Skipped = append(out.Skipped, c)
+			out.SkippedReasons = append(out.SkippedReasons, events.PreparerDecisionReasonAlreadyKnown)
+		} else if injectCount >= cfg.CapPerTurn {
+			// The candidate WOULD have injected but the per-turn cap
+			// kicked in. Record under Skipped so the event consumer
+			// sees the budget-pressure signal.
+			out.Skipped = append(out.Skipped, c)
+			out.SkippedReasons = append(out.SkippedReasons, events.PreparerDecisionReasonCapExceeded)
+		} else {
+			out.Injected = append(out.Injected, c)
+			out.InjectedReasons = append(out.InjectedReasons, injectReason)
+			injectCount++
+			if injectReason == events.PreparerDecisionReasonScoreOverride {
+				out.ScoreOverrides = append(out.ScoreOverrides, events.PreparerDecisionScoreOverride{
+					ArticleID:    c.ArticleID,
+					CurrentScore: c.Score,
+					Threshold:    cfg.ReinjectScoreThreshold,
+				})
+			}
+		}
+
+		// State update: every fresh SHA gets a known_knowledge entry
+		// regardless of whether it injected or was skipped — the LLM
+		// will "see" it in the rendered KC block (if injected) or
+		// "know about" it because the cap or threshold pushed it out
+		// (then the next turn shouldn't re-surface it as new).
+		if !seen {
+			out.UpdatedState.KnownKnowledge = append(out.UpdatedState.KnownKnowledge, state.KnownKnowledgeEntry{
+				ArticleID:         c.ArticleID,
+				ContentSHA256:     c.ContentSHA256,
+				FirstInjectedTurn: currentTurn,
+			})
+			known[c.ContentSHA256] = true
+		}
+	}
+	return out
+}
+
+// knowledgeCandidatesToInjections converts the dedup decision's
+// Injected slice into the input shape renderKnowledgeContextBlock
+// expects. Pure — no state, no allocation when the input is empty.
+func knowledgeCandidatesToInjections(cands []KnowledgeCandidate) []kcInjection {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]kcInjection, len(cands))
+	for i, c := range cands {
+		out[i] = kcInjection{
+			ArticleID:     c.ArticleID,
+			ContentSHA256: c.ContentSHA256,
+			Body:          c.Content,
+		}
+	}
+	return out
+}
+
+// applyDedupToContent rebuilds the current-turn user message: strip
+// every plugin-emitted [knowledge_context] block, prepend the
+// dedup-decision's rendered block (when non-empty), and join with a
+// single blank line so the LLM sees the KC envelope cleanly preceded
+// by the user's actual text.
+//
+// When the decision injects nothing, the stripped user text is
+// returned as-is (no empty `[knowledge_context]` shell). When the
+// decision injects something but the stripped user text is empty
+// (rare — only when the plugin returned a KC-only Message), the KC
+// block becomes the entire content; the LLM treats the KC as its
+// instruction context, which mirrors what the legacy per-turn
+// re-inject behaviour already does.
+func applyDedupToContent(content string, injections []kcInjection) string {
+	stripped := stripKnowledgeContext(content)
+	rendered := renderKnowledgeContextBlock(injections)
+	switch {
+	case rendered == "":
+		return stripped
+	case stripped == "":
+		return rendered
+	default:
+		return rendered + "\n\n" + stripped
+	}
+}
+
+// prepareDedupDecision is the orchestrator's Phase-3 entry point for
+// READ + COMPUTE: read the persisted InjectionState, run the dedup
+// decision, rewrite the user-turn content with the deduped
+// [knowledge_context] block, and stash the decision on agg so
+// emitPreparerDecision picks up the full-mode payload. The actual
+// state PERSIST happens in persistDedupDecision after the event is
+// emitted — RFC #249 invariant: "Event emission precedes state writes
+// within a turn. If a state write fails after an event was emitted,
+// the next preparer pass detects drift and reconciles. This
+// guarantees the event log is the durable record even on partial
+// failure."
+//
+// Robustness contract:
+//   - If reading the state fails, log and start fresh (RFC: "service
+//     availability ahead of dedup correctness"). The orchestrator
+//     proceeds with an empty existing state — every candidate then
+//     appears as "new" — which gives the user this turn full context
+//     at the cost of one extra LLM token spend.
+//
+// The method assumes the caller has already verified that dedup is
+// enabled, a store is wired, and there are knowledge candidates to
+// decide on — see the preparer-loop callsite.
+func (o *Orchestrator) prepareDedupDecision(ctx context.Context, sessionID, content string, agg *preparerAggregate) string {
+	existing, err := o.injectionStateStore.GetInjectionState(ctx, sessionID)
+	if err != nil {
+		slog.WarnContext(ctx, "knowledge_dedup: read state failed, starting fresh",
+			"component", "orchestrator", "session", sessionID, "error", err)
+		existing = state.InjectionState{}
+	}
+
+	turn := o.turnNumberForDedup(sessionID)
+	decision := applyKnowledgeDedup(agg.Knowledge, existing, o.knowledgeDedup, turn)
+	agg.KnowledgeDedup = &decision
+
+	return applyDedupToContent(content, knowledgeCandidatesToInjections(decision.Injected))
+}
+
+// persistDedupDecision writes the decision's UpdatedState back to the
+// store. Logs and swallows errors so a transient store failure
+// doesn't abort the user turn — the next preparer pass's lazy
+// reconciliation step (Phase 3 C5) catches the resulting drift and
+// self-corrects. Caller is expected to have already emitted the
+// preparer_decision event so the audit trail survives partial
+// failure (RFC #249 invariant).
+func (o *Orchestrator) persistDedupDecision(ctx context.Context, sessionID string, agg *preparerAggregate) {
+	if agg.KnowledgeDedup == nil {
+		return
+	}
+	if err := o.injectionStateStore.UpdateInjectionState(ctx, sessionID, agg.KnowledgeDedup.UpdatedState); err != nil {
+		slog.WarnContext(ctx, "knowledge_dedup: write state failed, will reconcile next turn",
+			"component", "orchestrator", "session", sessionID, "error", err)
+	}
+}
+
+// turnNumberForDedup returns a stable monotonically-increasing turn
+// counter for the session — used as KnownKnowledgeEntry.FirstInjectedTurn
+// so a downstream event consumer can tell "this article was first
+// surfaced 4 turns ago" without scanning the full event log.
+//
+// Implemented as the count of user-role messages in the session plus
+// one, on the theory that the upcoming user message will become the
+// next entry. Imperfect (assistant-led turns aren't counted, store
+// errors silently fall back to turn=1) but sufficient for diagnostic
+// value; an explicit turn-counter column would be the proper Phase-4
+// fix if/when analytics needs it.
+func (o *Orchestrator) turnNumberForDedup(sessionID string) int {
+	sess, err := o.sessions.Get(sessionID)
+	if err != nil || sess == nil {
+		return 1
+	}
+	turn := 1
+	for _, m := range sess.Messages {
+		if m.Role == provider.RoleUser {
+			turn++
+		}
+	}
+	return turn
+}

--- a/internal/orchestrator/knowledge_dedup.go
+++ b/internal/orchestrator/knowledge_dedup.go
@@ -255,6 +255,32 @@ func (o *Orchestrator) persistDedupDecision(ctx context.Context, sessionID strin
 	}
 }
 
+// legacyWarningKeySeparator joins sessionID and pluginName into the
+// sync.Map key. Pulled into a constant so callers and tests share one
+// source of truth — drifting the delimiter would silently double-warn.
+const legacyWarningKeySeparator = "|"
+
+// warnLegacyKnowledgePluginsOnce logs a deprecation warning the first
+// time a (sessionID, pluginName) pair hits the legacy_fallback path.
+// Subsequent legacy detections for the same pair stay silent so a
+// session that keeps using a legacy preparer doesn't flood the log
+// with the same message every turn. The de-dup map is in-process,
+// not persisted — a process restart re-warns once per session, which
+// is acceptable for what is fundamentally observability data.
+func (o *Orchestrator) warnLegacyKnowledgePluginsOnce(ctx context.Context, sessionID string, plugins []string) {
+	for _, plugin := range plugins {
+		key := sessionID + legacyWarningKeySeparator + plugin
+		if _, alreadyWarned := o.legacyKnowledgeWarnings.LoadOrStore(key, struct{}{}); alreadyWarned {
+			continue
+		}
+		slog.WarnContext(ctx,
+			"knowledge_dedup: plugin returned legacy [knowledge_context] in pr.Message without structured knowledge_candidates — falling back to mode=legacy_fallback for this turn. Please migrate the plugin to return KnowledgeCandidates so dedup can run.",
+			"component", "orchestrator",
+			"session", sessionID,
+			"plugin", plugin)
+	}
+}
+
 // turnNumberForDedup returns a stable monotonically-increasing turn
 // counter for the session — used as KnownKnowledgeEntry.FirstInjectedTurn
 // so a downstream event consumer can tell "this article was first

--- a/internal/orchestrator/knowledge_dedup.go
+++ b/internal/orchestrator/knowledge_dedup.go
@@ -225,12 +225,11 @@ func applyDedupToContent(content string, injections []kcInjection) string {
 // enabled, a store is wired, and there are knowledge candidates to
 // decide on — see the preparer-loop callsite.
 func (o *Orchestrator) prepareDedupDecision(ctx context.Context, sessionID, content string, agg *preparerAggregate) string {
-	existing, err := o.injectionStateStore.GetInjectionState(ctx, sessionID)
-	if err != nil {
-		slog.WarnContext(ctx, "knowledge_dedup: read state failed, starting fresh",
-			"component", "orchestrator", "session", sessionID, "error", err)
-		existing = state.InjectionState{}
-	}
+	// Reconciliation step: load persisted state, scan the visible
+	// message stream, emit drift_detected when they disagree, and
+	// use the corrected state as the dedup input. RFC #249: the
+	// visible-message scan is authoritative.
+	existing := o.reconcileAndEmitDrift(ctx, sessionID)
 
 	turn := o.turnNumberForDedup(sessionID)
 	decision := applyKnowledgeDedup(agg.Knowledge, existing, o.knowledgeDedup, turn)

--- a/internal/orchestrator/knowledge_dedup_config_test.go
+++ b/internal/orchestrator/knowledge_dedup_config_test.go
@@ -1,0 +1,101 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// fakeInjectionStateStore is a minimal InjectionStateStore implementation
+// used by the wiring tests. It captures the last write so the test can
+// assert the orchestrator's plumbing reaches the dependency.
+type fakeInjectionStateStore struct {
+	getCalls    int
+	updateCalls int
+	lastWritten state.InjectionState
+}
+
+func (f *fakeInjectionStateStore) GetInjectionState(_ context.Context, _ string) (state.InjectionState, error) {
+	f.getCalls++
+	return state.InjectionState{}, nil
+}
+
+func (f *fakeInjectionStateStore) UpdateInjectionState(_ context.Context, _ string, st state.InjectionState) error {
+	f.updateCalls++
+	f.lastWritten = st
+	return nil
+}
+
+func TestKnowledgeDedupConfig_NormalizesZeroValuesToRFCDefaults(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		// KnowledgeDedup intentionally left zero-valued.
+	})
+	got := orch.knowledgeDedup
+	if got.Enabled {
+		t.Error("zero-value KnowledgeDedup must keep Enabled=false")
+	}
+	if got.ReinjectScoreThreshold != 0.85 {
+		t.Errorf("ReinjectScoreThreshold default = %v, want 0.85", got.ReinjectScoreThreshold)
+	}
+	if got.ReinjectTopKForce != 3 {
+		t.Errorf("ReinjectTopKForce default = %d, want 3", got.ReinjectTopKForce)
+	}
+	if got.CapPerTurn != 5 {
+		t.Errorf("CapPerTurn default = %d, want 5", got.CapPerTurn)
+	}
+}
+
+func TestKnowledgeDedupConfig_PreservesExplicitValues(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		KnowledgeDedup: KnowledgeDedupConfig{
+			Enabled:                true,
+			ReinjectScoreThreshold: 0.95,
+			ReinjectTopKForce:      7,
+			CapPerTurn:             12,
+		},
+	})
+	got := orch.knowledgeDedup
+	if !got.Enabled {
+		t.Error("Enabled=true must round-trip")
+	}
+	if got.ReinjectScoreThreshold != 0.95 || got.ReinjectTopKForce != 7 || got.CapPerTurn != 12 {
+		t.Errorf("explicit values clobbered: %+v", got)
+	}
+}
+
+func TestKnowledgeDedup_NilStoreStaysNilForDisabledFlag(t *testing.T) {
+	// Disabled dedup with no store wired is the safe default state
+	// every test using the in-memory state.SessionStore lands in. The
+	// orchestrator must not synthesize a store on its own.
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{})
+	if orch.injectionStateStore != nil {
+		t.Errorf("injectionStateStore should default to nil, got %#v", orch.injectionStateStore)
+	}
+}
+
+func TestKnowledgeDedup_StoreInterfaceIsCarriedThrough(t *testing.T) {
+	// When an InjectionStateStore is injected via OrchestratorOpts it
+	// must reach the Orchestrator unchanged. Phase 3's decision logic
+	// (a later commit) will reach for it via this field.
+	store := &fakeInjectionStateStore{}
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+		InjectionStateStore: store,
+	})
+	if orch.injectionStateStore != InjectionStateStore(store) {
+		t.Errorf("injectionStateStore must reach the orchestrator, got %#v", orch.injectionStateStore)
+	}
+}

--- a/internal/orchestrator/knowledge_dedup_config_test.go
+++ b/internal/orchestrator/knowledge_dedup_config_test.go
@@ -8,22 +8,41 @@ import (
 )
 
 // fakeInjectionStateStore is a minimal InjectionStateStore implementation
-// used by the wiring tests. It captures the last write so the test can
-// assert the orchestrator's plumbing reaches the dependency.
+// used by the wiring tests AND the C4 integration tests. It round-trips
+// state per session (so a two-turn test sees turn 1's writes in turn 2),
+// counts calls for assertion, and lets a test inject failure modes via
+// failGetErr / failUpdateErr to exercise the orchestrator's
+// "warn-and-continue" fallback paths.
 type fakeInjectionStateStore struct {
-	getCalls    int
-	updateCalls int
-	lastWritten state.InjectionState
+	getCalls      int
+	updateCalls   int
+	lastWritten   state.InjectionState
+	store         map[string]state.InjectionState
+	failGetErr    error
+	failUpdateErr error
 }
 
-func (f *fakeInjectionStateStore) GetInjectionState(_ context.Context, _ string) (state.InjectionState, error) {
+func (f *fakeInjectionStateStore) GetInjectionState(_ context.Context, sessionID string) (state.InjectionState, error) {
 	f.getCalls++
-	return state.InjectionState{}, nil
+	if f.failGetErr != nil {
+		return state.InjectionState{}, f.failGetErr
+	}
+	if f.store == nil {
+		return state.InjectionState{}, nil
+	}
+	return f.store[sessionID], nil
 }
 
-func (f *fakeInjectionStateStore) UpdateInjectionState(_ context.Context, _ string, st state.InjectionState) error {
+func (f *fakeInjectionStateStore) UpdateInjectionState(_ context.Context, sessionID string, st state.InjectionState) error {
 	f.updateCalls++
 	f.lastWritten = st
+	if f.failUpdateErr != nil {
+		return f.failUpdateErr
+	}
+	if f.store == nil {
+		f.store = make(map[string]state.InjectionState)
+	}
+	f.store[sessionID] = st
 	return nil
 }
 

--- a/internal/orchestrator/knowledge_dedup_test.go
+++ b/internal/orchestrator/knowledge_dedup_test.go
@@ -1,0 +1,321 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// defaultDedupCfg returns the RFC-default config so each test reads
+// like the runtime would behave with an empty `knowledge_dedup:`
+// YAML block (sans master-switch — every test enables the flag
+// explicitly via its own decision).
+func defaultDedupCfg() KnowledgeDedupConfig {
+	return KnowledgeDedupConfig{
+		Enabled:                true,
+		ReinjectScoreThreshold: 0.85,
+		ReinjectTopKForce:      3,
+		CapPerTurn:             5,
+	}
+}
+
+func TestApplyKnowledgeDedup_FirstTurnAllNew(t *testing.T) {
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Score: 0.91, Content: "first body"},
+		{ArticleID: "kb_b", ContentSHA256: "bbb", Score: 0.55, Content: "second body"},
+	}
+	d := applyKnowledgeDedup(candidates, state.InjectionState{}, defaultDedupCfg(), 1)
+	if len(d.Injected) != 2 {
+		t.Fatalf("first turn must inject all candidates, got %d", len(d.Injected))
+	}
+	for _, r := range d.InjectedReasons {
+		if r != events.PreparerDecisionReasonNew {
+			t.Errorf("first-turn reason must be %q, got %q", events.PreparerDecisionReasonNew, r)
+		}
+	}
+	if len(d.Skipped) != 0 {
+		t.Errorf("first turn must skip nothing, got %d entries", len(d.Skipped))
+	}
+	if len(d.UpdatedState.KnownKnowledge) != 2 {
+		t.Errorf("UpdatedState must record all candidates, got %d", len(d.UpdatedState.KnownKnowledge))
+	}
+	if d.UpdatedState.KnownKnowledge[0].FirstInjectedTurn != 1 {
+		t.Errorf("FirstInjectedTurn = %d, want 1", d.UpdatedState.KnownKnowledge[0].FirstInjectedTurn)
+	}
+}
+
+func TestApplyKnowledgeDedup_KnownSHAsSkipped(t *testing.T) {
+	existing := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	// Place candidate AFTER ReinjectTopKForce so top_k_force doesn't fire.
+	// Score below ReinjectScoreThreshold so score_override doesn't fire.
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_x", ContentSHA256: "xxx", Score: 0.6, Content: "x"},
+		{ArticleID: "kb_y", ContentSHA256: "yyy", Score: 0.6, Content: "y"},
+		{ArticleID: "kb_z", ContentSHA256: "zzz", Score: 0.6, Content: "z"},
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Score: 0.6, Content: "a"}, // index 3 — outside top-K-force=3, score below threshold
+	}
+	d := applyKnowledgeDedup(candidates, existing, defaultDedupCfg(), 2)
+	// Expect: kb_x/y/z injected as new, kb_a skipped as already_known.
+	if len(d.Injected) != 3 {
+		t.Fatalf("got %d injected, want 3", len(d.Injected))
+	}
+	if len(d.Skipped) != 1 || d.Skipped[0].ArticleID != "kb_a" {
+		t.Fatalf("expected kb_a skipped, got %+v", d.Skipped)
+	}
+	if d.SkippedReasons[0] != events.PreparerDecisionReasonAlreadyKnown {
+		t.Errorf("skip reason = %q, want %q", d.SkippedReasons[0], events.PreparerDecisionReasonAlreadyKnown)
+	}
+}
+
+func TestApplyKnowledgeDedup_ScoreOverrideReinjectsKnown(t *testing.T) {
+	existing := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	// Place kb_a outside top-K-force (index 3) so only score_override can rescue it.
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_x", ContentSHA256: "xxx", Score: 0.5},
+		{ArticleID: "kb_y", ContentSHA256: "yyy", Score: 0.5},
+		{ArticleID: "kb_z", ContentSHA256: "zzz", Score: 0.5},
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Score: 0.92, Content: "high-scoring re-inject"},
+	}
+	d := applyKnowledgeDedup(candidates, existing, defaultDedupCfg(), 2)
+	if len(d.Injected) != 4 {
+		t.Fatalf("got %d injected, want 4 (3 new + 1 score_override)", len(d.Injected))
+	}
+	if d.InjectedReasons[3] != events.PreparerDecisionReasonScoreOverride {
+		t.Errorf("last reason = %q, want %q", d.InjectedReasons[3], events.PreparerDecisionReasonScoreOverride)
+	}
+	if len(d.ScoreOverrides) != 1 {
+		t.Fatalf("expected 1 score-override record, got %d", len(d.ScoreOverrides))
+	}
+	if d.ScoreOverrides[0].ArticleID != "kb_a" || d.ScoreOverrides[0].CurrentScore != 0.92 || d.ScoreOverrides[0].Threshold != 0.85 {
+		t.Errorf("score-override payload mismatch: %+v", d.ScoreOverrides[0])
+	}
+}
+
+func TestApplyKnowledgeDedup_TopKForceReinjectsKnown(t *testing.T) {
+	existing := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+			{ArticleID: "kb_b", ContentSHA256: "bbb", FirstInjectedTurn: 1},
+		},
+	}
+	// Known candidate at index 0 with score below threshold — only
+	// top_k_force can carry it across.
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Score: 0.4, Content: "carried by top-K"},
+		{ArticleID: "kb_b", ContentSHA256: "bbb", Score: 0.4, Content: "carried by top-K"},
+		{ArticleID: "kb_b_other", ContentSHA256: "bb2", Score: 0.4},
+		{ArticleID: "kb_c", ContentSHA256: "ccc", Score: 0.4},
+	}
+	d := applyKnowledgeDedup(candidates, existing, defaultDedupCfg(), 2)
+	// Indexes 0,1 should be top_k_force; index 2 new; index 3 new.
+	if len(d.Injected) != 4 {
+		t.Fatalf("got %d injected, want 4", len(d.Injected))
+	}
+	if d.InjectedReasons[0] != events.PreparerDecisionReasonTopKForce || d.InjectedReasons[1] != events.PreparerDecisionReasonTopKForce {
+		t.Errorf("top-K reasons mismatch: %v", d.InjectedReasons)
+	}
+	if d.InjectedReasons[2] != events.PreparerDecisionReasonNew || d.InjectedReasons[3] != events.PreparerDecisionReasonNew {
+		t.Errorf("trailing reasons should be 'new': %v", d.InjectedReasons)
+	}
+	if len(d.ScoreOverrides) != 0 {
+		t.Errorf("top-K-force must not record as score-override, got %+v", d.ScoreOverrides)
+	}
+}
+
+func TestApplyKnowledgeDedup_CapPerTurnExceeded(t *testing.T) {
+	cfg := defaultDedupCfg()
+	cfg.CapPerTurn = 2
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Score: 0.9},
+		{ArticleID: "kb_b", ContentSHA256: "bbb", Score: 0.9},
+		{ArticleID: "kb_c", ContentSHA256: "ccc", Score: 0.9},
+		{ArticleID: "kb_d", ContentSHA256: "ddd", Score: 0.9},
+	}
+	d := applyKnowledgeDedup(candidates, state.InjectionState{}, cfg, 1)
+	if len(d.Injected) != 2 {
+		t.Fatalf("cap=2 must produce 2 injections, got %d", len(d.Injected))
+	}
+	if len(d.Skipped) != 2 {
+		t.Fatalf("cap=2 with 4 candidates must skip 2, got %d", len(d.Skipped))
+	}
+	for _, r := range d.SkippedReasons {
+		if r != events.PreparerDecisionReasonCapExceeded {
+			t.Errorf("cap-exceeded reason expected, got %q", r)
+		}
+	}
+	// All four still recorded in UpdatedState — RFC: the LLM "knows
+	// about" rejected-because-capped ones too.
+	if len(d.UpdatedState.KnownKnowledge) != 4 {
+		t.Errorf("UpdatedState must record all 4 candidates, got %d", len(d.UpdatedState.KnownKnowledge))
+	}
+}
+
+func TestApplyKnowledgeDedup_NoCandidatesReturnsEmptyDecision(t *testing.T) {
+	d := applyKnowledgeDedup(nil, state.InjectionState{}, defaultDedupCfg(), 1)
+	if len(d.Injected) != 0 || len(d.Skipped) != 0 || len(d.UpdatedState.KnownKnowledge) != 0 {
+		t.Errorf("empty input must yield empty decision, got %+v", d)
+	}
+}
+
+func TestApplyKnowledgeDedup_SameSHAInInputOnlyOneStateEntry(t *testing.T) {
+	// A plugin returning the same SHA twice within a turn (e.g. the
+	// same article hit by two RAG queries) must produce a single
+	// known_knowledge entry — otherwise the state grows unboundedly.
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_dup", ContentSHA256: "dup", Score: 0.7, Content: "body"},
+		{ArticleID: "kb_dup", ContentSHA256: "dup", Score: 0.7, Content: "body"},
+	}
+	d := applyKnowledgeDedup(candidates, state.InjectionState{}, defaultDedupCfg(), 1)
+	// First instance is "new"; second is treated as already-known
+	// because the in-turn map was updated. Skipped because below
+	// the score_override threshold and at index 1 (top_k_force
+	// covers indices 0..2 so index 1 IS top_k_force) — actually
+	// at top_k_force=3 the second candidate hits the top_k_force
+	// path because seen==true at index 1.
+	if len(d.UpdatedState.KnownKnowledge) != 1 {
+		t.Errorf("same SHA twice must produce 1 known entry, got %d", len(d.UpdatedState.KnownKnowledge))
+	}
+}
+
+func TestApplyKnowledgeDedup_PreservesPhase4KnownTools(t *testing.T) {
+	// Phase 3 must not clobber Phase-4 KnownTools entries when it
+	// rewrites the state.
+	existing := state.InjectionState{
+		KnownTools: []state.KnownToolEntry{
+			{ToolName: "timly__keep", Tier: "tier1", LRURank: 4},
+		},
+	}
+	candidates := []KnowledgeCandidate{
+		{ArticleID: "kb_a", ContentSHA256: "aaa", Content: "x"},
+	}
+	d := applyKnowledgeDedup(candidates, existing, defaultDedupCfg(), 1)
+	if len(d.UpdatedState.KnownTools) != 1 || d.UpdatedState.KnownTools[0].ToolName != "timly__keep" {
+		t.Errorf("Phase-4 KnownTools must survive Phase-3 update, got %+v", d.UpdatedState.KnownTools)
+	}
+}
+
+func TestApplyDedupToContent_EmptyInjectionsStripsPluginKC(t *testing.T) {
+	content := "[knowledge_context]\nold body\n[/knowledge_context]\n\nuser question"
+	out := applyDedupToContent(content, nil)
+	if out != "user question" {
+		t.Errorf("empty injections must strip and leave user text, got %q", out)
+	}
+}
+
+func TestApplyDedupToContent_NoKCPassthrough(t *testing.T) {
+	const content = "plain user question with no plugin KC"
+	if out := applyDedupToContent(content, nil); out != content {
+		t.Errorf("no-KC passthrough mutated: got %q, want %q", out, content)
+	}
+}
+
+func TestApplyDedupToContent_RebuildsKCFromDecision(t *testing.T) {
+	content := "[knowledge_context]\nold plugin KC\n[/knowledge_context]\n\nuser asks something"
+	injections := []kcInjection{
+		{ArticleID: "kb_new", ContentSHA256: "abc", Body: "fresh deduped body"},
+	}
+	out := applyDedupToContent(content, injections)
+	if strings.Contains(out, "old plugin KC") {
+		t.Errorf("dedup must drop plugin's KC, got %q", out)
+	}
+	if !strings.Contains(out, "fresh deduped body") || !strings.Contains(out, `id="kb_new"`) {
+		t.Errorf("dedup must render new KC with attributes, got %q", out)
+	}
+	if !strings.Contains(out, "user asks something") {
+		t.Errorf("user text must be preserved, got %q", out)
+	}
+	// Verify ordering: KC block precedes user text.
+	if strings.Index(out, "fresh deduped body") > strings.Index(out, "user asks something") {
+		t.Errorf("KC block must come before user text, got %q", out)
+	}
+}
+
+func TestApplyDedupToContent_EmptyContentWithInjections(t *testing.T) {
+	// Pathological but defined: plugin returned only a KC block as
+	// pr.Message — after strip the user text is empty. The rendered
+	// KC becomes the entire content.
+	const content = "[knowledge_context]\nold\n[/knowledge_context]"
+	injections := []kcInjection{{ArticleID: "kb_x", ContentSHA256: "x", Body: "deduped"}}
+	out := applyDedupToContent(content, injections)
+	if !strings.HasPrefix(out, "[knowledge_context") || !strings.Contains(out, "deduped") {
+		t.Errorf("KC-only content must result in pure rendered KC, got %q", out)
+	}
+	if strings.Contains(out, "\n\n") {
+		t.Errorf("KC-only content must not have trailing blank line, got %q", out)
+	}
+}
+
+func TestDedupInjectedItems_BuildsEventPayload(t *testing.T) {
+	d := &knowledgeDedupDecision{
+		Injected: []KnowledgeCandidate{
+			{ArticleID: "kb_a", ContentSHA256: "aaa"},
+			{ArticleID: "kb_b", ContentSHA256: "bbb"},
+		},
+		InjectedReasons: []string{events.PreparerDecisionReasonNew, events.PreparerDecisionReasonScoreOverride},
+	}
+	got := dedupInjectedItems(d)
+	if len(got) != 2 {
+		t.Fatalf("got %d items, want 2", len(got))
+	}
+	if got[0].ArticleID != "kb_a" || got[0].Reason != events.PreparerDecisionReasonNew {
+		t.Errorf("first item mismatch: %+v", got[0])
+	}
+	if got[1].Reason != events.PreparerDecisionReasonScoreOverride {
+		t.Errorf("second item reason = %q, want %q", got[1].Reason, events.PreparerDecisionReasonScoreOverride)
+	}
+}
+
+func TestKnowledgeDedupDecision_InjectedBytesSumsContentLengths(t *testing.T) {
+	d := &knowledgeDedupDecision{
+		Injected: []KnowledgeCandidate{
+			{Content: "12345"},         // 5 bytes
+			{Content: "Hello, world!"}, // 13 bytes
+			{Content: ""},              // 0 bytes
+		},
+	}
+	if got := d.InjectedBytes(); got != 18 {
+		t.Errorf("InjectedBytes = %d, want 18", got)
+	}
+}
+
+func TestTurnNumberForDedup_EmptySessionStartsAtOne(t *testing.T) {
+	sessions := state.NewSessionStore("")
+	sessions.Create("s", "", "")
+	orch := &Orchestrator{sessions: sessions}
+	if got := orch.turnNumberForDedup("s"); got != 1 {
+		t.Errorf("empty session turn = %d, want 1", got)
+	}
+}
+
+func TestTurnNumberForDedup_CountsUserMessagesOnly(t *testing.T) {
+	sessions := state.NewSessionStore("")
+	sessions.Create("s", "", "")
+	// 2 user messages + 1 assistant + 1 tool → turn 3 (1 base + 2 user).
+	_ = sessions.AddMessage("s", provider.Message{Role: provider.RoleUser, Content: "q1"})
+	_ = sessions.AddMessage("s", provider.Message{Role: provider.RoleAssistant, Content: "a1"})
+	_ = sessions.AddMessage("s", provider.Message{Role: provider.RoleUser, Content: "q2"})
+	_ = sessions.AddMessage("s", provider.Message{Role: provider.RoleTool, Content: "tool-result"})
+	orch := &Orchestrator{sessions: sessions}
+	if got := orch.turnNumberForDedup("s"); got != 3 {
+		t.Errorf("turn = %d, want 3 (1 base + 2 user messages)", got)
+	}
+}
+
+func TestTurnNumberForDedup_MissingSessionFallsBackToOne(t *testing.T) {
+	sessions := state.NewSessionStore("")
+	orch := &Orchestrator{sessions: sessions}
+	if got := orch.turnNumberForDedup("does-not-exist"); got != 1 {
+		t.Errorf("missing session must fall back to 1, got %d", got)
+	}
+}

--- a/internal/orchestrator/knowledge_dedup_test.go
+++ b/internal/orchestrator/knowledge_dedup_test.go
@@ -193,7 +193,7 @@ func TestApplyKnowledgeDedup_PreservesPhase4KnownTools(t *testing.T) {
 	// rewrites the state.
 	existing := state.InjectionState{
 		KnownTools: []state.KnownToolEntry{
-			{ToolName: "timly__keep", Tier: "tier1", LRURank: 4},
+			{ToolName: "timly__keep", Tier: state.KnownToolTier1, LRURank: 4},
 		},
 	}
 	candidates := []KnowledgeCandidate{

--- a/internal/orchestrator/knowledge_legacy_fallback_test.go
+++ b/internal/orchestrator/knowledge_legacy_fallback_test.go
@@ -1,0 +1,410 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+func TestResponseUsesLegacyKnowledgeInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		pr   preparerResponse
+		want bool
+	}{
+		{
+			name: "candidates_present_message_with_kc",
+			pr: preparerResponse{
+				Message:             "[knowledge_context]\nbody\n[/knowledge_context]\nrest",
+				KnowledgeCandidates: []KnowledgeCandidate{{ArticleID: "kb", ContentSHA256: "x"}},
+			},
+			want: false, // structured candidates win
+		},
+		{
+			name: "no_candidates_message_with_kc",
+			pr:   preparerResponse{Message: "[knowledge_context]\nbody\n[/knowledge_context]"},
+			want: true,
+		},
+		{
+			name: "no_candidates_message_with_tagged_kc",
+			pr:   preparerResponse{Message: `[knowledge_context id="kb_a" sha="aaa"]body[/knowledge_context]`},
+			want: true, // tagged but no candidate-slice still trips fallback
+		},
+		{
+			name: "no_candidates_message_without_kc",
+			pr:   preparerResponse{Message: "plain user content"},
+			want: false,
+		},
+		{
+			name: "everything_empty",
+			pr:   preparerResponse{},
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := responseUsesLegacyKnowledgeInjection(c.pr); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestPreparerAggregate_AppendRecordsLegacyPlugin(t *testing.T) {
+	var agg preparerAggregate
+	agg.append("modern", preparerResponse{
+		KnowledgeCandidates: []KnowledgeCandidate{{ArticleID: "kb_x", ContentSHA256: "x"}},
+	})
+	agg.append("legacy", preparerResponse{
+		Message: "[knowledge_context]\nbody\n[/knowledge_context]",
+	})
+	if len(agg.LegacyKnowledgePlugins) != 1 || agg.LegacyKnowledgePlugins[0] != "legacy" {
+		t.Errorf("LegacyKnowledgePlugins = %v, want [legacy]", agg.LegacyKnowledgePlugins)
+	}
+	if len(agg.Knowledge) != 1 {
+		t.Errorf("modern plugin's candidate must still be aggregated, got %+v", agg.Knowledge)
+	}
+}
+
+func TestWarnLegacyKnowledgePluginsOnce_DedupesAcrossCalls(t *testing.T) {
+	// Same (session, plugin) pair across multiple calls only warns
+	// once. Verified indirectly via the sync.Map state: a second
+	// LoadOrStore for the same key reports "loaded=true" so the
+	// warning block is short-circuited. We can't capture slog output
+	// without rewiring the global logger, so this test instead
+	// proves the de-dup map is the gate by asserting it holds the
+	// expected key after the second call.
+	orch := &Orchestrator{}
+	orch.warnLegacyKnowledgePluginsOnce(context.Background(), "s1", []string{"legacy-plugin"})
+	orch.warnLegacyKnowledgePluginsOnce(context.Background(), "s1", []string{"legacy-plugin"})
+	key := "s1" + legacyWarningKeySeparator + "legacy-plugin"
+	if _, loaded := orch.legacyKnowledgeWarnings.Load(key); !loaded {
+		t.Fatalf("first call must record the (session, plugin) pair under key %q", key)
+	}
+	// Different session for the same plugin must record a separate key.
+	orch.warnLegacyKnowledgePluginsOnce(context.Background(), "s2", []string{"legacy-plugin"})
+	if _, loaded := orch.legacyKnowledgeWarnings.Load("s2" + legacyWarningKeySeparator + "legacy-plugin"); !loaded {
+		t.Errorf("different session must produce a separate warn-key")
+	}
+}
+
+func TestWarnLegacyKnowledgePluginsOnce_ParallelSafe(t *testing.T) {
+	// Concurrent calls with the same key must not race the sync.Map.
+	orch := &Orchestrator{}
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			orch.warnLegacyKnowledgePluginsOnce(context.Background(), "s1", []string{"plugin-a"})
+		}()
+	}
+	wg.Wait()
+	// Only one entry should exist for the contended key.
+	count := 0
+	orch.legacyKnowledgeWarnings.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	if count != 1 {
+		t.Errorf("contended sync.Map must hold exactly 1 entry, got %d", count)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyKnowledgePluginEmitsLegacyFallback(t *testing.T) {
+	// End-to-end: a plugin that returns a [knowledge_context] block
+	// in pr.Message without structured KnowledgeCandidates triggers
+	// mode=legacy_fallback when dedup is enabled. The orchestrator
+	// MUST:
+	//   - skip the dedup-decision rebuild (content passes through
+	//     verbatim from the plugin)
+	//   - NOT call UpdateInjectionState (no decision to persist)
+	//   - emit preparer_decision with mode=legacy_fallback and an
+	//     empty Knowledge.Injected slice
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "[knowledge_context]\nplugin-rendered body\n[/knowledge_context]\n\nuser question"
+	}`
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-rag", Description: "legacy RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&capturingLLM{responses: []string{"answer"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "legacy-rag", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: dedupStore,
+		})
+	if _, err := orch.Run(context.Background(), "s1", "user question"); err != nil {
+		t.Fatal(err)
+	}
+
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing")
+	}
+	var p events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Mode != events.PreparerDecisionModeLegacyFallback {
+		t.Errorf("Mode = %q, want %q", p.Mode, events.PreparerDecisionModeLegacyFallback)
+	}
+	if len(p.Knowledge.Injected) != 0 {
+		t.Errorf("legacy_fallback must leave Knowledge.Injected empty, got %+v", p.Knowledge.Injected)
+	}
+	if dedupStore.updateCalls != 0 {
+		t.Errorf("legacy_fallback must NOT persist state, got updateCalls=%d", dedupStore.updateCalls)
+	}
+	// Warn-key for the legacy plugin must be recorded.
+	if _, loaded := orch.legacyKnowledgeWarnings.Load("s1" + legacyWarningKeySeparator + "legacy-rag"); !loaded {
+		t.Errorf("deprecation warning de-dup key not recorded for legacy plugin")
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyFallbackPassesPluginMessageVerbatim(t *testing.T) {
+	// Robustness contract: the legacy plugin's pr.Message reaches the
+	// LLM unchanged (with its embedded [knowledge_context] block).
+	// Phase 3 dedup would have rewritten this; legacy_fallback must
+	// not.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "[knowledge_context]\nlegacy plugin body\n[/knowledge_context]\n\nuser question"
+	}`
+	sink := &recordingEventSink{}
+	llm := &capturingLLM{responses: []string{"answer"}}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-rag", Description: "legacy RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm,
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "legacy-rag", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: &fakeInjectionStateStore{},
+		})
+	if _, err := orch.Run(context.Background(), "s1", "user question"); err != nil {
+		t.Fatal(err)
+	}
+	if len(llm.requests) == 0 {
+		t.Fatal("LLM not called")
+	}
+	var lastUser string
+	for _, m := range llm.requests[0].Messages {
+		if m.Role == "user" {
+			lastUser = m.Content
+		}
+	}
+	if !strings.Contains(lastUser, "legacy plugin body") {
+		t.Errorf("legacy_fallback must forward plugin's KC body verbatim, got %q", lastUser)
+	}
+	// The block must NOT be ID-tagged — the legacy plugin emitted a
+	// bare form, and dedup did NOT run to rewrite it.
+	if strings.Contains(lastUser, "id=") {
+		t.Errorf("legacy_fallback must keep the plugin's bare KC form, got %q", lastUser)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyWithDedupDisabledStaysInstrumentationOnly(t *testing.T) {
+	// Regression guard: a legacy plugin is NORMAL when dedup is
+	// disabled. The mode must stay instrumentation_only (NOT
+	// legacy_fallback) — fallback is a dedup-specific concept.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "[knowledge_context]\nplugin body\n[/knowledge_context]\nq"
+	}`
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-rag", Description: "legacy RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:        sink,
+			ContentPreparers: []ContentPreparerEntry{{Plugin: "legacy-rag", Action: "prepare"}},
+			KnowledgeDedup:   KnowledgeDedupConfig{Enabled: false},
+		})
+	if _, err := orch.Run(context.Background(), "s1", "q"); err != nil {
+		t.Fatal(err)
+	}
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		// preparer_decision must STILL emit even though there were no
+		// structured candidates — the legacy plugin's relevant_tools
+		// or message-only response counts as "the preparer ran". But
+		// since the legacy detection here is purely Knowledge-side
+		// AND we have no Knowledge/Glossary/Tools, the event may
+		// short-circuit. Tolerate either path by skipping when no
+		// event was produced.
+		t.Skip("preparer_decision short-circuited (no candidates of any kind); legacy-only message-mode is acceptable")
+		return
+	}
+	var p events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Mode == events.PreparerDecisionModeLegacyFallback {
+		t.Errorf("legacy plugin must not trigger legacy_fallback when dedup is disabled, got %q", p.Mode)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyFallbackSurfacesStructuredCandidateIDs(t *testing.T) {
+	// Mixed-preparer case: preparer A returns structured candidates,
+	// preparer B returns legacy [knowledge_context] in pr.Message.
+	// Per RFC "per-turn fallback": the whole turn switches to
+	// legacy_fallback (Injected/Skipped stay empty) but CandidateIDs
+	// must still surface A's contributions so the audit trail shows
+	// what was retrieved even though no decision was made.
+	prepA := `{"send_to_llm": true, "message": "A's text",
+	 "knowledge_candidates": [{"article_id": "kb_structured", "content": "body", "content_sha256": "sha-s", "score": 0.9}]}`
+	prepB := `{"send_to_llm": true, "message": "[knowledge_context]\nlegacy B body\n[/knowledge_context]\nuser text"}`
+
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-a", Description: "structured",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepA})
+	_ = registry.Register(PluginCapability{
+		Name: "rag-b-legacy", Description: "legacy",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepB})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink: sink,
+			ContentPreparers: []ContentPreparerEntry{
+				{Plugin: "rag-a", Action: "prepare"},
+				{Plugin: "rag-b-legacy", Action: "prepare"},
+			},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: &fakeInjectionStateStore{},
+		})
+	if _, err := orch.Run(context.Background(), "s1", "user text"); err != nil {
+		t.Fatal(err)
+	}
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing")
+	}
+	var p events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Mode != events.PreparerDecisionModeLegacyFallback {
+		t.Errorf("Mode = %q, want %q", p.Mode, events.PreparerDecisionModeLegacyFallback)
+	}
+	if len(p.Knowledge.CandidateIDs) != 1 || p.Knowledge.CandidateIDs[0] != "kb_structured" {
+		t.Errorf("CandidateIDs must surface structured contribution, got %v", p.Knowledge.CandidateIDs)
+	}
+	if len(p.Knowledge.Injected) != 0 {
+		t.Errorf("legacy_fallback must leave Injected empty, got %+v", p.Knowledge.Injected)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_MultipleLegacyPluginsPerSessionWarnSeparately(t *testing.T) {
+	// Two distinct legacy plugins in one session — each must get its
+	// own warn-key under the same session prefix, and prepAgg.LegacyKnowledgePlugins
+	// must aggregate them in preparer order without duplication.
+	prepA := `{"send_to_llm": true, "message": "[knowledge_context]\nA body\n[/knowledge_context]\nq"}`
+	prepB := `{"send_to_llm": true, "message": "[knowledge_context]\nB body\n[/knowledge_context]\nq"}`
+
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-a", Description: "legacy A",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepA})
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-b", Description: "legacy B",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepB})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink: sink,
+			ContentPreparers: []ContentPreparerEntry{
+				{Plugin: "legacy-a", Action: "prepare"},
+				{Plugin: "legacy-b", Action: "prepare"},
+			},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: &fakeInjectionStateStore{},
+		})
+	if _, err := orch.Run(context.Background(), "s1", "q"); err != nil {
+		t.Fatal(err)
+	}
+	for _, plugin := range []string{"legacy-a", "legacy-b"} {
+		key := "s1" + legacyWarningKeySeparator + plugin
+		if _, loaded := orch.legacyKnowledgeWarnings.Load(key); !loaded {
+			t.Errorf("warn-key %q missing — each legacy plugin must be tracked separately", key)
+		}
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyFallbackPreservesStoreState(t *testing.T) {
+	// A legacy_fallback turn must not mutate the persisted state.
+	// Pre-populate state with entries; run the turn; confirm the
+	// store's map is unchanged. (The orchestrator skips both
+	// prepareDedupDecision and persistDedupDecision in legacy mode.)
+	preLoaded := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_pre", ContentSHA256: "sha-pre", FirstInjectedTurn: 1},
+		},
+	}
+	dedupStore := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{"s1": preLoaded},
+	}
+	preparerJSON := `{"send_to_llm": true,
+	 "message": "[knowledge_context]\nlegacy body\n[/knowledge_context]\nuser q"}`
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy", Description: "legacy",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "legacy", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: dedupStore,
+		})
+	if _, err := orch.Run(context.Background(), "s1", "user q"); err != nil {
+		t.Fatal(err)
+	}
+	got := dedupStore.store["s1"]
+	if len(got.KnownKnowledge) != 1 || got.KnownKnowledge[0].ContentSHA256 != "sha-pre" {
+		t.Errorf("pre-loaded state must survive legacy_fallback turn, got %+v", got.KnownKnowledge)
+	}
+	if dedupStore.updateCalls != 0 {
+		t.Errorf("legacy_fallback must skip UpdateInjectionState, got %d calls", dedupStore.updateCalls)
+	}
+}

--- a/internal/orchestrator/knowledge_reconcile.go
+++ b/internal/orchestrator/knowledge_reconcile.go
@@ -1,0 +1,227 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
+)
+
+// RFC #249 Phase 3 lazy reconciliation: scan the visible message
+// stream for ID-tagged [knowledge_context] blocks, derive the actually
+// injected SHA set, and reconcile against the persisted InjectionState.
+//
+// Why this exists:
+//   - The dedup decision (knowledge_dedup.go) trusts persisted state to
+//     answer "is this article already in the LLM's context?". Anything
+//     that mutates the message stream outside the orchestrator's
+//     awareness — summarization, sliding-window truncation, future
+//     redaction — invalidates that trust.
+//   - Reconciliation runs once per preparer pass, BEFORE the dedup
+//     decision. The corrected state feeds applyKnowledgeDedup.
+//   - When state and visible disagree, a drift_detected event records
+//     what was rewritten so the audit trail stays complete.
+//
+// Reconciliation is intentionally authoritative: the visible-message
+// scan wins. If state says "kb_a known" but no kb_a block is visible,
+// kb_a is dropped from state (LLM doesn't "know" it anymore, future
+// re-retrieval will re-inject). Symmetrically, an extra visible block
+// not in state gets added — without this the orchestrator would
+// double-inject content the LLM already has.
+
+// reconciliationAction is the fixed-vocabulary value the drift_detected
+// event records when reconciliation rewrote state. Phase 3 has only
+// one corrective strategy (rewrite-from-visible) so a single constant
+// suffices; future strategies (e.g. "partial_merge_with_state") will
+// add siblings rather than reformatting this one.
+const reconciliationActionRewriteFromVisible = "state_rewritten_from_visible_scan"
+
+// driftReport captures the discrepancy between persisted and visible
+// state. Empty fields mean no drift in that direction; the whole
+// struct is nil when state and visible agree. Used by both the
+// drift_detected event payload and the unit tests.
+type driftReport struct {
+	StateBelievedKnown   []string // SHAs persisted state thought were known
+	ActuallyVisible      []string // SHAs the message scan actually found
+	MissingFromVisible   []string // in state, not in visible — LLM forgot
+	ExtrasInVisible      []string // in visible, not in state — state lost track
+	ReconciliationAction string
+}
+
+// reconcileInjectionState runs the lazy-reconciliation algorithm.
+// Returns the corrected state (always — even when there's no drift,
+// callers can use the result directly) and an optional drift report
+// (nil when state and visible agree). Pure function — no orchestrator
+// state mutation, no I/O.
+//
+// Only user-role messages are scanned: [knowledge_context] blocks only
+// appear in user messages by construction (the orchestrator prepends
+// them when it builds the current-turn content).
+//
+// When drift is detected, the corrected state's KnownKnowledge is
+// derived from the visible blocks; FirstInjectedTurn is preserved
+// from the persisted entry when the SHA was already known
+// (continuity for diagnostics), or set to 0 for extras_in_visible
+// entries (lost-track entries get a synthetic "unknown turn" marker).
+// KnownTools is copied through unchanged — Phase 4 territory.
+func reconcileInjectionState(messages []provider.Message, persisted state.InjectionState) (state.InjectionState, *driftReport) {
+	visible := scanVisibleKnowledgeBlocks(messages)
+
+	visibleSHAs := make(map[string]parsedKCBlock, len(visible))
+	for _, blk := range visible {
+		if blk.ContentSHA256 == "" {
+			continue // legacy untagged block — nothing to reconcile against
+		}
+		visibleSHAs[blk.ContentSHA256] = blk
+	}
+
+	persistedSHAs := make(map[string]state.KnownKnowledgeEntry, len(persisted.KnownKnowledge))
+	for _, k := range persisted.KnownKnowledge {
+		persistedSHAs[k.ContentSHA256] = k
+	}
+
+	var missing, extras []string
+	for sha := range persistedSHAs {
+		if _, ok := visibleSHAs[sha]; !ok {
+			missing = append(missing, sha)
+		}
+	}
+	for sha := range visibleSHAs {
+		if _, ok := persistedSHAs[sha]; !ok {
+			extras = append(extras, sha)
+		}
+	}
+
+	if len(missing) == 0 && len(extras) == 0 {
+		// State and visible agree → return persisted state unchanged
+		// so the caller can keep its slice header. No drift event.
+		return persisted, nil
+	}
+
+	corrected := state.InjectionState{
+		KnownKnowledge: rebuildKnownKnowledge(visible, persistedSHAs),
+		KnownTools:     persisted.KnownTools,
+	}
+	report := &driftReport{
+		StateBelievedKnown:   sortedKeys(persistedSHAs),
+		ActuallyVisible:      sortedKeys(visibleSHAs),
+		MissingFromVisible:   sortedStrings(missing),
+		ExtrasInVisible:      sortedStrings(extras),
+		ReconciliationAction: reconciliationActionRewriteFromVisible,
+	}
+	return corrected, report
+}
+
+// scanVisibleKnowledgeBlocks walks the user-role messages and returns
+// every parsed [knowledge_context] block. Blocks without an `id` and
+// `sha` attribute (legacy untagged form) are still returned so callers
+// can count them, but they're filtered out by the dedup-state
+// reconciliation since their identity is unknown.
+func scanVisibleKnowledgeBlocks(messages []provider.Message) []parsedKCBlock {
+	var out []parsedKCBlock
+	for _, m := range messages {
+		if m.Role != provider.RoleUser || m.Content == "" {
+			continue
+		}
+		out = append(out, parseKnowledgeContextBlocks(m.Content)...)
+	}
+	return out
+}
+
+// rebuildKnownKnowledge constructs the corrected KnownKnowledge slice
+// from the visible blocks. Persisted FirstInjectedTurn is preserved
+// when the SHA was already known — that diagnostic value should
+// survive reconciliation. Extras (visible but unpersisted) get
+// FirstInjectedTurn=0 to mark them as "discovered via reconciliation".
+func rebuildKnownKnowledge(visible []parsedKCBlock, persistedSHAs map[string]state.KnownKnowledgeEntry) []state.KnownKnowledgeEntry {
+	out := make([]state.KnownKnowledgeEntry, 0, len(visible))
+	seen := make(map[string]bool, len(visible))
+	for _, blk := range visible {
+		if blk.ContentSHA256 == "" || seen[blk.ContentSHA256] {
+			continue
+		}
+		seen[blk.ContentSHA256] = true
+		entry := state.KnownKnowledgeEntry{
+			ArticleID:     blk.ArticleID,
+			ContentSHA256: blk.ContentSHA256,
+		}
+		if prior, ok := persistedSHAs[blk.ContentSHA256]; ok {
+			entry.FirstInjectedTurn = prior.FirstInjectedTurn
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// sortedKeys returns the map keys in a deterministic order so the
+// drift_detected event payload doesn't churn on every emit.
+func sortedKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// sortedStrings returns a sorted copy of in. Convenience wrapper so
+// the call sites in reconcileInjectionState stay one-liners.
+func sortedStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+// reconcileAndEmitDrift is the orchestrator's reconciliation entry point.
+// Loads persisted state, runs reconciliation against the session's
+// visible messages, emits a drift_detected event when drift is found,
+// and returns the corrected state for the dedup decision to consume.
+//
+// Failure-mode contract — both error paths fall back to empty state
+// rather than persisted state. The visible-message scan is the
+// authoritative source per RFC #249; if we can't run it (either we
+// can't read state, or we can't load the message stream) we err
+// toward "treat as first turn" so a later turn's full re-injection
+// is the worst case, instead of carrying stale state forward.
+//
+// The drift_detected event inherits ctx's ParentID (which the caller
+// has scoped to user_message, matching the other preparer-phase
+// events).
+func (o *Orchestrator) reconcileAndEmitDrift(ctx context.Context, sessionID string) state.InjectionState {
+	if o.injectionStateStore == nil {
+		return state.InjectionState{}
+	}
+	persisted, err := o.injectionStateStore.GetInjectionState(ctx, sessionID)
+	if err != nil {
+		slog.WarnContext(ctx, "knowledge_dedup: read state failed during reconciliation, starting fresh",
+			"component", "orchestrator", "session", sessionID, "error", err)
+		return state.InjectionState{}
+	}
+	sess, err := o.sessions.Get(sessionID)
+	if err != nil || sess == nil {
+		slog.WarnContext(ctx, "knowledge_dedup: session lookup failed during reconciliation, starting fresh",
+			"component", "orchestrator", "session", sessionID, "error", err)
+		return state.InjectionState{}
+	}
+	corrected, drift := reconcileInjectionState(sess.Messages, persisted)
+	if drift == nil {
+		return corrected
+	}
+	emit.EmitDriftDetected(ctx, o.eventSink, emit.DriftDetectedArgs{
+		StateBelievedKnown:   drift.StateBelievedKnown,
+		ActuallyVisible:      drift.ActuallyVisible,
+		MissingFromVisible:   drift.MissingFromVisible,
+		ExtrasInVisible:      drift.ExtrasInVisible,
+		ReconciliationAction: drift.ReconciliationAction,
+	})
+	return corrected
+}

--- a/internal/orchestrator/knowledge_reconcile_test.go
+++ b/internal/orchestrator/knowledge_reconcile_test.go
@@ -1,0 +1,373 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+func TestReconcileInjectionState_NoDriftReturnsNil(t *testing.T) {
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]body[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift != nil {
+		t.Fatalf("no-drift case must return nil drift, got %+v", drift)
+	}
+	if len(corrected.KnownKnowledge) != 1 || corrected.KnownKnowledge[0].FirstInjectedTurn != 1 {
+		t.Errorf("no-drift state must round-trip unchanged, got %+v", corrected)
+	}
+}
+
+func TestReconcileInjectionState_MissingFromVisible(t *testing.T) {
+	// State thinks kb_b is known, but no kb_b block appears in
+	// messages — likely because a sliding-window cut dropped it.
+	// Reconciliation must drop kb_b from state and emit drift.
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+			{ArticleID: "kb_b", ContentSHA256: "bbb", FirstInjectedTurn: 2},
+		},
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]still here[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift == nil {
+		t.Fatal("expected drift, got nil")
+	}
+	if len(drift.MissingFromVisible) != 1 || drift.MissingFromVisible[0] != "bbb" {
+		t.Errorf("MissingFromVisible mismatch: %+v", drift.MissingFromVisible)
+	}
+	if len(drift.ExtrasInVisible) != 0 {
+		t.Errorf("ExtrasInVisible must be empty, got %+v", drift.ExtrasInVisible)
+	}
+	if len(corrected.KnownKnowledge) != 1 || corrected.KnownKnowledge[0].ContentSHA256 != "aaa" {
+		t.Errorf("corrected state must keep only the visible SHA, got %+v", corrected.KnownKnowledge)
+	}
+	if corrected.KnownKnowledge[0].FirstInjectedTurn != 1 {
+		t.Errorf("FirstInjectedTurn must survive reconciliation, got %d", corrected.KnownKnowledge[0].FirstInjectedTurn)
+	}
+}
+
+func TestReconcileInjectionState_ExtrasInVisible(t *testing.T) {
+	// A KC block reached the LLM that the state doesn't know about
+	// — e.g. a previous turn wrote the message but the state-update
+	// failed. Reconciliation must add it to state with
+	// FirstInjectedTurn=0 (synthetic "discovered via reconciliation").
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]known[/knowledge_context]`},
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_b" sha="bbb"]new arrival[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift == nil {
+		t.Fatal("expected drift, got nil")
+	}
+	if len(drift.ExtrasInVisible) != 1 || drift.ExtrasInVisible[0] != "bbb" {
+		t.Errorf("ExtrasInVisible mismatch: %+v", drift.ExtrasInVisible)
+	}
+	if len(corrected.KnownKnowledge) != 2 {
+		t.Fatalf("corrected state must include both SHAs, got %+v", corrected.KnownKnowledge)
+	}
+	// kb_b should land with FirstInjectedTurn=0 (synthetic marker).
+	for _, e := range corrected.KnownKnowledge {
+		if e.ContentSHA256 == "bbb" && e.FirstInjectedTurn != 0 {
+			t.Errorf("extras-in-visible entry must have FirstInjectedTurn=0, got %d", e.FirstInjectedTurn)
+		}
+	}
+}
+
+func TestReconcileInjectionState_BothDirectionsAtOnce(t *testing.T) {
+	// State thinks kb_a is known but it was cut; kb_b reached the LLM
+	// without the state knowing. Both drift signals should fire in
+	// one event.
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_b" sha="bbb"]new[/knowledge_context]`},
+	}
+	_, drift := reconcileInjectionState(msgs, persisted)
+	if drift == nil {
+		t.Fatal("expected drift, got nil")
+	}
+	if len(drift.MissingFromVisible) != 1 || drift.MissingFromVisible[0] != "aaa" {
+		t.Errorf("MissingFromVisible: %+v", drift.MissingFromVisible)
+	}
+	if len(drift.ExtrasInVisible) != 1 || drift.ExtrasInVisible[0] != "bbb" {
+		t.Errorf("ExtrasInVisible: %+v", drift.ExtrasInVisible)
+	}
+	if drift.ReconciliationAction != reconciliationActionRewriteFromVisible {
+		t.Errorf("ReconciliationAction = %q, want %q", drift.ReconciliationAction, reconciliationActionRewriteFromVisible)
+	}
+}
+
+func TestReconcileInjectionState_LegacyUntaggedBlocksIgnored(t *testing.T) {
+	// A legacy bare [knowledge_context] block carries no id/sha so
+	// reconciliation can't tie it back to state. It must be ignored
+	// for drift purposes — neither counted as extras_in_visible nor
+	// as authoritative-and-corrects-state.
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+		},
+	}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "[knowledge_context]\nlegacy body, no attributes\n[/knowledge_context]"},
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]tagged[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift != nil {
+		t.Fatalf("legacy block alongside matching tagged block must not trigger drift, got %+v", drift)
+	}
+	if len(corrected.KnownKnowledge) != 1 {
+		t.Errorf("corrected state must reflect only the ID-tagged blocks, got %+v", corrected.KnownKnowledge)
+	}
+}
+
+func TestReconcileInjectionState_DuplicateVisibleSHAs_DedupedInCorrectedState(t *testing.T) {
+	// The same article re-appears in two user messages (e.g. score-
+	// override re-injected it in turn 5 after turn 1). The corrected
+	// state must contain a single entry for that SHA.
+	persisted := state.InjectionState{}
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]copy 1[/knowledge_context]`},
+		{Role: provider.RoleUser, Content: `[knowledge_context id="kb_a" sha="aaa"]copy 2[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift == nil {
+		t.Fatal("expected drift (extra in visible)")
+	}
+	if len(corrected.KnownKnowledge) != 1 || corrected.KnownKnowledge[0].ContentSHA256 != "aaa" {
+		t.Errorf("dup-SHA must collapse to one entry, got %+v", corrected.KnownKnowledge)
+	}
+}
+
+func TestReconcileInjectionState_NonUserMessagesIgnored(t *testing.T) {
+	// Only user-role messages carry [knowledge_context] blocks by
+	// construction. A tagged block accidentally appearing in an
+	// assistant or tool message must not affect reconciliation.
+	persisted := state.InjectionState{}
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, Content: `[knowledge_context id="kb_a" sha="aaa"]wrong-role[/knowledge_context]`},
+		{Role: provider.RoleTool, Content: `[knowledge_context id="kb_b" sha="bbb"]wrong-role[/knowledge_context]`},
+	}
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift != nil {
+		t.Errorf("non-user-role blocks must not trigger drift, got %+v", drift)
+	}
+	if len(corrected.KnownKnowledge) != 0 {
+		t.Errorf("non-user-role blocks must not appear in corrected state, got %+v", corrected.KnownKnowledge)
+	}
+}
+
+func TestReconcileInjectionState_PreservesPhase4KnownTools(t *testing.T) {
+	// Phase 4's KnownTools entries must survive reconciliation
+	// regardless of knowledge-side drift.
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_drop", ContentSHA256: "drop", FirstInjectedTurn: 1},
+		},
+		KnownTools: []state.KnownToolEntry{
+			{ToolName: "timly__keep", Tier: "tier1", LRURank: 7},
+		},
+	}
+	msgs := []provider.Message{} // empty → kb_drop is missing
+	corrected, drift := reconcileInjectionState(msgs, persisted)
+	if drift == nil {
+		t.Fatal("expected drift on missing kb_drop")
+	}
+	if len(corrected.KnownTools) != 1 || corrected.KnownTools[0].ToolName != "timly__keep" {
+		t.Errorf("KnownTools must survive reconciliation, got %+v", corrected.KnownTools)
+	}
+}
+
+func TestReconcileAndEmitDrift_EmitsEventWithMissingAndExtras(t *testing.T) {
+	// End-to-end: a session with persisted state but a visible-message
+	// scan that disagrees. The orchestrator method must emit one
+	// drift_detected event with the correct buckets.
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {
+				KnownKnowledge: []state.KnownKnowledgeEntry{
+					{ArticleID: "kb_gone", ContentSHA256: "gone", FirstInjectedTurn: 1},
+				},
+			},
+		},
+	}
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	_ = sessions.AddMessage("s1", provider.Message{
+		Role:    provider.RoleUser,
+		Content: `[knowledge_context id="kb_new" sha="new"]surprise body[/knowledge_context]`,
+	})
+	orch := &Orchestrator{
+		sessions:            sessions,
+		eventSink:           sink,
+		injectionStateStore: dedupStore,
+	}
+	corrected := orch.reconcileAndEmitDrift(context.Background(), "s1")
+	if len(corrected.KnownKnowledge) != 1 || corrected.KnownKnowledge[0].ContentSHA256 != "new" {
+		t.Errorf("corrected state must reflect visible SHA, got %+v", corrected.KnownKnowledge)
+	}
+	evs := sink.snapshot()
+	drift := findEventByType(evs, events.TypeDriftDetected)
+	if drift == nil {
+		t.Fatal("drift_detected event missing")
+	}
+	var p events.DriftDetectedPayload
+	if err := json.Unmarshal(drift.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(p.MissingFromVisible) != 1 || p.MissingFromVisible[0] != "gone" {
+		t.Errorf("MissingFromVisible = %v", p.MissingFromVisible)
+	}
+	if len(p.ExtrasInVisible) != 1 || p.ExtrasInVisible[0] != "new" {
+		t.Errorf("ExtrasInVisible = %v", p.ExtrasInVisible)
+	}
+	if p.ReconciliationAction == "" {
+		t.Errorf("ReconciliationAction must be set")
+	}
+}
+
+func TestReconcileAndEmitDrift_NoStoreReturnsEmptyState(t *testing.T) {
+	// Defensive guard: when no InjectionStateStore is wired the
+	// reconciliation step still returns a usable (zero-valued) state
+	// so the dedup decision can proceed as if first-turn.
+	orch := &Orchestrator{
+		sessions:  state.NewSessionStore(""),
+		eventSink: &recordingEventSink{},
+	}
+	got := orch.reconcileAndEmitDrift(context.Background(), "s-no-store")
+	if len(got.KnownKnowledge) != 0 {
+		t.Errorf("nil-store path must return empty state, got %+v", got)
+	}
+}
+
+func TestReconcileInjectionState_EmptyBothReturnsNilDrift(t *testing.T) {
+	// Pinning the no-input case so a future refactor that adds a "drift
+	// on first-turn" misfeature gets caught: empty state + empty
+	// messages must produce no drift event.
+	corrected, drift := reconcileInjectionState(nil, state.InjectionState{})
+	if drift != nil {
+		t.Errorf("empty inputs must yield nil drift, got %+v", drift)
+	}
+	if len(corrected.KnownKnowledge) != 0 {
+		t.Errorf("empty inputs must yield empty corrected state, got %+v", corrected)
+	}
+}
+
+func TestReconcileInjectionState_EmptyMessagesDropsAllKnownKnowledge(t *testing.T) {
+	// State carries entries but the message stream is empty (e.g. a
+	// summarization just collapsed history). Reconciliation must wipe
+	// KnownKnowledge to match the visible truth.
+	persisted := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+			{ArticleID: "kb_b", ContentSHA256: "bbb", FirstInjectedTurn: 1},
+		},
+	}
+	corrected, drift := reconcileInjectionState(nil, persisted)
+	if drift == nil {
+		t.Fatal("expected drift, got nil")
+	}
+	if len(corrected.KnownKnowledge) != 0 {
+		t.Errorf("empty messages must drop all KnownKnowledge, got %+v", corrected.KnownKnowledge)
+	}
+	if len(drift.MissingFromVisible) != 2 {
+		t.Errorf("both SHAs must appear as missing, got %v", drift.MissingFromVisible)
+	}
+}
+
+func TestReconcileAndEmitDrift_GetStateErrorReturnsEmptyAndNoEvent(t *testing.T) {
+	// Robustness contract: when GetInjectionState fails the
+	// reconciliation step returns empty state (so the dedup decision
+	// treats every candidate as new) and does NOT emit drift_detected
+	// (there's nothing to reconcile against).
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{failGetErr: errors.New("simulated read failure")}
+	orch := &Orchestrator{
+		sessions:            state.NewSessionStore(""),
+		eventSink:           sink,
+		injectionStateStore: dedupStore,
+	}
+	got := orch.reconcileAndEmitDrift(context.Background(), "s1")
+	if len(got.KnownKnowledge) != 0 {
+		t.Errorf("read failure must yield empty state, got %+v", got)
+	}
+	if findEventByType(sink.snapshot(), events.TypeDriftDetected) != nil {
+		t.Errorf("read failure must not emit drift_detected")
+	}
+}
+
+func TestReconcileAndEmitDrift_SessionLookupErrorReturnsEmpty(t *testing.T) {
+	// Symmetric robustness path: when the session can't be loaded
+	// (e.g. evicted between turns) the visible-scan can't run, so the
+	// authoritative-visible rule defaults to empty state — caller
+	// treats every candidate as new rather than trusting stale state.
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownKnowledge: []state.KnownKnowledgeEntry{
+				{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+			}},
+		},
+	}
+	orch := &Orchestrator{
+		sessions:            state.NewSessionStore(""), // empty store — session "s1" doesn't exist
+		eventSink:           sink,
+		injectionStateStore: dedupStore,
+	}
+	got := orch.reconcileAndEmitDrift(context.Background(), "s1")
+	if len(got.KnownKnowledge) != 0 {
+		t.Errorf("session-lookup failure must yield empty state, got %+v", got)
+	}
+	if findEventByType(sink.snapshot(), events.TypeDriftDetected) != nil {
+		t.Errorf("session-lookup failure must not emit drift_detected")
+	}
+}
+
+func TestReconcileAndEmitDrift_NoDriftEmitsNothing(t *testing.T) {
+	// Regression guard: drift_detected must NOT fire on aligned state.
+	sink := &recordingEventSink{}
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	_ = sessions.AddMessage("s1", provider.Message{
+		Role:    provider.RoleUser,
+		Content: `[knowledge_context id="kb_a" sha="aaa"]body[/knowledge_context]`,
+	})
+	dedupStore := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownKnowledge: []state.KnownKnowledgeEntry{
+				{ArticleID: "kb_a", ContentSHA256: "aaa", FirstInjectedTurn: 1},
+			}},
+		},
+	}
+	orch := &Orchestrator{
+		sessions:            sessions,
+		eventSink:           sink,
+		injectionStateStore: dedupStore,
+	}
+	orch.reconcileAndEmitDrift(context.Background(), "s1")
+	if findEventByType(sink.snapshot(), events.TypeDriftDetected) != nil {
+		t.Error("no-drift path must not emit drift_detected")
+	}
+}

--- a/internal/orchestrator/knowledge_reconcile_test.go
+++ b/internal/orchestrator/knowledge_reconcile_test.go
@@ -186,7 +186,7 @@ func TestReconcileInjectionState_PreservesPhase4KnownTools(t *testing.T) {
 			{ArticleID: "kb_drop", ContentSHA256: "drop", FirstInjectedTurn: 1},
 		},
 		KnownTools: []state.KnownToolEntry{
-			{ToolName: "timly__keep", Tier: "tier1", LRURank: 7},
+			{ToolName: "timly__keep", Tier: state.KnownToolTier1, LRURank: 7},
 		},
 	}
 	msgs := []provider.Message{} // empty → kb_drop is missing

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4433,21 +4433,6 @@ func fnv64a(s string) uint64 {
 	return h
 }
 
-// stripKnowledgeContext removes [knowledge_context]...[/knowledge_context] blocks
-// from a message. Used to strip historical knowledge context and planner input.
-func stripKnowledgeContext(s string) string {
-	const open, close = "[knowledge_context]", "[/knowledge_context]"
-	start := strings.Index(s, open)
-	if start < 0 {
-		return s
-	}
-	end := strings.Index(s, close)
-	if end < 0 {
-		return s
-	}
-	return strings.TrimSpace(s[:start] + s[end+len(close):])
-}
-
 func capabilitiesToPlannerInfo(caps []PluginCapability) []pipeline.CapabilityInfo {
 	result := make([]pipeline.CapabilityInfo, len(caps))
 	for i, cap := range caps {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2141,7 +2141,17 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// action needs confirmation, pause the agent loop and return a
 			// confirmation prompt to the user. The pending call is stored
 			// and executed on the next message if approved.
-			if o.confirmationPlugin != "" && o.confirmationAction != "" && !calls[i].ConfirmationBypass {
+			//
+			// Skip the entire gate for actions whose manifest declares
+			// `read_only = true`. Pure queries don't need user approval
+			// and asking would be noise — both to the user (a yes/no
+			// prompt for a list/show call) and to the LLM budget (a
+			// planner-narration round-trip per call). The flag originates
+			// from the plugin's manifest (for MCP-sourced tools, propagated
+			// from `annotations.readOnlyHint`).
+			if o.confirmationPlugin != "" && o.confirmationAction != "" &&
+				!calls[i].ConfirmationBypass &&
+				!o.registry.IsActionReadOnly(calls[i].Plugin, calls[i].Action) {
 				confResult := o.checkConfirmationPlugin(ctx, []*pipeline.Step{{
 					ID:      calls[i].ID,
 					Name:    calls[i].Action,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1321,9 +1321,25 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		if dedupActive {
 			content = o.prepareDedupDecision(ctx, sessionID, content, &prepAgg)
 		}
+		// RFC #249 Phase 4 tier decision: same activation contract as
+		// dedup (skip on legacy_fallback so the LLM sees the plugin's
+		// raw injection; skip without a state store so LRU has nowhere
+		// to persist). When both dedup and tier run, prepareToolTier-
+		// Decision merges its KnownTools delta into the dedup
+		// decision's UpdatedState — the dedup persist then writes both
+		// in one round-trip.
+		tierActive := !legacyFallback &&
+			o.toolTiers.Enabled &&
+			o.injectionStateStore != nil
+		if tierActive {
+			o.prepareToolTierDecision(ctx, sessionID, &prepAgg)
+		}
 		o.emitPreparerDecision(ctx, prepAgg)
 		if dedupActive {
 			o.persistDedupDecision(ctx, sessionID, &prepAgg)
+		}
+		if tierActive {
+			o.persistToolTierDecision(ctx, sessionID, &prepAgg)
 		}
 		// Store relevant tools in context so buildSystemPrompt and planner can filter.
 		if relevantToolsSet {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -286,6 +286,15 @@ type Orchestrator struct {
 	pendingPipelines        map[string]*pipeline.Pipeline // sessionID -> pending pipeline
 	pendingToolCalls        map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
 	pendingConfirmationIDs  map[string]string             // sessionID -> session-event id of the confirmation_requested event; stamped as parent on the matching confirmation_resolved emit
+	// recentToolPromotions holds tool names the LLM pulled in via
+	// _meta.get_tool_details since the last preparer pass on each
+	// session. persistToolPromotion appends; promotedToolsThisTurn
+	// returns + clears. In-memory only — across orchestrator restart
+	// the LRU rank persisted to InjectionState still puts the tool
+	// in Tier 1, just without the promoted_via_get_tool_details
+	// provenance flag on the next preparer_decision.
+	recentToolPromotionsMu  sync.Mutex
+	recentToolPromotions    map[string][]string
 	pipelineConfig          pipeline.PipelineConfig
 	confirmationPlugin      string                  // optional; plugin for confirmation strategy
 	confirmationAction      string                  // optional; action name for confirmation check
@@ -469,6 +478,7 @@ func NewWithRules(
 		pendingPipelines:        make(map[string]*pipeline.Pipeline),
 		pendingToolCalls:        make(map[string]*ToolCall),
 		pendingConfirmationIDs:  make(map[string]string),
+		recentToolPromotions:    make(map[string][]string),
 		pipelineConfig:          pipelineCfg,
 		confirmationPlugin:      opts.ConfirmationPlugin,
 		confirmationAction:      opts.ConfirmationAction,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1357,7 +1357,16 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		if tierActive {
 			o.prepareToolTierDecision(ctx, sessionID, &prepAgg)
 		}
-		o.emitPreparerDecision(ctx, prepAgg)
+		decisionID := o.emitPreparerDecision(ctx, prepAgg)
+		if decisionID != "" {
+			refs, tier1Count, tier3Count := turnStartRefsFromAggregate(prepAgg)
+			ctx = withTurnStartContext(ctx, turnStartContext{
+				PreparerDecisionID: decisionID,
+				InjectedKnowledge:  refs,
+				Tier1Count:         tier1Count,
+				Tier3Count:         tier3Count,
+			})
+		}
 		if dedupActive {
 			o.persistDedupDecision(ctx, sessionID, &prepAgg)
 		}
@@ -2458,6 +2467,18 @@ func (o *Orchestrator) prepareTurnStart(ctx context.Context, systemPrompt, model
 	sort.Slice(args.AvailableTools, func(i, j int) bool {
 		return args.AvailableTools[i].Name < args.AvailableTools[j].Name
 	})
+	// RFC #249 Pillar C: quote the preparer-phase references back into
+	// turn_start so consumers can render the preparer outcome in-place
+	// without walking sibling events by parent_id. The ctx slot is
+	// populated by the preparer-loop after emitPreparerDecision; absent
+	// on early-exit paths (no preparer ran / no signal) — the zero
+	// values then leave the new fields omitted from the payload.
+	if tsc, ok := turnStartContextFromContext(ctx); ok {
+		args.PreparerDecisionID = tsc.PreparerDecisionID
+		args.InjectedKnowledge = tsc.InjectedKnowledge
+		args.ToolTier1Count = tsc.Tier1Count
+		args.ToolTier3Count = tsc.Tier3Count
+	}
 	return args
 }
 
@@ -3087,12 +3108,53 @@ func (o *Orchestrator) applySlidingWindow(ctx context.Context, msgs []provider.M
 		return msgs
 	}
 	dropped := len(msgs) - o.contextMessages
+	// RFC #249 Pillar C: scan the dropped slice for [knowledge_context]
+	// blocks so consumers can correlate the cut with InjectionState
+	// release without re-reconciling. Visible-message scan is the same
+	// data source the next preparer pass uses for lazy reconciliation,
+	// so the two numbers stay in lockstep without a DB read here.
+	released := releasedKnowledgeIDs(msgs[:dropped])
+	remaining := len(uniqueKnowledgeArticles(scanVisibleKnowledgeBlocks(msgs[dropped:])))
 	emit.EmitMessagesTruncated(ctx, o.eventSink, emit.MessagesTruncatedArgs{
-		DroppedSeqFrom: 0,
-		DroppedSeqTo:   dropped - 1,
-		DroppedCount:   dropped,
+		DroppedSeqFrom:               0,
+		DroppedSeqTo:                 dropped - 1,
+		DroppedCount:                 dropped,
+		ReleasedKnowledgeIDs:         released,
+		RemainingKnownKnowledgeCount: remaining,
 	})
 	return msgs[dropped:]
+}
+
+// releasedKnowledgeIDs returns the deduplicated article_ids whose
+// [knowledge_context] blocks live in the given message slice. Empty
+// when the slice carries no KC-bearing user messages or every block
+// is the legacy untagged shape (where ArticleID is unknown).
+// Used by both the sliding-window cutter and the summarization
+// trim — both replace the message slice with a stand-in, releasing
+// every KC reference inside the replaced range.
+func releasedKnowledgeIDs(messages []provider.Message) []string {
+	return uniqueKnowledgeArticles(scanVisibleKnowledgeBlocks(messages))
+}
+
+// uniqueKnowledgeArticles collapses a parsedKCBlock slice to its
+// distinct article_ids in first-seen order. Blocks without an
+// article_id (legacy untagged form) are skipped — they cannot be
+// correlated with InjectionState anyway. Returns nil when nothing
+// to report so the emitted payload omits the field cleanly.
+func uniqueKnowledgeArticles(blocks []parsedKCBlock) []string {
+	if len(blocks) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(blocks))
+	var out []string
+	for _, b := range blocks {
+		if b.ArticleID == "" || seen[b.ArticleID] {
+			continue
+		}
+		seen[b.ArticleID] = true
+		out = append(out, b.ArticleID)
+	}
+	return out
 }
 
 func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, userMessage string, includeServerInstructions ...bool) []provider.Message {
@@ -4026,9 +4088,10 @@ func (o *Orchestrator) maybeSummarizeSession(ctx context.Context, sessionID stri
 		return
 	}
 	emit.EmitSummarizationCompleted(ctx, o.eventSink, emit.SummarizationCompletedArgs{
-		Summary:      newSummary,
-		KeptMessages: len(keepMessages),
-		LatencyMS:    time.Since(summarizeStart).Milliseconds(),
+		Summary:              newSummary,
+		KeptMessages:         len(keepMessages),
+		LatencyMS:            time.Since(summarizeStart).Milliseconds(),
+		ReleasedKnowledgeIDs: releasedKnowledgeIDs(toSummarize),
 	})
 }
 
@@ -4166,6 +4229,36 @@ func formatToolResultMessage(result ToolResult) string {
 		return fmt.Sprintf("[tool_result] error: %s", result.Error)
 	}
 	return fmt.Sprintf("[tool_result] %s", result.Content)
+}
+
+// turnStartContextKey is the ctx slot the preparer phase fills in
+// after emitPreparerDecision so prepareTurnStart can quote the
+// decision back as TurnStartPayload.PreparerDecisionID +
+// InjectedKnowledge + tier1/tier3 counts (RFC #249 Pillar C). Set
+// inside the same Run call, before EmitTurnStart fires.
+type turnStartContextKey struct{}
+
+// turnStartContext carries the preparer-phase references the next
+// turn_start event quotes. PreparerDecisionID may be "" when no
+// preparer_decision event was emitted (no signal in the aggregate);
+// in that case InjectedKnowledge / Tier1Count / Tier3Count are also
+// zero values and the turn_start payload omits all four under
+// `omitempty`. See turnStartRefsFromAggregate for the per-mode
+// derivation.
+type turnStartContext struct {
+	PreparerDecisionID string
+	InjectedKnowledge  []events.KnowledgeRef
+	Tier1Count         int
+	Tier3Count         int
+}
+
+func withTurnStartContext(ctx context.Context, tsc turnStartContext) context.Context {
+	return context.WithValue(ctx, turnStartContextKey{}, tsc)
+}
+
+func turnStartContextFromContext(ctx context.Context) (turnStartContext, bool) {
+	v, ok := ctx.Value(turnStartContextKey{}).(turnStartContext)
+	return v, ok
 }
 
 // relevantToolsKey is the context key for tool filtering from preparer responses.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -157,6 +157,37 @@ type InjectionStateStore interface {
 	UpdateInjectionState(ctx context.Context, sessionID string, st state.InjectionState) error
 }
 
+// ToolTiersConfig is the runtime form of the RFC #249 Phase 4 tool-tier
+// visibility flags. Zero values are normalized to the RFC defaults in
+// NewWithRules, mirroring the KnowledgeDedupConfig precedent. Enabled
+// is the master switch — when false the orchestrator falls back to the
+// pre-Phase-4 behaviour (all RAG-matched tools land in `tools` with
+// full schemas) and the Tier-2/Tier-3 system-prompt sections are
+// suppressed.
+//
+// EnableGetToolDetails activates the meta-tool that lets the LLM
+// promote a Tier-2/Tier-3 tool back to Tier 1 on demand. Setting it
+// true with Enabled=false would expose a tool no one can use, so the
+// normalization step in NewWithRules upgrades Enabled to true in that
+// case (matching the operator-friendly intent of the YAML flag).
+type ToolTiersConfig struct {
+	Enabled              bool
+	Tier1Cap             int  // max Tier-1 tools (full schemas in `tools`); default 10
+	Tier2Cap             int  // max Tier-2 tools (name + 1-line summary in system prompt); default 15
+	EnableGetToolDetails bool // expose the LLM-driven promotion meta-tool; default false
+}
+
+// ToolErrorHandlingConfig is the runtime form of the RFC #249 Phase 4
+// tool-failure protections. Zero values normalize to the RFC defaults
+// in NewWithRules. LoopCapPerTurn governs the in-loop "Tool X failed N
+// times" system-message injection; StickyDemotionThreshold governs the
+// session-level demotion flag in known_tools. Successful invocations
+// reset both counters (self-healing).
+type ToolErrorHandlingConfig struct {
+	LoopCapPerTurn          int // consecutive identical-tool errors per turn before system-msg injection; default 2
+	StickyDemotionThreshold int // consecutive session-level errors before known_tools demotion; default 3
+}
+
 // OrchestratorOpts holds optional configuration for NewWithRules. Zero values mean defaults (no permission check, no summarization).
 type OrchestratorOpts struct {
 	CustomRules             []string
@@ -175,24 +206,26 @@ type OrchestratorOpts struct {
 	PipelineEnabled         bool                          // when true, create Planner from llm
 	PlanTimeout             time.Duration                 // max time for planner LLM call; 0 = default 15s
 	PipelineConfig          pipeline.PipelineConfig
-	ConfirmationPlugin      string                 // optional; plugin name for confirmation strategy (e.g. "planner")
-	ConfirmationAction      string                 // optional; action name (e.g. "check_confirmation")
-	ContextWindow           int                    // model context window in tokens; 0 = no trimming
-	MaxConcurrentSessions   int                    // max sessions running in parallel; default 1 (sequential)
-	GroupPluginLookup       GroupPluginLookup      // optional; when set, filters tool list by profile group
-	UsageRecorder           UsageRecorder          // optional; when set, records LLM usage after each run
-	PluginCallObserver      PluginCallObserver     // optional; when set, notified after each plugin/tool call
-	EventSink               emit.Sink              // optional; nil defaults to emit.NoOpSink (helpers run unconditionally, the no-op sink discards them)
-	PromptSnapshotStore     PromptSnapshotUpserter // optional; when set, system prompt + server instructions + tool descriptions are persisted by sha256 so turn_start hashes resolve to content
-	SyncActionsPlugin       string                 // optional; plugin name for action sync (e.g. "weaviate")
-	SyncActionsAction       string                 // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
-	SyncGlossaryAction      string                 // optional; action name for glossary sync (e.g. "sync_glossary"); uses SyncActionsPlugin
-	Knowledge               KnowledgeConfig        // optional; knowledge directory ingestion
-	Subprocess              SubprocessConfig       // optional; subprocess (sub-agent) support
-	OnStreamChunk           StreamChunkCallback    // optional; when set and LLM supports streaming, final answers are streamed
-	ShowToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
-	KnowledgeDedup          KnowledgeDedupConfig   // RFC #249 Phase 3 dedup flags; zero value disables (= instrumentation_only mode)
-	InjectionStateStore     InjectionStateStore    // optional; required only when KnowledgeDedup.Enabled is true
+	ConfirmationPlugin      string                  // optional; plugin name for confirmation strategy (e.g. "planner")
+	ConfirmationAction      string                  // optional; action name (e.g. "check_confirmation")
+	ContextWindow           int                     // model context window in tokens; 0 = no trimming
+	MaxConcurrentSessions   int                     // max sessions running in parallel; default 1 (sequential)
+	GroupPluginLookup       GroupPluginLookup       // optional; when set, filters tool list by profile group
+	UsageRecorder           UsageRecorder           // optional; when set, records LLM usage after each run
+	PluginCallObserver      PluginCallObserver      // optional; when set, notified after each plugin/tool call
+	EventSink               emit.Sink               // optional; nil defaults to emit.NoOpSink (helpers run unconditionally, the no-op sink discards them)
+	PromptSnapshotStore     PromptSnapshotUpserter  // optional; when set, system prompt + server instructions + tool descriptions are persisted by sha256 so turn_start hashes resolve to content
+	SyncActionsPlugin       string                  // optional; plugin name for action sync (e.g. "weaviate")
+	SyncActionsAction       string                  // optional; action name for sync (e.g. "sync_actions"); requires SyncActionsPlugin
+	SyncGlossaryAction      string                  // optional; action name for glossary sync (e.g. "sync_glossary"); uses SyncActionsPlugin
+	Knowledge               KnowledgeConfig         // optional; knowledge directory ingestion
+	Subprocess              SubprocessConfig        // optional; subprocess (sub-agent) support
+	OnStreamChunk           StreamChunkCallback     // optional; when set and LLM supports streaming, final answers are streamed
+	ShowToolCalls           string                  // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	KnowledgeDedup          KnowledgeDedupConfig    // RFC #249 Phase 3 dedup flags; zero value disables (= instrumentation_only mode)
+	InjectionStateStore     InjectionStateStore     // optional; required only when KnowledgeDedup.Enabled is true
+	ToolTiers               ToolTiersConfig         // RFC #249 Phase 4 three-tier tool visibility flags; zero value disables (= pre-Phase-4 single-tier behaviour)
+	ToolErrorHandling       ToolErrorHandlingConfig // RFC #249 Phase 4 tool-failure protections; zero value normalizes to RFC defaults
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -254,23 +287,25 @@ type Orchestrator struct {
 	pendingToolCalls        map[string]*ToolCall          // sessionID -> pending tool call awaiting confirmation
 	pendingConfirmationIDs  map[string]string             // sessionID -> session-event id of the confirmation_requested event; stamped as parent on the matching confirmation_resolved emit
 	pipelineConfig          pipeline.PipelineConfig
-	confirmationPlugin      string                 // optional; plugin for confirmation strategy
-	confirmationAction      string                 // optional; action name for confirmation check
-	contextWindow           int                    // model context window in tokens; 0 = no trimming
-	groupPluginLookup       GroupPluginLookup      // optional; nil = no group-based filtering
-	usageRecorder           UsageRecorder          // optional; nil = no usage tracking
-	pluginCallObserver      PluginCallObserver     // optional; nil = no plugin call observation
-	eventSink               emit.Sink              // structured session event sink; always non-nil (NoOpSink default)
-	snapshotStore           PromptSnapshotUpserter // optional; nil = turn_start hashes are emitted but content is not persisted
-	syncActionsPlugin       string                 // optional; plugin name for action sync
-	syncActionsAction       string                 // optional; action name for action sync
-	syncGlossaryAction      string                 // optional; action name for glossary sync (uses syncActionsPlugin)
-	knowledge               KnowledgeConfig        // optional; knowledge directory ingestion
-	subprocessConfig        SubprocessConfig       // optional; subprocess (sub-agent) support
-	onStreamChunk           StreamChunkCallback    // optional; when set, final answers stream to caller
-	showToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
-	knowledgeDedup          KnowledgeDedupConfig   // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
-	injectionStateStore     InjectionStateStore    // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
+	confirmationPlugin      string                  // optional; plugin for confirmation strategy
+	confirmationAction      string                  // optional; action name for confirmation check
+	contextWindow           int                     // model context window in tokens; 0 = no trimming
+	groupPluginLookup       GroupPluginLookup       // optional; nil = no group-based filtering
+	usageRecorder           UsageRecorder           // optional; nil = no usage tracking
+	pluginCallObserver      PluginCallObserver      // optional; nil = no plugin call observation
+	eventSink               emit.Sink               // structured session event sink; always non-nil (NoOpSink default)
+	snapshotStore           PromptSnapshotUpserter  // optional; nil = turn_start hashes are emitted but content is not persisted
+	syncActionsPlugin       string                  // optional; plugin name for action sync
+	syncActionsAction       string                  // optional; action name for action sync
+	syncGlossaryAction      string                  // optional; action name for glossary sync (uses syncActionsPlugin)
+	knowledge               KnowledgeConfig         // optional; knowledge directory ingestion
+	subprocessConfig        SubprocessConfig        // optional; subprocess (sub-agent) support
+	onStreamChunk           StreamChunkCallback     // optional; when set, final answers stream to caller
+	showToolCalls           string                  // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	knowledgeDedup          KnowledgeDedupConfig    // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
+	injectionStateStore     InjectionStateStore     // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
+	toolTiers               ToolTiersConfig         // RFC #249 Phase 4 tier-visibility flags; Enabled=false short-circuits to pre-Phase-4 single-tier behaviour
+	toolErrorHandling       ToolErrorHandlingConfig // RFC #249 Phase 4 tool-failure protections; thresholds always carry RFC defaults after NewWithRules
 	// legacyKnowledgeWarnings tracks the (sessionID, pluginName) pairs
 	// we've already deprecation-warned for, so a session that keeps
 	// using a legacy preparer doesn't spam the log every turn. Key is
@@ -382,6 +417,31 @@ func NewWithRules(
 		dedupCfg.CapPerTurn = 5
 	}
 
+	// Normalize ToolTiers + ToolErrorHandling to RFC #249 Phase 4
+	// defaults, same precedent as KnowledgeDedup above. Enabled stays
+	// false by default. EnableGetToolDetails carries an extra rule:
+	// turning the meta-tool on with the master switch still off would
+	// register a Tier-0 tool no one can use, so we upgrade Enabled to
+	// true in that case — keeps the YAML surface obvious for operators
+	// who only set the meta-tool flag.
+	tierCfg := opts.ToolTiers
+	if tierCfg.Tier1Cap == 0 {
+		tierCfg.Tier1Cap = 10
+	}
+	if tierCfg.Tier2Cap == 0 {
+		tierCfg.Tier2Cap = 15
+	}
+	if tierCfg.EnableGetToolDetails {
+		tierCfg.Enabled = true
+	}
+	errCfg := opts.ToolErrorHandling
+	if errCfg.LoopCapPerTurn == 0 {
+		errCfg.LoopCapPerTurn = 2
+	}
+	if errCfg.StickyDemotionThreshold == 0 {
+		errCfg.StickyDemotionThreshold = 3
+	}
+
 	o := &Orchestrator{
 		sessionMuxes:            make(map[string]*sessionMutex),
 		semaphore:               semaphore,
@@ -425,6 +485,8 @@ func NewWithRules(
 		showToolCalls:           opts.ShowToolCalls,
 		knowledgeDedup:          dedupCfg,
 		injectionStateStore:     opts.InjectionStateStore,
+		toolTiers:               tierCfg,
+		toolErrorHandling:       errCfg,
 	}
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2348,13 +2348,7 @@ func (o *Orchestrator) supportsNativeTools() bool {
 // for native function calling. Only includes actions visible to the current profile.
 func (o *Orchestrator) buildToolDefinitions(ctx context.Context) []provider.ToolDefinition {
 	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
-	preparerAction := make(map[string]bool)
-	for _, prep := range o.preparers {
-		preparerAction[prep.Plugin+"."+prep.Action] = true
-	}
-	for _, g := range o.guards {
-		preparerAction[g.Plugin+"."+g.Action] = true
-	}
+	preparerAction := preparerActionSet(o.preparers, o.guards)
 
 	relevantToolSet := make(map[string]bool)
 	rtTools, relevantToolsActive := relevantToolsFromContext(ctx)
@@ -3361,13 +3355,7 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 	}
 
 	// Don't list content-preparer or guard actions as tools; they run automatically before LLM calls.
-	preparerAction := make(map[string]bool)
-	for _, prep := range o.preparers {
-		preparerAction[prep.Plugin+"."+prep.Action] = true
-	}
-	for _, g := range o.guards {
-		preparerAction[g.Plugin+"."+g.Action] = true
-	}
+	preparerAction := preparerActionSet(o.preparers, o.guards)
 
 	// Resolve the set of plugins allowed for the current profile group (if any).
 	allowedPlugins := o.resolveAllowedPlugins(ctx)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -271,6 +271,12 @@ type Orchestrator struct {
 	showToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
 	knowledgeDedup          KnowledgeDedupConfig   // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
 	injectionStateStore     InjectionStateStore    // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
+	// legacyKnowledgeWarnings tracks the (sessionID, pluginName) pairs
+	// we've already deprecation-warned for, so a session that keeps
+	// using a legacy preparer doesn't spam the log every turn. Key is
+	// "<sessionID>|<pluginName>"; value is unused. Zero value is
+	// usable directly, so no NewWithRules wiring is needed.
+	legacyKnowledgeWarnings sync.Map
 }
 
 // resolveAllowedPluginNames returns a JSON array of allowed plugin names for the
@@ -1223,18 +1229,33 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// candidate slices for the composite preparer_decision
 			// emitted after the loop.
 			o.emitPreparerRetrievals(ctx, userMessage, searchSource, outcome.Response)
-			prepAgg.append(outcome.Response)
+			prepAgg.append(prep.Plugin, outcome.Response)
 		}
-		// RFC #249 Phase 3 dedup: when the operator has flipped the
-		// knowledge_dedup.enabled flag AND a store is wired up AND
-		// at least one preparer returned structured KnowledgeCandidates,
-		// run the dedup decision over the aggregate candidate list.
-		// The content rewrite happens before the event emits; state
-		// persist happens AFTER the emit so the event log is the
-		// durable record even on partial failure (RFC #249 cross-phase
-		// invariant). When any precondition is false the path falls
-		// through to Phase 2's mode = "instrumentation_only".
-		dedupActive := o.knowledgeDedup.Enabled && o.injectionStateStore != nil && len(prepAgg.Knowledge) > 0
+		// RFC #249 Phase 3 dedup decision tree:
+		//   - Any preparer used the legacy [knowledge_context]-in-Message
+		//     shape AND dedup is enabled → mode=legacy_fallback. Skip
+		//     the dedup pass entirely (content stays as the legacy
+		//     plugin produced it), log one deprecation warning per
+		//     (plugin, session).
+		//   - Dedup enabled AND store wired AND structured candidates
+		//     present → run the full dedup decision; content rewrite
+		//     happens before the event emits, state persist happens
+		//     AFTER the emit so the event log is the durable record
+		//     even on partial failure (RFC #249 cross-phase invariant).
+		//   - Otherwise → Phase 2 mode = instrumentation_only.
+		// prepAgg.LegacyKnowledgePlugins is built by the sequential
+		// preparer loop above; no concurrent access. If that loop
+		// ever parallelizes, the append in preparerAggregate.append
+		// would race — keep the assumption documented here so the
+		// next refactor knows to guard the aggregate.
+		legacyFallback := o.knowledgeDedup.Enabled && len(prepAgg.LegacyKnowledgePlugins) > 0
+		if legacyFallback {
+			o.warnLegacyKnowledgePluginsOnce(ctx, sessionID, prepAgg.LegacyKnowledgePlugins)
+		}
+		dedupActive := !legacyFallback &&
+			o.knowledgeDedup.Enabled &&
+			o.injectionStateStore != nil &&
+			len(prepAgg.Knowledge) > 0
 		if dedupActive {
 			content = o.prepareDedupDecision(ctx, sessionID, content, &prepAgg)
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2235,6 +2235,38 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			if toolResult.Error != "" {
 				log.Warn("tool call error", "plugin", call.Plugin, "action", call.Action, "error", toolResult.Error)
 			}
+
+			// Same-turn promotion completion for _meta.get_tool_details.
+			// The executor (system_tools.go) already persists a Tier-1
+			// KnownToolEntry so the NEXT turn's preparer puts the tool
+			// in the LLM's tools array. Without the rebuild below the
+			// promotion would not take effect IN THE CURRENT TURN for
+			// native-tools-mode providers — the per-Run cachedTools
+			// snapshot built before the loop would still drive every
+			// subsequent round's `req.Tools`, leaving the LLM with the
+			// same Tier-3-name-only entry it just looked up.
+			//
+			// Gated on:
+			//   * native-tools mode (text-mode LLMs read the description
+			//     directly out of tool_call_result; cachedTools is
+			//     irrelevant on that path)
+			//   * successful meta-tool result (failed lookups don't
+			//     promote anything)
+			//   * non-empty "name" arg (executor already rejects empty,
+			//     but we double-gate to keep the rebuild path tight)
+			//
+			// withPromotedTool is a no-op when no relevant-tools list is
+			// set (no preparer ran) — buildToolDefinitions already
+			// exposes every allowed tool in that mode.
+			if nativeMode && toolResult.Error == "" &&
+				call.Plugin == metaPluginName && call.Action == metaGetToolDetails {
+				if promoted := strings.TrimSpace(call.Args["name"]); promoted != "" {
+					ctx = withPromotedTool(ctx, promoted)
+					cachedTools = o.buildToolDefinitions(ctx)
+					log.Debug("cachedTools refreshed after _meta.get_tool_details promotion",
+						"tool", promoted, "tools_count", len(cachedTools))
+				}
+			}
 			// RFC #249 Phase 4 D5: update the consecutive-error counters,
 			// inject the "Tool X failed N times" nudge into the next LLM
 			// iteration when LoopCapPerTurn trips, and flip the Demoted
@@ -4160,6 +4192,39 @@ func relevantToolsFromContext(ctx context.Context) ([]string, bool) {
 		return nil, false
 	}
 	return r.tools, true
+}
+
+// withPromotedTool augments the relevant-tools list on ctx with toolName.
+// Idempotent: a name already in the list returns ctx unchanged. When no
+// relevant-tools list is set (no preparer ran for this turn), returns ctx
+// unchanged because buildToolDefinitions already exposes every tool in
+// that mode — there's nothing to promote.
+//
+// Used by the agent-loop's `_meta.get_tool_details` follow-through to put
+// the just-inspected tool into the SAME turn's tools array on the next
+// LLM round. Without it the promotion only takes effect next user turn
+// via the InjectionState LRU rank; the contract on get_tool_details's
+// description ("promotes the tool back to the LLM's tools array for the
+// rest of the session") needs the same-turn step too for native-tools
+// mode, where the cached tools array is what the LLM API gets verbatim
+// on every round.
+func withPromotedTool(ctx context.Context, toolName string) context.Context {
+	if toolName == "" {
+		return ctx
+	}
+	existing, ok := relevantToolsFromContext(ctx)
+	if !ok {
+		return ctx
+	}
+	for _, t := range existing {
+		if t == toolName {
+			return ctx
+		}
+	}
+	updated := make([]string, len(existing)+1)
+	copy(updated, existing)
+	updated[len(existing)] = toolName
+	return withRelevantTools(ctx, updated)
 }
 
 type searchQueryKey struct{}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -491,6 +491,17 @@ func NewWithRules(
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)
 
+	// Register the orchestrator-owned get_tool_details meta-tool when
+	// ToolTiersConfig.EnableGetToolDetails is set. AlwaysInclude on
+	// the registered action pins it into Tier 0 so the LLM always
+	// has a path back to full schemas for Tier-2/3 entries. The
+	// runtime normalization above also flips toolTiers.Enabled=true
+	// when this flag is on, so the rest of the tier pipeline (which
+	// the meta-tool depends on) is always coherent.
+	if o.toolTiers.EnableGetToolDetails {
+		o.registerGetToolDetailsTool()
+	}
+
 	// Register the built-in _subprocess plugin when enabled.
 	o.subprocessConfig = opts.Subprocess
 	if opts.Subprocess.Enabled {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4355,6 +4355,17 @@ func (o *Orchestrator) resolveAllowedPlugins(ctx context.Context) cachedAllowedP
 // Non-strict mode (group DB lookup): only capabilities that have AllowedGroups set
 // are gated; capabilities without AllowedGroups remain publicly visible.
 func (o *Orchestrator) pluginAllowed(cap PluginCapability, allowed cachedAllowedPlugins) bool {
+	if cap.Name == metaPluginName {
+		// `_meta` is orchestrator-owned (host-internal namespace) — every
+		// profile that has the meta-tool registered (i.e. tool_tiers config
+		// enables get_tool_details) should be able to call it. The profile /
+		// WhoAmI plugin-list gate is for external plugins and a customer's
+		// WhoAmI response never lists `_meta` because it isn't a plugin the
+		// customer owns. Special-casing here so an LLM-driven
+		// `_meta.get_tool_details` call doesn't get refused for a profile
+		// that legitimately registered the meta-tool via config.
+		return true
+	}
 	if allowed.m == nil {
 		// No profile / no lookup configured — unrestricted.
 		return true

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2820,6 +2820,31 @@ func hasToolResults(msgs []provider.Message) bool {
 	return false
 }
 
+// applySlidingWindow keeps only the last o.contextMessages entries
+// from msgs when configured. When the cut fires, it emits one
+// messages_truncated event with the dropped index range so analytics
+// can correlate context-window pressure across sessions. Returns the
+// (possibly shortened) slice; when contextMessages is zero or the
+// input fits, returns msgs unchanged with no event.
+//
+// Called from both buildMessages and buildMessagesWithPrompt inside
+// the agent loop, so a long tool-call session can produce multiple
+// messages_truncated events per turn — each one represents a
+// distinct cut that actually dropped something. Consumers that want
+// "the first cut per turn" should fold by turn_start parent.
+func (o *Orchestrator) applySlidingWindow(ctx context.Context, msgs []provider.Message) []provider.Message {
+	if o.contextMessages <= 0 || len(msgs) <= o.contextMessages {
+		return msgs
+	}
+	dropped := len(msgs) - o.contextMessages
+	emit.EmitMessagesTruncated(ctx, o.eventSink, emit.MessagesTruncatedArgs{
+		DroppedSeqFrom: 0,
+		DroppedSeqTo:   dropped - 1,
+		DroppedCount:   dropped,
+	})
+	return msgs[dropped:]
+}
+
 func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, userMessage string, includeServerInstructions ...bool) []provider.Message {
 	messages := make([]provider.Message, 0, len(sess.Messages)+4)
 
@@ -2844,13 +2869,11 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 			Content: "Previous conversation summary: " + sess.Summary,
 		})
 	}
-	// When context_messages is set, keep only the last N messages to avoid
-	// blowing the context window. This is a simple sliding window that
-	// preserves tool results (unlike LLM summarization which loses them).
-	convMessages := sess.Messages
-	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
-		convMessages = convMessages[len(convMessages)-o.contextMessages:]
-	}
+	// Apply the sliding-window cutter (config-driven via o.contextMessages)
+	// and emit messages_truncated when it fires. Both buildMessages and
+	// buildMessagesWithPrompt go through the same helper so analytics see
+	// exactly one event per cut regardless of which assembly path ran.
+	convMessages := o.applySlidingWindow(ctx, sess.Messages)
 	// Strip [knowledge_context] from HISTORICAL user messages only. The
 	// current turn's user message is preserved verbatim so preparer-injected
 	// RAG content actually reaches the LLM. Historical turns are still
@@ -2909,10 +2932,7 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 			Content: "Previous conversation summary: " + sess.Summary,
 		})
 	}
-	convMessages := sess.Messages
-	if o.contextMessages > 0 && len(convMessages) > o.contextMessages {
-		convMessages = convMessages[len(convMessages)-o.contextMessages:]
-	}
+	convMessages := o.applySlidingWindow(ctx, sess.Messages)
 	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
 
 	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1341,6 +1341,19 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		if tierActive {
 			o.persistToolTierDecision(ctx, sessionID, &prepAgg)
 		}
+		// RFC #249 Phase 4: when the tier decision ran, override the
+		// relevant_tools narrowing to Tier 0 + Tier 1 so buildToolDefinitions
+		// + the per-plugin loop in buildSystemPrompt only surface those.
+		// Tier 2 + Tier 3 are added as separate system-prompt sections
+		// (D3 renderers) so the LLM still sees them — at lower per-tool
+		// token cost. The full decision is stashed in ctx so
+		// buildSystemPrompt can pull the Tier 2/3 names without
+		// re-deriving them.
+		if tierActive && prepAgg.ToolTier != nil {
+			relevantTools = append(append([]string(nil), prepAgg.ToolTier.Tier0...), prepAgg.ToolTier.Tier1...)
+			relevantToolsSet = true
+			ctx = withToolTierDecision(ctx, prepAgg.ToolTier)
+		}
 		// Store relevant tools in context so buildSystemPrompt and planner can filter.
 		if relevantToolsSet {
 			ctx = withRelevantTools(ctx, relevantTools)
@@ -3313,11 +3326,21 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 		sb.WriteString("\n")
 	}
 
-	// When RAG filtering is active, list plugins that have actions but none
-	// matched the current query. The LLM can use ask_knowledge to discover
-	// their actions on demand. Use alias names (e.g. "jira", "tickets") when
-	// available, since those are the names the LLM should use.
-	if len(discoverablePlugins) > 0 {
+	// RFC #249 Phase 4: when a tier decision is active, render Tier 2
+	// (name + 1-liner) and Tier 3 (names grouped by plugin) sections.
+	// These supersede the pre-Phase-4 discoverable-plugins block — Tier 3
+	// is the same idea but per-action rather than per-plugin, and the
+	// nudge points at get_tool_details (D4) instead of ask_knowledge.
+	tierDecision := toolTierDecisionFromContext(ctx)
+	if tierDecision != nil {
+		sb.WriteString(renderTier2Section(tierDecision, o.registry))
+		sb.WriteString(renderTier3Section(tierDecision))
+	} else if len(discoverablePlugins) > 0 {
+		// Pre-Phase-4 path: RAG filtering active but no tier decision.
+		// List plugins that have actions but none matched the current
+		// query so the LLM can fall back to ask_knowledge discovery.
+		// Use alias names when available since those are what the LLM
+		// should call.
 		sb.WriteString("## Other available plugins\n")
 		sb.WriteString("These plugins have tools but none matched your current request. Use weaviate.ask_knowledge to discover their actions.\n")
 		for _, name := range discoverablePlugins {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1225,7 +1225,23 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			o.emitPreparerRetrievals(ctx, userMessage, searchSource, outcome.Response)
 			prepAgg.append(outcome.Response)
 		}
+		// RFC #249 Phase 3 dedup: when the operator has flipped the
+		// knowledge_dedup.enabled flag AND a store is wired up AND
+		// at least one preparer returned structured KnowledgeCandidates,
+		// run the dedup decision over the aggregate candidate list.
+		// The content rewrite happens before the event emits; state
+		// persist happens AFTER the emit so the event log is the
+		// durable record even on partial failure (RFC #249 cross-phase
+		// invariant). When any precondition is false the path falls
+		// through to Phase 2's mode = "instrumentation_only".
+		dedupActive := o.knowledgeDedup.Enabled && o.injectionStateStore != nil && len(prepAgg.Knowledge) > 0
+		if dedupActive {
+			content = o.prepareDedupDecision(ctx, sessionID, content, &prepAgg)
+		}
 		o.emitPreparerDecision(ctx, prepAgg)
+		if dedupActive {
+			o.persistDedupDecision(ctx, sessionID, &prepAgg)
+		}
 		// Store relevant tools in context so buildSystemPrompt and planner can filter.
 		if relevantToolsSet {
 			ctx = withRelevantTools(ctx, relevantTools)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -306,6 +306,7 @@ type Orchestrator struct {
 	injectionStateStore     InjectionStateStore     // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
 	toolTiers               ToolTiersConfig         // RFC #249 Phase 4 tier-visibility flags; Enabled=false short-circuits to pre-Phase-4 single-tier behaviour
 	toolErrorHandling       ToolErrorHandlingConfig // RFC #249 Phase 4 tool-failure protections; thresholds always carry RFC defaults after NewWithRules
+	toolErrorTracker        *toolErrorTracker       // RFC #249 Phase 4 in-memory consecutive-error counters (per session, per tool); always allocated, gated at use-site by toolTiers.Enabled
 	// legacyKnowledgeWarnings tracks the (sessionID, pluginName) pairs
 	// we've already deprecation-warned for, so a session that keeps
 	// using a legacy preparer doesn't spam the log every turn. Key is
@@ -487,6 +488,7 @@ func NewWithRules(
 		injectionStateStore:     opts.InjectionStateStore,
 		toolTiers:               tierCfg,
 		toolErrorHandling:       errCfg,
+		toolErrorTracker:        newToolErrorTracker(),
 	}
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)
@@ -2212,6 +2214,14 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			log.Info("plugin call", "plugin", call.Plugin, "action", call.Action, "duration", pluginDuration.Round(time.Millisecond).String(), "error", toolResult.Error != "")
 			if toolResult.Error != "" {
 				log.Warn("tool call error", "plugin", call.Plugin, "action", call.Action, "error", toolResult.Error)
+			}
+			// RFC #249 Phase 4 D5: update the consecutive-error counters,
+			// inject the "Tool X failed N times" nudge into the next LLM
+			// iteration when LoopCapPerTurn trips, and flip the Demoted
+			// flag in known_tools when StickyDemotionThreshold trips
+			// (cleared again on the next successful invocation).
+			if warning := o.recordToolOutcome(ctx, sessionID, call, toolResult); warning != nil {
+				transientMessages = append(transientMessages, *warning)
 			}
 			if o.pluginCallObserver != nil {
 				o.pluginCallObserver.ObservePluginCall(call.Plugin, call.Action, toolResult.Error != "", perCallInput, perCallOutput)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -293,29 +293,29 @@ type Orchestrator struct {
 	// the LRU rank persisted to InjectionState still puts the tool
 	// in Tier 1, just without the promoted_via_get_tool_details
 	// provenance flag on the next preparer_decision.
-	recentToolPromotionsMu  sync.Mutex
-	recentToolPromotions    map[string][]string
-	pipelineConfig          pipeline.PipelineConfig
-	confirmationPlugin      string                  // optional; plugin for confirmation strategy
-	confirmationAction      string                  // optional; action name for confirmation check
-	contextWindow           int                     // model context window in tokens; 0 = no trimming
-	groupPluginLookup       GroupPluginLookup       // optional; nil = no group-based filtering
-	usageRecorder           UsageRecorder           // optional; nil = no usage tracking
-	pluginCallObserver      PluginCallObserver      // optional; nil = no plugin call observation
-	eventSink               emit.Sink               // structured session event sink; always non-nil (NoOpSink default)
-	snapshotStore           PromptSnapshotUpserter  // optional; nil = turn_start hashes are emitted but content is not persisted
-	syncActionsPlugin       string                  // optional; plugin name for action sync
-	syncActionsAction       string                  // optional; action name for action sync
-	syncGlossaryAction      string                  // optional; action name for glossary sync (uses syncActionsPlugin)
-	knowledge               KnowledgeConfig         // optional; knowledge directory ingestion
-	subprocessConfig        SubprocessConfig        // optional; subprocess (sub-agent) support
-	onStreamChunk           StreamChunkCallback     // optional; when set, final answers stream to caller
-	showToolCalls           string                  // "raw" = debug blocks, "friendly" = short labels, "" = hidden
-	knowledgeDedup          KnowledgeDedupConfig    // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
-	injectionStateStore     InjectionStateStore     // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
-	toolTiers               ToolTiersConfig         // RFC #249 Phase 4 tier-visibility flags; Enabled=false short-circuits to pre-Phase-4 single-tier behaviour
-	toolErrorHandling       ToolErrorHandlingConfig // RFC #249 Phase 4 tool-failure protections; thresholds always carry RFC defaults after NewWithRules
-	toolErrorTracker        *toolErrorTracker       // RFC #249 Phase 4 in-memory consecutive-error counters (per session, per tool); always allocated, gated at use-site by toolTiers.Enabled
+	recentToolPromotionsMu sync.Mutex
+	recentToolPromotions   map[string][]string
+	pipelineConfig         pipeline.PipelineConfig
+	confirmationPlugin     string                  // optional; plugin for confirmation strategy
+	confirmationAction     string                  // optional; action name for confirmation check
+	contextWindow          int                     // model context window in tokens; 0 = no trimming
+	groupPluginLookup      GroupPluginLookup       // optional; nil = no group-based filtering
+	usageRecorder          UsageRecorder           // optional; nil = no usage tracking
+	pluginCallObserver     PluginCallObserver      // optional; nil = no plugin call observation
+	eventSink              emit.Sink               // structured session event sink; always non-nil (NoOpSink default)
+	snapshotStore          PromptSnapshotUpserter  // optional; nil = turn_start hashes are emitted but content is not persisted
+	syncActionsPlugin      string                  // optional; plugin name for action sync
+	syncActionsAction      string                  // optional; action name for action sync
+	syncGlossaryAction     string                  // optional; action name for glossary sync (uses syncActionsPlugin)
+	knowledge              KnowledgeConfig         // optional; knowledge directory ingestion
+	subprocessConfig       SubprocessConfig        // optional; subprocess (sub-agent) support
+	onStreamChunk          StreamChunkCallback     // optional; when set, final answers stream to caller
+	showToolCalls          string                  // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	knowledgeDedup         KnowledgeDedupConfig    // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
+	injectionStateStore    InjectionStateStore     // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
+	toolTiers              ToolTiersConfig         // RFC #249 Phase 4 tier-visibility flags; Enabled=false short-circuits to pre-Phase-4 single-tier behaviour
+	toolErrorHandling      ToolErrorHandlingConfig // RFC #249 Phase 4 tool-failure protections; thresholds always carry RFC defaults after NewWithRules
+	toolErrorTracker       *toolErrorTracker       // RFC #249 Phase 4 in-memory consecutive-error counters (per session, per tool); always allocated, gated at use-site by toolTiers.Enabled
 	// legacyKnowledgeWarnings tracks the (sessionID, pluginName) pairs
 	// we've already deprecation-warned for, so a session that keeps
 	// using a legacy preparer doesn't spam the log every turn. Key is

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -618,33 +618,54 @@ func (o *Orchestrator) runSTTPreparer(ctx context.Context, prep ContentPreparerE
 	return result.Content, nil
 }
 
-// runSinglePreparer executes one content preparer. Returns (new content, blocked result, relevant tools, error).
-// relevantTools is non-nil only when the preparer explicitly returns a relevant_tools list.
-// runSinglePreparerWithSearch calls runSinglePreparer and injects a
-// `search_text` arg when the enriched search query differs from the content.
-// The preparer can use search_text for RAG lookup while returning the
-// original content for the LLM.
-func (o *Orchestrator) runSinglePreparerWithSearch(ctx context.Context, prep ContentPreparerEntry, content, searchText, callPrefix string, allowInvoke bool) (string, *RunResult, []string, error) {
+// preparerOutcome is the result of one preparer pass. Content / Blocked
+// / RelevantTools drive what the orchestrator does next; Response holds
+// the parsed plugin JSON so callers can read the RFC #249 candidate
+// fields and emit retrieval events without re-deserializing. For Lua
+// preparers (no plugin protocol) Response stays zero-valued — its
+// KnowledgeCandidates / GlossaryCandidates / ToolCandidates slices are
+// nil and downstream emit logic short-circuits accordingly.
+type preparerOutcome struct {
+	Content       string
+	Blocked       *RunResult
+	RelevantTools []string
+	Response      preparerResponse
+}
+
+// blockedPreparerOutcome is the shorthand for "this preparer's output
+// halted the run" — used by the early-exit paths in runSinglePreparer
+// so Content stays in sync with the input and RelevantTools / Response
+// stay zero-valued.
+func blockedPreparerOutcome(content string, blocked *RunResult) preparerOutcome {
+	return preparerOutcome{Content: content, Blocked: blocked}
+}
+
+// runSinglePreparerWithSearch calls runSinglePreparer with a
+// `search_text` arg derived from the enriched search query so the RAG
+// lookup matches conversation context while the main `text` arg stays
+// as the original user message.
+func (o *Orchestrator) runSinglePreparerWithSearch(ctx context.Context, prep ContentPreparerEntry, content, searchText, callPrefix string, allowInvoke bool) (preparerOutcome, error) {
 	ctx = withSearchQuery(ctx, searchText)
 	return o.runSinglePreparer(ctx, prep, content, callPrefix, allowInvoke)
 }
 
-func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPreparerEntry, content, callPrefix string, allowInvoke bool) (string, *RunResult, []string, error) {
+// runSinglePreparer executes one content preparer. Errors and "fail
+// open" preparer failures both return a non-blocked outcome with
+// Content == the input content; an explicit guard block returns
+// Blocked set; an `invoke` directive returns Content == "" and Blocked
+// holding the invoke result. The Response field carries the parsed
+// plugin JSON (RFC #249 candidate fields included) so callers can emit
+// retrieval events without re-parsing.
+func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPreparerEntry, content, callPrefix string, allowInvoke bool) (preparerOutcome, error) {
 	if strings.HasPrefix(prep.Plugin, "lua:") {
 		scriptName := strings.TrimPrefix(prep.Plugin, "lua:")
 		scriptPath := o.luaScriptPaths[scriptName]
 		if scriptPath == "" {
-			if blocked := o.handlePreparerFailure(prep, "Lua script path not found"); blocked != nil {
-				return content, blocked, nil, nil
-			}
-			return content, nil, nil, nil
+			return blockedPreparerOutcome(content, o.handlePreparerFailure(prep, "Lua script path not found")), nil
 		}
 		result, err := lua.RunPrepare(scriptPath, content)
 		if err != nil {
-			if blocked := o.handlePreparerFailure(prep, err.Error()); blocked != nil {
-				return content, blocked, nil, nil
-			}
-			return content, nil, nil, nil
+			return blockedPreparerOutcome(content, o.handlePreparerFailure(prep, err.Error())), nil
 		}
 		if !result.SendToLLM {
 			if allowInvoke && len(result.InvokeSteps) > 0 {
@@ -653,15 +674,15 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 					steps[i] = InvokeStep{Plugin: s.Plugin, Action: s.Action, Args: s.Args}
 				}
 				invokeResult, err := o.runInvokeSteps(ctx, steps)
-				return "", invokeResult, nil, err
+				return preparerOutcome{Blocked: invokeResult}, err
 			}
 			msg := result.Content
 			if msg == "" {
 				msg = "Request blocked by guard."
 			}
-			return "", &RunResult{Response: msg}, nil, nil
+			return preparerOutcome{Blocked: &RunResult{Response: msg}}, nil
 		}
-		return result.Content, nil, nil, nil
+		return preparerOutcome{Content: result.Content}, nil
 	}
 
 	argKey := prep.ArgKey
@@ -669,10 +690,7 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 		argKey = "text"
 	}
 	if !o.registry.HasAction(prep.Plugin, prep.Action) {
-		if blocked := o.handlePreparerFailure(prep, "action not found"); blocked != nil {
-			return content, blocked, nil, nil
-		}
-		return content, nil, nil, nil
+		return blockedPreparerOutcome(content, o.handlePreparerFailure(prep, "action not found")), nil
 	}
 	call := ToolCall{
 		ID:     fmt.Sprintf("%s-%s-%s", callPrefix, prep.Plugin, prep.Action),
@@ -691,20 +709,17 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 	}
 	toolResult := o.executeCall(ctx, call)
 	if toolResult.Error != "" {
-		if blocked := o.handlePreparerFailure(prep, toolResult.Error); blocked != nil {
-			return content, blocked, nil, nil
-		}
-		return content, nil, nil, nil
+		return blockedPreparerOutcome(content, o.handlePreparerFailure(prep, toolResult.Error)), nil
 	}
 	var pr preparerResponse
 	if err := json.Unmarshal([]byte(toolResult.Content), &pr); err == nil && pr.SendToLLM != nil && !*pr.SendToLLM {
 		if allowInvoke && len(pr.Invoke) > 0 {
 			if prep.Insecure {
 				slog.Warn("insecure preparer cannot run invoke, ignoring", "plugin", prep.Plugin, "action", prep.Action)
-				return content, nil, nil, nil
+				return preparerOutcome{Content: content, Response: pr}, nil
 			}
 			invokeResult, err := o.runInvokeSteps(ctx, pr.Invoke)
-			return "", invokeResult, nil, err
+			return preparerOutcome{Blocked: invokeResult, Response: pr}, err
 		}
 		msg := pr.Message
 		if msg == "" {
@@ -713,12 +728,12 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 		if msg == "" {
 			msg = "Request blocked by guard."
 		}
-		return "", &RunResult{Response: msg}, nil, nil
+		return preparerOutcome{Blocked: &RunResult{Response: msg}, Response: pr}, nil
 	}
 	if pr.Message != "" {
-		return pr.Message, nil, pr.RelevantTools, nil
+		return preparerOutcome{Content: pr.Message, RelevantTools: pr.RelevantTools, Response: pr}, nil
 	}
-	return toolResult.Content, nil, pr.RelevantTools, nil
+	return preparerOutcome{Content: toolResult.Content, RelevantTools: pr.RelevantTools, Response: pr}, nil
 }
 
 // applyShowToolCalls prepends tool call details to result.Response based on show_tool_calls mode.
@@ -1122,18 +1137,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			if prep.STT {
 				continue
 			}
-			guardedContent, blocked, tools, err := o.runSinglePreparerWithSearch(ctx, prep, content, searchText, "preparer", true)
+			outcome, err := o.runSinglePreparerWithSearch(ctx, prep, content, searchText, "preparer", true)
 			if err != nil {
 				return nil, err
 			}
-			if blocked != nil {
-				return blocked, nil
+			if outcome.Blocked != nil {
+				return outcome.Blocked, nil
 			}
-			content = guardedContent
+			content = outcome.Content
 			// Last preparer that returns relevant_tools wins.
 			// Distinguish nil (no tools field) from [] (explicitly empty).
-			if tools != nil {
-				relevantTools = tools
+			if outcome.RelevantTools != nil {
+				relevantTools = outcome.RelevantTools
 				relevantToolsSet = true
 			}
 		}
@@ -2549,14 +2564,14 @@ func (o *Orchestrator) runGuardPlugins(ctx context.Context, messages []provider.
 	original := messages[lastIdx].Content
 	content := original
 	for _, g := range o.guards {
-		nextContent, blocked, _, err := o.runSinglePreparer(ctx, g, content, "guard", false)
+		outcome, err := o.runSinglePreparer(ctx, g, content, "guard", false)
 		if err != nil {
 			return nil, nil, err
 		}
-		if blocked != nil {
-			return nil, blocked, nil
+		if outcome.Blocked != nil {
+			return nil, outcome.Blocked, nil
 		}
-		content = nextContent
+		content = outcome.Content
 	}
 	if content == original {
 		return messages, nil, nil

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -894,7 +894,15 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 	// without reaching the agent loop (pending pipeline / tool-call
 	// confirmation), because the user did send a message regardless of how
 	// the orchestrator routes it.
-	emit.EmitUserMessage(ctx, o.eventSink, userMessage)
+	//
+	// Parent-chain: capture the returned event_id and wrap ctx so the
+	// preparer-phase events (knowledge_retrieval / glossary_retrieval /
+	// tool_retrieval / preparer_decision) and turn_start emitted later
+	// in this turn surface as children of user_message — matching the
+	// tree shape consumers (api-plugin aggregations, Timly review UI)
+	// rely on per RFC #249.
+	userMessageID := emit.EmitUserMessage(ctx, o.eventSink, userMessage)
+	ctx = emit.WithParent(ctx, userMessageID)
 
 	// Per-session deep debug: enabled by the set_debug_mode command, which
 	// stores debug=true in session metadata. With the flag set, the slog
@@ -1131,8 +1139,18 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				searchText = strings.Join(parts, " ") + " " + content
 			}
 		}
+		// Default search-text source for the *_retrieval events: when
+		// the orchestrator enriched the query (added recent
+		// conversation context), report "enriched"; otherwise
+		// "user_input". The plugin can override either via
+		// RetrievalMetrics.<corpus>.SearchTextSource.
+		searchSource := events.SearchTextSourceUserInput
+		if searchText != content {
+			searchSource = events.SearchTextSourceEnriched
+		}
 		var relevantTools []string
 		relevantToolsSet := false
+		var prepAgg preparerAggregate
 		for _, prep := range o.preparers {
 			if prep.STT {
 				continue
@@ -1151,7 +1169,14 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 				relevantTools = outcome.RelevantTools
 				relevantToolsSet = true
 			}
+			// RFC #249 Phase 2 instrumentation: publish per-corpus
+			// retrieval events for this preparer, then accumulate the
+			// candidate slices for the composite preparer_decision
+			// emitted after the loop.
+			o.emitPreparerRetrievals(ctx, userMessage, searchSource, outcome.Response)
+			prepAgg.append(outcome.Response)
 		}
+		o.emitPreparerDecision(ctx, prepAgg)
 		// Store relevant tools in context so buildSystemPrompt and planner can filter.
 		if relevantToolsSet {
 			ctx = withRelevantTools(ctx, relevantTools)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -429,11 +429,90 @@ func (s *invokeStepsUnmarshal) UnmarshalJSON(data []byte) error {
 }
 
 // preparerResponse is the optional JSON shape from a content preparer (guard or invoke).
+//
+// Candidate fields (knowledge / glossary / tool) are RFC #249 additions
+// — preparers that retrieve from a RAG corpus may return the structured
+// candidate list alongside (or instead of) the legacy `message` /
+// `relevant_tools` fields so the orchestrator can apply per-session
+// dedup + tier-promotion logic in Phase 3+.
+//
+// In Phase 2 the candidate slices are deserialized for instrumentation
+// (knowledge_retrieval / glossary_retrieval / tool_retrieval events
+// carry the hits) but do not yet drive injection decisions — the
+// `message` body remains authoritative for what reaches the LLM.
+// Plugins returning only the legacy fields stay fully backwards-
+// compatible: the candidate slices unmarshal to nil and the
+// orchestrator falls through to the legacy path.
 type preparerResponse struct {
 	SendToLLM     *bool                `json:"send_to_llm"`
 	Message       string               `json:"message"`
 	Invoke        invokeStepsUnmarshal `json:"invoke"`
 	RelevantTools []string             `json:"relevant_tools,omitempty"` // optional: filter system prompt to these tools (format: "plugin.action")
+
+	KnowledgeCandidates []KnowledgeCandidate `json:"knowledge_candidates,omitempty"`
+	GlossaryCandidates  []GlossaryCandidate  `json:"glossary_candidates,omitempty"`
+	ToolCandidates      []ToolCandidate      `json:"tool_candidates,omitempty"`
+
+	// RetrievalMetrics is an optional per-corpus timing / scoring
+	// summary the plugin can attach so the orchestrator's emit step
+	// has min_score / top_k / latency_ms to publish without inferring
+	// them. All fields are optional; missing values stay zero-valued
+	// in the corresponding *_retrieval events.
+	RetrievalMetrics *PreparerRetrievalMetrics `json:"retrieval_metrics,omitempty"`
+}
+
+// KnowledgeCandidate is one knowledge-base article returned by the
+// preparer's RAG search. Content carries the body the orchestrator
+// would inject into [knowledge_context]; ContentSHA256 is the dedup
+// key (Phase 3+).
+type KnowledgeCandidate struct {
+	ArticleID         string  `json:"article_id"`
+	Title             string  `json:"title,omitempty"`
+	Content           string  `json:"content"`
+	ContentSHA256     string  `json:"content_sha256,omitempty"`
+	Score             float64 `json:"score"`
+	Source            string  `json:"source,omitempty"`
+	PositionInResults int     `json:"position_in_results,omitempty"`
+}
+
+// GlossaryCandidate mirrors KnowledgeCandidate; the only difference is
+// the per-entry "term" instead of "title".
+type GlossaryCandidate struct {
+	Term              string  `json:"term"`
+	Content           string  `json:"content"`
+	ContentSHA256     string  `json:"content_sha256,omitempty"`
+	Score             float64 `json:"score"`
+	Source            string  `json:"source,omitempty"`
+	PositionInResults int     `json:"position_in_results,omitempty"`
+}
+
+// ToolCandidate is the RAG-retrieved tool entry with score so the
+// orchestrator (Phase 4) can apply the LRU + tier-promotion logic and
+// the *_retrieval event can publish ranked hits.
+type ToolCandidate struct {
+	ToolName          string  `json:"tool_name"`
+	Score             float64 `json:"score"`
+	PositionInResults int     `json:"position_in_results,omitempty"`
+}
+
+// PreparerRetrievalMetrics is a per-corpus optional summary returned
+// alongside the candidate slices. All three corpora share the same
+// shape; the plugin sets only the corpora it actually searched. Phase
+// 2 forwards these directly into the *_retrieval event payloads.
+type PreparerRetrievalMetrics struct {
+	Knowledge *PreparerCorpusMetrics `json:"knowledge,omitempty"`
+	Glossary  *PreparerCorpusMetrics `json:"glossary,omitempty"`
+	Tools     *PreparerCorpusMetrics `json:"tools,omitempty"`
+}
+
+// PreparerCorpusMetrics is the optional timing / scoring summary for
+// one RAG corpus. SearchTextSource carries the events.SearchTextSource*
+// constant value when the plugin distinguishes raw vs enriched query.
+type PreparerCorpusMetrics struct {
+	SearchTextSource string  `json:"search_text_source,omitempty"`
+	TopK             int     `json:"top_k,omitempty"`
+	MinScore         float64 `json:"min_score,omitempty"`
+	LatencyMS        int64   `json:"latency_ms,omitempty"`
 }
 
 func (o *Orchestrator) handlePreparerFailure(prep ContentPreparerEntry, details string) *RunResult {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -129,6 +129,34 @@ type KnowledgeConfig struct {
 	Dir    string // directory to scan for .md files
 }
 
+// KnowledgeDedupConfig is the runtime form of the RFC #249 Phase 3
+// knowledge-dedup flags. Zero values are normalized to the RFC defaults
+// inside NewWithRules so an OrchestratorOpts authored by a test (no
+// YAML in scope) gets sensible thresholds without having to repeat the
+// canonical numbers.
+//
+// When Enabled is false the dedup decision logic short-circuits to the
+// Phase-2 "instrumentation_only" mode and the InjectionStateStore is
+// not consulted — callers can leave that interface nil in that case.
+type KnowledgeDedupConfig struct {
+	Enabled                bool
+	ReinjectScoreThreshold float64 // overrides "already known" when current score > threshold; default 0.85
+	ReinjectTopKForce      int     // top-N candidates always inject regardless of known state; default 3
+	CapPerTurn             int     // hard ceiling on delta articles per turn; default 5
+}
+
+// InjectionStateStore is the optional store dependency the orchestrator
+// uses to read/write the per-session knowledge dedup bookkeeping. It is
+// only consulted when KnowledgeDedupConfig.Enabled is true.
+// SessionStore (state/store) satisfies this interface in production;
+// tests may inject a fake. The shape matches SessionStore's helpers
+// exactly so structural typing wires both ends without an explicit
+// adapter.
+type InjectionStateStore interface {
+	GetInjectionState(ctx context.Context, sessionID string) (state.InjectionState, error)
+	UpdateInjectionState(ctx context.Context, sessionID string, st state.InjectionState) error
+}
+
 // OrchestratorOpts holds optional configuration for NewWithRules. Zero values mean defaults (no permission check, no summarization).
 type OrchestratorOpts struct {
 	CustomRules             []string
@@ -163,6 +191,8 @@ type OrchestratorOpts struct {
 	Subprocess              SubprocessConfig       // optional; subprocess (sub-agent) support
 	OnStreamChunk           StreamChunkCallback    // optional; when set and LLM supports streaming, final answers are streamed
 	ShowToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	KnowledgeDedup          KnowledgeDedupConfig   // RFC #249 Phase 3 dedup flags; zero value disables (= instrumentation_only mode)
+	InjectionStateStore     InjectionStateStore    // optional; required only when KnowledgeDedup.Enabled is true
 }
 
 // MemoryStoreInterface is the scoped memory store used for general + per-actor memories.
@@ -239,6 +269,8 @@ type Orchestrator struct {
 	subprocessConfig        SubprocessConfig       // optional; subprocess (sub-agent) support
 	onStreamChunk           StreamChunkCallback    // optional; when set, final answers stream to caller
 	showToolCalls           string                 // "raw" = debug blocks, "friendly" = short labels, "" = hidden
+	knowledgeDedup          KnowledgeDedupConfig   // RFC #249 Phase 3 dedup flags; Enabled=false skips dedup logic and InjectionStateStore reads
+	injectionStateStore     InjectionStateStore    // optional; nil = dedup decision logic short-circuits to instrumentation_only mode
 }
 
 // resolveAllowedPluginNames returns a JSON array of allowed plugin names for the
@@ -329,6 +361,21 @@ func NewWithRules(
 		eventSink = emit.NoOpSink{}
 	}
 
+	// Normalize KnowledgeDedup to RFC #249 defaults so callers that
+	// build OrchestratorOpts in code (mostly tests) don't have to
+	// repeat the canonical numbers. The Enabled flag stays false by
+	// default — that's the whole point of the master switch.
+	dedupCfg := opts.KnowledgeDedup
+	if dedupCfg.ReinjectScoreThreshold == 0 {
+		dedupCfg.ReinjectScoreThreshold = 0.85
+	}
+	if dedupCfg.ReinjectTopKForce == 0 {
+		dedupCfg.ReinjectTopKForce = 3
+	}
+	if dedupCfg.CapPerTurn == 0 {
+		dedupCfg.CapPerTurn = 5
+	}
+
 	o := &Orchestrator{
 		sessionMuxes:            make(map[string]*sessionMutex),
 		semaphore:               semaphore,
@@ -370,6 +417,8 @@ func NewWithRules(
 		knowledge:               opts.Knowledge,
 		onStreamChunk:           opts.OnStreamChunk,
 		showToolCalls:           opts.ShowToolCalls,
+		knowledgeDedup:          dedupCfg,
+		injectionStateStore:     opts.InjectionStateStore,
 	}
 	// Context arg providers need access to 'o' for allowed_plugins resolution.
 	o.contextArgProviders = defaultContextArgProviders(o, opts.ContextArgProviders)

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -2111,6 +2111,61 @@ func TestOrchestrator_Confirmation_ReadOnlyAction_SkipsPrompt(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_Confirmation_ReadOnlyAction_MatchesPrefixedManifestName(t *testing.T) {
+	// Regression: mcp-plugin stores each action's Name in the
+	// prefixed form "server__tool" (e.g. "timly__list-items"). The LLM
+	// emits the same name; parseToolName splits on `__` so the
+	// orchestrator-side ToolCall ends up with Plugin="timly",
+	// Action="list-items" (the unprefixed form). IsActionReadOnly's
+	// lookup must accept both shapes — without it the short-circuit
+	// would silently miss every mcp-sourced read-only tool.
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:        "tc-mcp",
+			Name:      "timly__list-items",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "results above",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	// Capability registered exactly the way mcp-plugin emits it:
+	// Cap.Name = "mcp", Actions carry the server-prefixed action name.
+	// An alias "timly" -> "mcp" resolves the LLM's call name to the
+	// underlying capability.
+	_ = registry.Register(PluginCapability{
+		Name:    "mcp",
+		Actions: []Action{{Name: "timly__list-items", ReadOnly: true}},
+	}, &echoExecutor{})
+	if err := registry.RegisterAlias("timly", "mcp"); err != nil {
+		t.Fatalf("RegisterAlias: %v", err)
+	}
+	_ = registry.Register(PluginCapability{
+		Name:    "conf",
+		Actions: []Action{{Name: "check"}},
+	}, confirmingExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:          sink,
+		ConfirmationPlugin: "conf",
+		ConfirmationAction: "check",
+	})
+
+	if _, err := orch.Run(context.Background(), "sess", "list my items"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationRequestedPayloads(t, sink.snapshot())
+	if len(got) != 0 {
+		t.Errorf("confirmation_requested count = %d, want 0 for mcp-style prefixed read-only action", len(got))
+	}
+}
+
 func TestOrchestrator_Confirmation_NonReadOnlyAction_StillPrompts(t *testing.T) {
 	// Sibling to the ReadOnly skip test: an action that is NOT declared
 	// read-only must still go through the confirmation gate, even if a

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -2082,7 +2082,11 @@ func findEventsByType(evs []emit.Event, eventType string) []emit.Event {
 	return out
 }
 
-func TestParentID_TurnStartIsRoot(t *testing.T) {
+func TestParentID_TurnStartParentsUserMessage(t *testing.T) {
+	// Post-RFC-#249-Phase-2 tree: user_message is the root of every turn;
+	// turn_start (and the preparer-phase events emitted between them)
+	// hang off user_message. The old "turn_start is root" assertion was
+	// pre-RFC and is replaced here.
 	sink := &recordingEventSink{}
 	llm := &fakeLLM{responses: []string{"hello back"}}
 	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
@@ -2090,15 +2094,23 @@ func TestParentID_TurnStartIsRoot(t *testing.T) {
 	if _, err := orch.Run(context.Background(), sessID, "hi"); err != nil {
 		t.Fatal(err)
 	}
-	ts := findEventByType(sink.snapshot(), events.TypeTurnStart)
+	snap := sink.snapshot()
+	um := findEventByType(snap, events.TypeUserMessage)
+	ts := findEventByType(snap, events.TypeTurnStart)
+	if um == nil {
+		t.Fatal("user_message not emitted")
+	}
 	if ts == nil {
 		t.Fatal("turn_start not emitted")
 	}
 	if ts.ID == "" {
 		t.Errorf("turn_start.ID empty — producer-side id generation broken")
 	}
-	if ts.ParentID != "" {
-		t.Errorf("turn_start.ParentID = %q, want empty (root of turn tree)", ts.ParentID)
+	if um.ParentID != "" {
+		t.Errorf("user_message.ParentID = %q, want empty (root of turn tree)", um.ParentID)
+	}
+	if ts.ParentID != um.ID {
+		t.Errorf("turn_start.ParentID = %q, want user_message.ID (%q)", ts.ParentID, um.ID)
 	}
 }
 
@@ -2338,5 +2350,339 @@ func TestParentID_EveryEventHasID(t *testing.T) {
 		if e.ID == "" {
 			t.Errorf("event[%d] type=%q has empty ID", i, e.EventType)
 		}
+	}
+}
+
+func TestOrchestrator_PreparerPhase_EmitsRetrievalAndDecision(t *testing.T) {
+	// RFC #249 Phase 2: a preparer that returns structured knowledge /
+	// glossary / tool candidates should trigger three retrieval events
+	// (one per non-empty corpus) plus a composite preparer_decision —
+	// all parented to user_message so the session timeline reads as a
+	// tree.
+	//
+	// Mode is instrumentation_only since Phase 2 has no dedup state;
+	// every candidate appears under Knowledge.Injected with that
+	// reason, and tool names land under Tools.Tier1New.
+
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "do the thing",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "title": "A", "content": "body-a", "content_sha256": "sha-a", "score": 0.9, "source": "knowledge_base"},
+			{"article_id": "kb_b", "title": "B", "content": "body-bb", "content_sha256": "sha-b", "score": 0.6}
+		],
+		"glossary_candidates": [
+			{"term": "ticket", "content": "definition", "score": 0.71}
+		],
+		"tool_candidates": [
+			{"tool_name": "gitlab.analyze_code", "score": 0.88, "position_in_results": 0}
+		],
+		"retrieval_metrics": {
+			"knowledge": {"search_text_source": "enriched", "top_k": 5, "min_score": 0.45, "latency_ms": 142},
+			"glossary":  {"top_k": 3, "min_score": 0.50, "latency_ms": 38},
+			"tools":     {"top_k": 8, "min_score": 0.60, "latency_ms": 98}
+		}
+	}`
+
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG preparer",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:        sink,
+		ContentPreparers: []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "do the thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	evs := sink.snapshot()
+	userMsg := findEventByType(evs, events.TypeUserMessage)
+	if userMsg == nil || userMsg.ID == "" {
+		t.Fatal("user_message event missing or has empty ID")
+	}
+
+	// One event per corpus retrieved + one composite decision.
+	wantTypes := []string{
+		events.TypeKnowledgeRetrieval,
+		events.TypeGlossaryRetrieval,
+		events.TypeToolRetrieval,
+		events.TypePreparerDecision,
+	}
+	for _, wantType := range wantTypes {
+		e := findEventByType(evs, wantType)
+		if e == nil {
+			t.Errorf("missing event of type %q", wantType)
+			continue
+		}
+		if e.ParentID != userMsg.ID {
+			t.Errorf("%s.ParentID = %q, want user_message.ID (%q)", wantType, e.ParentID, userMsg.ID)
+		}
+	}
+
+	// Spot-check the knowledge_retrieval payload: hits + metrics from
+	// the plugin should round-trip into the event.
+	kr := findEventByType(evs, events.TypeKnowledgeRetrieval)
+	if kr == nil {
+		t.Fatal("knowledge_retrieval event missing")
+	}
+	var krPayload events.KnowledgeRetrievalPayload
+	if err := json.Unmarshal(kr.Payload, &krPayload); err != nil {
+		t.Fatalf("unmarshal knowledge_retrieval payload: %v", err)
+	}
+	if len(krPayload.Hits) != 2 || krPayload.Hits[0].ArticleID != "kb_a" {
+		t.Errorf("knowledge_retrieval hits mismatch: %+v", krPayload.Hits)
+	}
+	if krPayload.SearchTextSource != events.SearchTextSourceEnriched {
+		t.Errorf("knowledge_retrieval SearchTextSource = %q, want %q",
+			krPayload.SearchTextSource, events.SearchTextSourceEnriched)
+	}
+	if krPayload.TopK != 5 || krPayload.MinScore != 0.45 || krPayload.LatencyMS != 142 {
+		t.Errorf("knowledge_retrieval metrics mismatch: TopK=%d MinScore=%v LatencyMS=%d",
+			krPayload.TopK, krPayload.MinScore, krPayload.LatencyMS)
+	}
+
+	// Spot-check glossary + tool retrievals too: per-corpus metrics
+	// must round-trip independently. A regression where the wrong
+	// corpus's metrics get pasted into knowledge_retrieval shows up
+	// here.
+	gr := findEventByType(evs, events.TypeGlossaryRetrieval)
+	if gr == nil {
+		t.Fatal("glossary_retrieval event missing")
+	}
+	var grPayload events.GlossaryRetrievalPayload
+	if err := json.Unmarshal(gr.Payload, &grPayload); err != nil {
+		t.Fatalf("unmarshal glossary_retrieval payload: %v", err)
+	}
+	if len(grPayload.Hits) != 1 || grPayload.Hits[0].Term != "ticket" {
+		t.Errorf("glossary_retrieval hits mismatch: %+v", grPayload.Hits)
+	}
+	if grPayload.LatencyMS != 38 || grPayload.TopK != 3 {
+		t.Errorf("glossary_retrieval metrics mismatch: TopK=%d LatencyMS=%d", grPayload.TopK, grPayload.LatencyMS)
+	}
+
+	tr := findEventByType(evs, events.TypeToolRetrieval)
+	if tr == nil {
+		t.Fatal("tool_retrieval event missing")
+	}
+	var trPayload events.ToolRetrievalPayload
+	if err := json.Unmarshal(tr.Payload, &trPayload); err != nil {
+		t.Fatalf("unmarshal tool_retrieval payload: %v", err)
+	}
+	if len(trPayload.Hits) != 1 || trPayload.Hits[0].ToolName != "gitlab.analyze_code" {
+		t.Errorf("tool_retrieval hits mismatch: %+v", trPayload.Hits)
+	}
+	if trPayload.LatencyMS != 98 || trPayload.TopK != 8 {
+		t.Errorf("tool_retrieval metrics mismatch: TopK=%d LatencyMS=%d", trPayload.TopK, trPayload.LatencyMS)
+	}
+
+	// preparer_decision should carry mode=instrumentation_only with
+	// both knowledge and tools populated from the candidate slices.
+	pd := findEventByType(evs, events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision event missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal preparer_decision payload: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeInstrumentationOnly {
+		t.Errorf("preparer_decision Mode = %q, want %q",
+			pdPayload.Mode, events.PreparerDecisionModeInstrumentationOnly)
+	}
+	if len(pdPayload.Knowledge.CandidateIDs) != 2 {
+		t.Errorf("preparer_decision Knowledge.CandidateIDs len = %d, want 2", len(pdPayload.Knowledge.CandidateIDs))
+	}
+	if len(pdPayload.Knowledge.Injected) != 2 {
+		t.Errorf("preparer_decision Knowledge.Injected len = %d, want 2", len(pdPayload.Knowledge.Injected))
+	}
+	if pdPayload.Knowledge.InjectedBytes != len("body-a")+len("body-bb") {
+		t.Errorf("preparer_decision Knowledge.InjectedBytes = %d, want %d",
+			pdPayload.Knowledge.InjectedBytes, len("body-a")+len("body-bb"))
+	}
+	if len(pdPayload.Tools.Tier1New) != 1 || pdPayload.Tools.Tier1New[0] != "gitlab.analyze_code" {
+		t.Errorf("preparer_decision Tools.Tier1New = %v", pdPayload.Tools.Tier1New)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_NoPreparerNoDecisionEvent(t *testing.T) {
+	// When the orchestrator has no preparers (or all are STT), the
+	// preparer_decision event should NOT fire — emitting an empty
+	// composite would just produce noise. user_message and turn_start
+	// still emit as normal.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"hi"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	orch, sessID := setupOrchestratorWithSink(llm, parser, sink)
+
+	if _, err := orch.Run(context.Background(), sessID, "hello"); err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range sink.snapshot() {
+		if e.EventType == events.TypePreparerDecision {
+			t.Errorf("preparer_decision should not emit when no preparers retrieve anything; got payload: %s", e.Payload)
+		}
+		if e.EventType == events.TypeKnowledgeRetrieval || e.EventType == events.TypeGlossaryRetrieval {
+			t.Errorf("%s should not emit without a preparer producing candidates", e.EventType)
+		}
+	}
+}
+
+func TestOrchestrator_PreparerPhase_LegacyPluginNoCandidates(t *testing.T) {
+	// A pre-RFC plugin returning only `message` + `relevant_tools`
+	// still gets a tool_retrieval event (synthesized from relevant_tools
+	// with score=0) plus a preparer_decision capturing the tool names
+	// under Tier1New. knowledge_retrieval / glossary_retrieval do NOT
+	// fire — there are no candidates and no metrics signaling those
+	// corpora ran.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "do the thing",
+		"relevant_tools": ["gitlab.analyze_code", "jira.create_issue"]
+	}`
+
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "legacy-plugin", Description: "Legacy",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{{Name: "analyze_code", Description: "Analyze"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira",
+		Actions: []Action{{Name: "create_issue", Description: "Create"}},
+	}, &echoExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:        sink,
+		ContentPreparers: []ContentPreparerEntry{{Plugin: "legacy-plugin", Action: "prepare"}},
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "do the thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	evs := sink.snapshot()
+	if findEventByType(evs, events.TypeKnowledgeRetrieval) != nil {
+		t.Error("knowledge_retrieval must not fire for legacy plugins without knowledge candidates")
+	}
+	if findEventByType(evs, events.TypeGlossaryRetrieval) != nil {
+		t.Error("glossary_retrieval must not fire for legacy plugins without glossary candidates")
+	}
+	tr := findEventByType(evs, events.TypeToolRetrieval)
+	if tr == nil {
+		t.Fatal("tool_retrieval should fire from legacy relevant_tools")
+	}
+	var trPayload events.ToolRetrievalPayload
+	if err := json.Unmarshal(tr.Payload, &trPayload); err != nil {
+		t.Fatalf("unmarshal tool_retrieval payload: %v", err)
+	}
+	if len(trPayload.Hits) != 2 {
+		t.Errorf("tool_retrieval hits len = %d, want 2 (from relevant_tools)", len(trPayload.Hits))
+	}
+	if trPayload.Hits[0].Score != 0 {
+		t.Errorf("tool_retrieval legacy synthesized hit must have score=0, got %v", trPayload.Hits[0].Score)
+	}
+
+	pd := findEventByType(evs, events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision should still fire for legacy tool retrieval")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal preparer_decision payload: %v", err)
+	}
+	if len(pdPayload.Tools.Tier1New) != 2 {
+		t.Errorf("preparer_decision Tools.Tier1New len = %d, want 2", len(pdPayload.Tools.Tier1New))
+	}
+}
+
+func TestOrchestrator_PreparerPhase_MultiPreparerAggregation(t *testing.T) {
+	// When the orchestrator runs more than one preparer per turn, the
+	// composite preparer_decision must aggregate the candidate lists
+	// across all of them. Two preparers each returning one knowledge
+	// candidate should produce two CandidateIDs + two Injected entries
+	// with InjectedBytes summed.
+	prepA := `{"send_to_llm": true, "message": "x",
+	 "knowledge_candidates": [{"article_id": "kb_a", "content": "AAA", "score": 0.9}]}`
+	prepB := `{"send_to_llm": true, "message": "x",
+	 "knowledge_candidates": [{"article_id": "kb_b", "content": "BBBB", "score": 0.7}]}`
+
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-a", Description: "RAG A",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepA})
+	_ = registry.Register(PluginCapability{
+		Name: "rag-b", Description: "RAG B",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepB})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink: sink,
+		ContentPreparers: []ContentPreparerEntry{
+			{Plugin: "rag-a", Action: "prepare"},
+			{Plugin: "rag-b", Action: "prepare"},
+		},
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "do the thing"); err != nil {
+		t.Fatal(err)
+	}
+
+	evs := sink.snapshot()
+	// Two knowledge_retrieval events fire (one per preparer), each
+	// carrying that preparer's single hit. They must NOT be merged
+	// into a single event — per-preparer granularity is the audit
+	// trail.
+	var kCount int
+	for _, e := range evs {
+		if e.EventType == events.TypeKnowledgeRetrieval {
+			kCount++
+		}
+	}
+	if kCount != 2 {
+		t.Errorf("knowledge_retrieval event count = %d, want 2 (one per preparer)", kCount)
+	}
+
+	// preparer_decision fires exactly once with both candidates merged.
+	pd := findEventByType(evs, events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision event missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal preparer_decision payload: %v", err)
+	}
+	if len(pdPayload.Knowledge.CandidateIDs) != 2 {
+		t.Errorf("CandidateIDs len = %d, want 2 (kb_a + kb_b across both preparers)",
+			len(pdPayload.Knowledge.CandidateIDs))
+	}
+	if pdPayload.Knowledge.InjectedBytes != len("AAA")+len("BBBB") {
+		t.Errorf("InjectedBytes = %d, want %d (sum across preparers)",
+			pdPayload.Knowledge.InjectedBytes, len("AAA")+len("BBBB"))
 	}
 }

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -3246,5 +3247,297 @@ func TestOrchestrator_MessagesTruncated_NotEmittedWhenWithinWindow(t *testing.T)
 	}
 	if mt := findEventByType(sink.snapshot(), events.TypeMessagesTruncated); mt != nil {
 		t.Errorf("messages_truncated must not emit when within window; got payload: %s", mt.Payload)
+	}
+}
+
+// --- RFC #249 Phase 4 (tool tiers) integration tests ---
+
+// preparerJSONWithTools returns a fake preparer Capabilities body that
+// surfaces tool_candidates so the tier decision has something to rank.
+// The plugin name "rag-plugin" + action "prepare" is preparer-only;
+// the candidates name a SEPARATE registry plugin's actions ("tools-
+// plugin.t1" etc.) so they're profile-allowed, non-user-only, and
+// non-preparer when the tier decision runs.
+const preparerJSONForTierTests = `{
+		"send_to_llm": true,
+		"message": "user question",
+		"tool_candidates": [
+			{"tool_name": "tools-plugin.t1", "score": 0.95},
+			{"tool_name": "tools-plugin.t2", "score": 0.85},
+			{"tool_name": "tools-plugin.t3", "score": 0.75},
+			{"tool_name": "tools-plugin.t4", "score": 0.55}
+		]
+	}`
+
+// registerTierTestPlugins wires a preparer (rag-plugin.prepare) +
+// five callable tools (tools-plugin.t1..t5) into the registry. The
+// preparer JSON returns ranked candidates that name t1..t4 so a tier
+// decision can split them across Tier 1 / Tier 2 / Tier 3.
+func registerTierTestPlugins(t *testing.T, registry *ToolRegistry, prepJSON string) {
+	t.Helper()
+	if err := registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG preparer",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: prepJSON}); err != nil {
+		t.Fatalf("register rag-plugin: %v", err)
+	}
+	if err := registry.Register(PluginCapability{
+		Name: "tools-plugin", Description: "Five business tools",
+		Actions: []Action{
+			{Name: "t1", Description: "Tool one"},
+			{Name: "t2", Description: "Tool two"},
+			{Name: "t3", Description: "Tool three"},
+			{Name: "t4", Description: "Tool four"},
+			{Name: "t5", Description: "Tool five"},
+		},
+	}, &fixedResultExecutor{content: "tool-result"}); err != nil {
+		t.Fatalf("register tools-plugin: %v", err)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_ToolTiersEnabledEmitsTieredBlock(t *testing.T) {
+	// RFC #249 Phase 4: with tool_tiers.enabled + a wired
+	// InjectionStateStore, the preparer_decision event's Tools block
+	// reports Tier 0/1/2/3 splits AND the cap snapshot, instead of the
+	// Phase-2 pass-through (all candidates in tier1_new).
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	tierStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, preparerJSONForTierTests)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: true, Tier1Cap: 2, Tier2Cap: 1},
+		InjectionStateStore: tierStore,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision event missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tb := pdPayload.Tools
+	// Tier1Cap=2 + Tier2Cap=1 + 4 candidates + 1 non-candidate (t5):
+	//   Tier 1 = [t1, t2]; Tier 2 = [t3]; Tier 3 = [t4, t5].
+	if tb.Tier1Cap != 2 {
+		t.Errorf("Tier1Cap snapshot = %d, want 2", tb.Tier1Cap)
+	}
+	if tb.Tier1SizeAfter != 2 {
+		t.Errorf("Tier1SizeAfter = %d, want 2", tb.Tier1SizeAfter)
+	}
+	wantT1New := []string{"tools-plugin.t1", "tools-plugin.t2"}
+	gotT1New := append([]string(nil), tb.Tier1New...)
+	sort.Strings(gotT1New)
+	sort.Strings(wantT1New)
+	if !reflect.DeepEqual(gotT1New, wantT1New) {
+		t.Errorf("Tier1New = %v, want %v", gotT1New, wantT1New)
+	}
+	if tb.Tier3TotalVisible != 2 {
+		t.Errorf("Tier3TotalVisible = %d, want 2 (t4 + t5)", tb.Tier3TotalVisible)
+	}
+	if tierStore.updateCalls != 1 {
+		t.Errorf("UpdateInjectionState calls = %d, want 1", tierStore.updateCalls)
+	}
+	if len(tierStore.lastWritten.KnownTools) == 0 {
+		t.Errorf("KnownTools must be persisted, got empty")
+	}
+}
+
+func TestOrchestrator_PreparerPhase_ToolTiersDisabledStaysPassThrough(t *testing.T) {
+	// Regression guard: with the master switch off (and even when a
+	// store is wired), preparer_decision must keep the Phase-2
+	// pass-through Tools block — every candidate in tier1_new, no
+	// tier1_cap snapshot, no store writes.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	tierStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, preparerJSONForTierTests)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: false},
+		InjectionStateStore: tierStore,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pdPayload.Tools.Tier1Cap != 0 {
+		t.Errorf("Tier1Cap must stay zero when tier logic disabled, got %d", pdPayload.Tools.Tier1Cap)
+	}
+	if len(pdPayload.Tools.Tier1New) != 4 {
+		t.Errorf("pass-through Tier1New len = %d, want 4 (all candidates)", len(pdPayload.Tools.Tier1New))
+	}
+	if tierStore.updateCalls != 0 {
+		t.Errorf("disabled tier_tiers must not write state, got %d update calls", tierStore.updateCalls)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_ToolTiersSecondTurnLRUCarriesOver(t *testing.T) {
+	// Two-turn LRU sanity: turn 1 establishes t1/t2 as Tier 1. Turn 2
+	// sees DIFFERENT candidates (t3/t4) and Tier1Cap=2 — but t1/t2's
+	// LRURank from turn 1 still falls below currentTurn=2, so t3/t4
+	// take Tier 1 and t1/t2 land in Tier1EvictedToTier3.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final-1", "final-2"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	tierStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, `{
+		"send_to_llm": true,
+		"message": "q",
+		"tool_candidates": [
+			{"tool_name": "tools-plugin.t1", "score": 0.9},
+			{"tool_name": "tools-plugin.t2", "score": 0.8}
+		]
+	}`)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: true, Tier1Cap: 2, Tier2Cap: 1},
+		InjectionStateStore: tierStore,
+	})
+
+	// Turn 1: t1/t2 enter Tier 1.
+	if _, err := orch.Run(context.Background(), "s1", "first"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Swap the preparer to return t3/t4 instead.
+	t1Caps := registry.ListCapabilities()
+	for _, cap := range t1Caps {
+		if cap.Name == "rag-plugin" {
+			_, _ = registry.GetExecutor(cap.Name) // sanity: it's registered
+		}
+	}
+	registry2 := NewToolRegistry()
+	registerTierTestPlugins(t, registry2, `{
+		"send_to_llm": true,
+		"message": "q2",
+		"tool_candidates": [
+			{"tool_name": "tools-plugin.t3", "score": 0.9},
+			{"tool_name": "tools-plugin.t4", "score": 0.8}
+		]
+	}`)
+	// Re-create the orchestrator with the new registry but the SAME
+	// store (so turn 2 reads turn 1's KnownTools).
+	orch2 := NewWithRules(llm, parser, registry2, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: true, Tier1Cap: 2, Tier2Cap: 1},
+		InjectionStateStore: tierStore,
+	})
+	if _, err := orch2.Run(context.Background(), "s1", "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the LAST preparer_decision (turn 2's).
+	evs := sink.snapshot()
+	var turn2 *emit.Event
+	for i := range evs {
+		if evs[i].EventType == events.TypePreparerDecision {
+			ev := evs[i]
+			turn2 = &ev
+		}
+	}
+	if turn2 == nil {
+		t.Fatal("turn 2 preparer_decision missing")
+	}
+	var p events.PreparerDecisionPayload
+	if err := json.Unmarshal(turn2.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	wantEvicted := []string{"tools-plugin.t1", "tools-plugin.t2"}
+	gotEvicted := append([]string(nil), p.Tools.Tier1EvictedToTier3...)
+	sort.Strings(gotEvicted)
+	sort.Strings(wantEvicted)
+	if !reflect.DeepEqual(gotEvicted, wantEvicted) {
+		t.Errorf("turn 2 Tier1EvictedToTier3 = %v, want %v", gotEvicted, wantEvicted)
+	}
+	gotT1New := append([]string(nil), p.Tools.Tier1New...)
+	sort.Strings(gotT1New)
+	wantT1New := []string{"tools-plugin.t3", "tools-plugin.t4"}
+	if !reflect.DeepEqual(gotT1New, wantT1New) {
+		t.Errorf("turn 2 Tier1New = %v, want %v", gotT1New, wantT1New)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_ToolTiersWithDedupSingleStateWrite(t *testing.T) {
+	// When BOTH dedup and tier decisions run, the tier preparer merges
+	// its KnownTools delta into the dedup decision's UpdatedState so a
+	// single UpdateInjectionState call carries both — avoids one
+	// clobbering the other and keeps writes to one round-trip.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "q",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body", "content_sha256": "sha-a", "score": 0.9}
+		],
+		"tool_candidates": [
+			{"tool_name": "tools-plugin.t1", "score": 0.95}
+		]
+	}`
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	combinedStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, preparerJSON)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+		ToolTiers:           ToolTiersConfig{Enabled: true, Tier1Cap: 3, Tier2Cap: 2},
+		InjectionStateStore: combinedStore,
+	})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	if combinedStore.updateCalls != 1 {
+		t.Errorf("UpdateInjectionState calls = %d, want 1 (dedup write carries tier delta)", combinedStore.updateCalls)
+	}
+	if len(combinedStore.lastWritten.KnownKnowledge) != 1 {
+		t.Errorf("KnownKnowledge persisted len = %d, want 1", len(combinedStore.lastWritten.KnownKnowledge))
+	}
+	if len(combinedStore.lastWritten.KnownTools) == 0 {
+		t.Errorf("KnownTools must also be persisted in the same write, got 0 entries")
 	}
 }

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -2687,6 +2687,405 @@ func TestOrchestrator_PreparerPhase_MultiPreparerAggregation(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_PreparerPhase_DedupEnabledEmitsFullMode(t *testing.T) {
+	// RFC #249 Phase 3: with knowledge_dedup.enabled + a wired
+	// InjectionStateStore, the orchestrator runs the dedup decision
+	// over the candidate list, rewrites the user-turn content with
+	// an ID-tagged [knowledge_context] block, persists the updated
+	// state, and emits preparer_decision with mode=full.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "[knowledge_context]\nplugin-rendered body\n[/knowledge_context]\n\nuser question",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body-a", "content_sha256": "sha-a", "score": 0.9},
+			{"article_id": "kb_b", "content": "body-bb", "content_sha256": "sha-b", "score": 0.6}
+		]
+	}`
+
+	sink := &recordingEventSink{}
+	llm := &capturingLLM{responses: []string{"final answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	dedupStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG preparer",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:        sink,
+		ContentPreparers: []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		KnowledgeDedup: KnowledgeDedupConfig{
+			Enabled:                true,
+			ReinjectScoreThreshold: 0.95,
+			ReinjectTopKForce:      3,
+			CapPerTurn:             5,
+		},
+		InjectionStateStore: dedupStore,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "user question"); err != nil {
+		t.Fatal(err)
+	}
+
+	// preparer_decision must report mode=full with both candidates injected
+	// as "new" (first turn, empty state).
+	evs := sink.snapshot()
+	pd := findEventByType(evs, events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision event missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal preparer_decision payload: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeFull {
+		t.Errorf("Mode = %q, want %q", pdPayload.Mode, events.PreparerDecisionModeFull)
+	}
+	if len(pdPayload.Knowledge.Injected) != 2 {
+		t.Fatalf("Injected len = %d, want 2", len(pdPayload.Knowledge.Injected))
+	}
+	for _, item := range pdPayload.Knowledge.Injected {
+		if item.Reason != "new" {
+			t.Errorf("first-turn injected reason = %q, want %q", item.Reason, "new")
+		}
+	}
+
+	// The state store must have been written with both SHAs.
+	if dedupStore.updateCalls != 1 {
+		t.Errorf("UpdateInjectionState called %d times, want 1", dedupStore.updateCalls)
+	}
+	if len(dedupStore.lastWritten.KnownKnowledge) != 2 {
+		t.Errorf("persisted KnownKnowledge len = %d, want 2", len(dedupStore.lastWritten.KnownKnowledge))
+	}
+
+	// The LLM's user message must carry the rebuilt ID-tagged KC
+	// block (with id="kb_a") and the user's original text, NOT the
+	// plugin's pre-tagged "plugin-rendered body" string.
+	if len(llm.requests) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	var lastUser provider.Message
+	for _, m := range llm.requests[0].Messages {
+		if m.Role == provider.RoleUser {
+			lastUser = m
+		}
+	}
+	if !strings.Contains(lastUser.Content, `[knowledge_context id="kb_a"`) {
+		t.Errorf("LLM user message missing ID-tagged KC block, got: %q", lastUser.Content)
+	}
+	if strings.Contains(lastUser.Content, "plugin-rendered body") {
+		t.Errorf("LLM user message must drop plugin's pre-tagged KC, got: %q", lastUser.Content)
+	}
+	if !strings.Contains(lastUser.Content, "user question") {
+		t.Errorf("LLM user message missing user text, got: %q", lastUser.Content)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_DedupSecondTurnReusesKnownState(t *testing.T) {
+	// Two-turn test: turn 1 introduces two candidates, turn 2 returns
+	// the same candidates. With reinject_top_k_force=1 only kb_a (at
+	// index 0) re-injects via top_k_force; kb_b is skipped as
+	// content_sha_already_known.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "user question",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body-a", "content_sha256": "sha-a", "score": 0.7},
+			{"article_id": "kb_b", "content": "body-bb", "content_sha256": "sha-b", "score": 0.5}
+		]
+	}`
+
+	sink := &recordingEventSink{}
+	llm := &capturingLLM{responses: []string{"first", "second"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	dedupStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG preparer",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:        sink,
+		ContentPreparers: []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		KnowledgeDedup: KnowledgeDedupConfig{
+			Enabled:                true,
+			ReinjectScoreThreshold: 0.95,
+			ReinjectTopKForce:      1,
+			CapPerTurn:             5,
+		},
+		InjectionStateStore: dedupStore,
+	})
+
+	// Turn 1: both candidates inject as "new".
+	if _, err := orch.Run(context.Background(), "s1", "first user question"); err != nil {
+		t.Fatal(err)
+	}
+	// Turn 2: same candidates, expect 1 injected (top_k_force) + 1 skipped (known).
+	if _, err := orch.Run(context.Background(), "s1", "second user question"); err != nil {
+		t.Fatal(err)
+	}
+
+	// LLM-content sanity check: the second-turn user message must
+	// carry kb_a's body but NOT kb_b's body (kb_b was skipped as
+	// already_known). The preparer replaces the user's literal input
+	// with its own `pr.Message`, then dedup prepends the rebuilt KC
+	// block — so the assertion targets the rendered KC content, not
+	// the user's typed text.
+	if len(llm.requests) < 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", len(llm.requests))
+	}
+	turn2Msgs := llm.requests[1].Messages
+	var lastTurn2User string
+	for _, m := range turn2Msgs {
+		if m.Role == provider.RoleUser {
+			lastTurn2User = m.Content
+		}
+	}
+	if lastTurn2User == "" {
+		t.Fatalf("turn-2 user message missing from LLM request: %+v", turn2Msgs)
+	}
+	if !strings.Contains(lastTurn2User, "body-a") {
+		t.Errorf("turn-2 user message must carry kb_a's body, got: %q", lastTurn2User)
+	}
+	if strings.Contains(lastTurn2User, "body-bb") {
+		t.Errorf("turn-2 user message must NOT carry kb_b's body (already known), got: %q", lastTurn2User)
+	}
+	if !strings.Contains(lastTurn2User, `id="kb_a"`) {
+		t.Errorf("turn-2 KC block must be ID-tagged, got: %q", lastTurn2User)
+	}
+
+	// Find the SECOND preparer_decision event (turn 2's). The first one
+	// reports turn 1's "all new" decision.
+	evs := sink.snapshot()
+	var pds []emit.Event
+	for _, e := range evs {
+		if e.EventType == events.TypePreparerDecision {
+			pds = append(pds, e)
+		}
+	}
+	if len(pds) != 2 {
+		t.Fatalf("got %d preparer_decision events, want 2", len(pds))
+	}
+
+	var turn2 events.PreparerDecisionPayload
+	if err := json.Unmarshal(pds[1].Payload, &turn2); err != nil {
+		t.Fatalf("unmarshal turn-2 preparer_decision payload: %v", err)
+	}
+	if len(turn2.Knowledge.Injected) != 1 || turn2.Knowledge.Injected[0].ArticleID != "kb_a" {
+		t.Fatalf("turn 2 must inject only kb_a, got %+v", turn2.Knowledge.Injected)
+	}
+	if turn2.Knowledge.Injected[0].Reason != "top_k_force" {
+		t.Errorf("kb_a reason = %q, want top_k_force", turn2.Knowledge.Injected[0].Reason)
+	}
+	if len(turn2.Knowledge.SkippedKnown) != 1 || turn2.Knowledge.SkippedKnown[0].ArticleID != "kb_b" {
+		t.Fatalf("turn 2 must skip kb_b, got %+v", turn2.Knowledge.SkippedKnown)
+	}
+	if turn2.Knowledge.SkippedKnown[0].Reason != "content_sha_already_known" {
+		t.Errorf("kb_b skip reason = %q", turn2.Knowledge.SkippedKnown[0].Reason)
+	}
+
+	// The dedup store should still hold both SHAs after turn 2 (not
+	// duplicated despite being seen twice across turns).
+	if len(dedupStore.lastWritten.KnownKnowledge) != 2 {
+		t.Errorf("post-turn-2 KnownKnowledge len = %d, want 2", len(dedupStore.lastWritten.KnownKnowledge))
+	}
+}
+
+func TestOrchestrator_PreparerPhase_DedupEnabledWithNilStoreStaysInstrumentationOnly(t *testing.T) {
+	// Defensive guard: even with KnowledgeDedup.Enabled=true, the
+	// preparer-loop's `o.injectionStateStore != nil` precondition
+	// short-circuits when no store was wired. The path must stay on
+	// the Phase-2 instrumentation_only branch without panicking.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "x",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body", "content_sha256": "sha-a", "score": 0.9}
+		]
+	}`
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:        sink,
+			ContentPreparers: []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+			KnowledgeDedup:   KnowledgeDedupConfig{Enabled: true},
+			// InjectionStateStore intentionally nil.
+		})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeInstrumentationOnly {
+		t.Errorf("enabled-flag + nil-store must stay in instrumentation_only, got %q", pdPayload.Mode)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_DedupStoreReadFailureStartsFresh(t *testing.T) {
+	// RFC #249 robustness: a store-read failure must NOT abort the
+	// user turn. The dedup logic falls back to an empty existing
+	// state — every candidate appears as "new" — and the event still
+	// emits with mode=full.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "x",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body", "content_sha256": "sha-a", "score": 0.9}
+		]
+	}`
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{failGetErr: errors.New("simulated read failure")}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: dedupStore,
+		})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatalf("dedup must not abort run on read failure: %v", err)
+	}
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing despite read failure")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeFull {
+		t.Errorf("mode = %q, want full (graceful-degradation still emits full)", pdPayload.Mode)
+	}
+	if len(pdPayload.Knowledge.Injected) != 1 || pdPayload.Knowledge.Injected[0].Reason != events.PreparerDecisionReasonNew {
+		t.Errorf("read-failure fallback must treat candidate as new, got %+v", pdPayload.Knowledge.Injected)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_DedupStoreWriteFailureStillEmitsEvent(t *testing.T) {
+	// RFC #249 invariant: "Event emission precedes state writes." A
+	// write failure must not lose the event — the next preparer pass's
+	// reconciliation step will catch the drift later.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "x",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body", "content_sha256": "sha-a", "score": 0.9}
+		]
+	}`
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{failUpdateErr: errors.New("simulated write failure")}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: dedupStore,
+		})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatalf("dedup must not abort run on write failure: %v", err)
+	}
+	if dedupStore.updateCalls != 1 {
+		t.Errorf("UpdateInjectionState must still be attempted, got %d calls", dedupStore.updateCalls)
+	}
+	// Event must have emitted before the (failing) write — i.e. it
+	// exists despite the write returning an error.
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing — emit must precede state write")
+	}
+}
+
+func TestOrchestrator_PreparerPhase_DedupDisabledStaysInstrumentationOnly(t *testing.T) {
+	// Regression guard: even with an InjectionStateStore wired, if the
+	// master Enabled flag is false the orchestrator must keep emitting
+	// mode=instrumentation_only and must NOT call the store.
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "x",
+		"knowledge_candidates": [
+			{"article_id": "kb_a", "content": "body", "content_sha256": "sha-a", "score": 0.9}
+		]
+	}`
+
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"final"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	dedupStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG preparer",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		KnowledgeDedup:      KnowledgeDedupConfig{Enabled: false}, // explicit off
+		InjectionStateStore: dedupStore,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	pd := findEventByType(sink.snapshot(), events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeInstrumentationOnly {
+		t.Errorf("Mode = %q, want %q", pdPayload.Mode, events.PreparerDecisionModeInstrumentationOnly)
+	}
+	if dedupStore.getCalls != 0 || dedupStore.updateCalls != 0 {
+		t.Errorf("disabled dedup must not touch the store, got get=%d update=%d",
+			dedupStore.getCalls, dedupStore.updateCalls)
+	}
+}
+
 func TestOrchestrator_MessagesTruncated_EmittedWhenSlidingWindowCuts(t *testing.T) {
 	// Sliding window: when sess.Messages exceeds ContextMessages, the
 	// orchestrator drops the oldest N entries and emits one

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -2057,6 +2057,112 @@ func TestOrchestrator_Confirmation_ToolCallRequiresConfirmation_EmitsRequested(t
 	}
 }
 
+func TestOrchestrator_Confirmation_ReadOnlyAction_SkipsPrompt(t *testing.T) {
+	// A read-only action must never trigger the confirmation gate, even
+	// when the confirmation plugin is wired and would otherwise fail-safe
+	// to "require confirmation" (the local-dev signal that surfaced the
+	// noise originally). The action's manifest carries
+	// ReadOnly=true and the orchestrator short-circuits before
+	// checkConfirmationPlugin runs — so no confirmation_requested event
+	// reaches the sink, the tool executes inline, and the LLM's
+	// "textAfter" closes the turn normally.
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:        "tc-readonly",
+			Name:      "gitlab.list_issues",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "here are your issues",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "gitlab",
+		Actions: []Action{{Name: "list_issues", ReadOnly: true}},
+	}, &echoExecutor{})
+	// A confirming executor backs the confirmation plugin — if the gate
+	// runs, it returns RequiresConfirmation=true and we'd see a
+	// confirmation_requested event in the sink. The point of this test
+	// is that this code path must not even be reached.
+	_ = registry.Register(PluginCapability{
+		Name:    "conf",
+		Actions: []Action{{Name: "check"}},
+	}, confirmingExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:          sink,
+		ConfirmationPlugin: "conf",
+		ConfirmationAction: "check",
+	})
+
+	if _, err := orch.Run(context.Background(), "sess", "list my issues"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationRequestedPayloads(t, sink.snapshot())
+	if len(got) != 0 {
+		t.Errorf("confirmation_requested count = %d, want 0 for read_only action (got prompts: %v)",
+			len(got), got)
+	}
+}
+
+func TestOrchestrator_Confirmation_NonReadOnlyAction_StillPrompts(t *testing.T) {
+	// Sibling to the ReadOnly skip test: an action that is NOT declared
+	// read-only must still go through the confirmation gate, even if a
+	// sibling action on the same plugin is read-only. Locks in that the
+	// short-circuit is keyed strictly on the per-action flag and doesn't
+	// accidentally infect every call to the same plugin.
+	sink := &recordingEventSink{}
+	llm := &nativeToolCallingLLM{
+		toolCalls: []provider.ToolCall{{
+			ID:        "tc-write",
+			Name:      "gitlab.create_issue",
+			Arguments: map[string]string{},
+		}},
+		textAfter: "done",
+	}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab",
+		Actions: []Action{
+			{Name: "list_issues", ReadOnly: true},
+			{Name: "create_issue"}, // ReadOnly=false (default)
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name:    "conf",
+		Actions: []Action{{Name: "check"}},
+	}, confirmingExecutor{})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:          sink,
+		ConfirmationPlugin: "conf",
+		ConfirmationAction: "check",
+	})
+
+	if _, err := orch.Run(context.Background(), "sess", "create an issue"); err != nil {
+		t.Fatal(err)
+	}
+
+	got := findConfirmationRequestedPayloads(t, sink.snapshot())
+	if len(got) != 1 {
+		t.Fatalf("confirmation_requested count = %d, want 1 for non-read-only action", len(got))
+	}
+	if got[0].ToolCallID != "tc-write" {
+		t.Errorf("ToolCallID = %q, want tc-write", got[0].ToolCallID)
+	}
+}
+
 // -----------------------------------------------------------------------------
 // parent_id linkage tests — verify that producer-side event_id generation
 // and WithParent ctx wiring produces the expected event tree.

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -3033,6 +3033,93 @@ func TestOrchestrator_PreparerPhase_DedupStoreWriteFailureStillEmitsEvent(t *tes
 	}
 }
 
+func TestOrchestrator_PreparerPhase_DedupReconciliationEmitsDriftAndCorrectsState(t *testing.T) {
+	// Pre-load the dedup store with a SHA that the session's visible
+	// messages don't carry (the message was deleted between turns —
+	// summarization, retention, or external mutation). The next
+	// preparer pass must:
+	//   - detect the drift via lazy reconciliation
+	//   - emit drift_detected with kb_gone in missing_from_visible
+	//   - run applyKnowledgeDedup against the CORRECTED state, so the
+	//     new candidate kb_new is treated as "new" (an empty corrected
+	//     state means kb_new is unseen).
+	preparerJSON := `{
+		"send_to_llm": true,
+		"message": "user question",
+		"knowledge_candidates": [
+			{"article_id": "kb_new", "content": "fresh body", "content_sha256": "sha-new", "score": 0.9}
+		]
+	}`
+	sink := &recordingEventSink{}
+	dedupStore := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownKnowledge: []state.KnownKnowledgeEntry{
+				{ArticleID: "kb_gone", ContentSHA256: "sha-gone", FirstInjectedTurn: 1},
+			}},
+		},
+	}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-plugin", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "Prepare"}},
+	}, &fixedResultExecutor{content: preparerJSON})
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{responses: []string{"final"}},
+		&fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, state.NewMemoryStore(""), sessions, OrchestratorOpts{
+			EventSink:           sink,
+			ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+			KnowledgeDedup:      KnowledgeDedupConfig{Enabled: true},
+			InjectionStateStore: dedupStore,
+		})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	// drift_detected must have fired with kb_gone missing and kb_new
+	// not yet visible (the preparer-loop runs reconciliation BEFORE
+	// the orchestrator splices the new KC block — so the snapshot the
+	// reconciler sees has no current-turn KC yet).
+	evs := sink.snapshot()
+	drift := findEventByType(evs, events.TypeDriftDetected)
+	if drift == nil {
+		t.Fatal("drift_detected event missing")
+	}
+	var dp events.DriftDetectedPayload
+	if err := json.Unmarshal(drift.Payload, &dp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(dp.MissingFromVisible) != 1 || dp.MissingFromVisible[0] != "sha-gone" {
+		t.Errorf("MissingFromVisible = %v, want [sha-gone]", dp.MissingFromVisible)
+	}
+
+	// preparer_decision must report kb_new as "new" (corrected state
+	// is empty, so the kb_new SHA isn't recognized as known) and
+	// kb_gone must NOT appear under SkippedKnown (the reconciliation
+	// already dropped it).
+	pd := findEventByType(evs, events.TypePreparerDecision)
+	if pd == nil {
+		t.Fatal("preparer_decision missing")
+	}
+	var pdPayload events.PreparerDecisionPayload
+	if err := json.Unmarshal(pd.Payload, &pdPayload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if pdPayload.Mode != events.PreparerDecisionModeFull {
+		t.Errorf("Mode = %q, want full", pdPayload.Mode)
+	}
+	if len(pdPayload.Knowledge.Injected) != 1 || pdPayload.Knowledge.Injected[0].Reason != events.PreparerDecisionReasonNew {
+		t.Errorf("kb_new must inject as new, got %+v", pdPayload.Knowledge.Injected)
+	}
+
+	// Persisted state after the turn should only carry kb_new (the
+	// reconciliation dropped kb_gone, the dedup added kb_new).
+	if len(dedupStore.lastWritten.KnownKnowledge) != 1 || dedupStore.lastWritten.KnownKnowledge[0].ContentSHA256 != "sha-new" {
+		t.Errorf("post-turn state must only carry kb_new, got %+v", dedupStore.lastWritten.KnownKnowledge)
+	}
+}
+
 func TestOrchestrator_PreparerPhase_DedupDisabledStaysInstrumentationOnly(t *testing.T) {
 	// Regression guard: even with an InjectionStateStore wired, if the
 	// master Enabled flag is false the orchestrator must keep emitting

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -2686,3 +2686,79 @@ func TestOrchestrator_PreparerPhase_MultiPreparerAggregation(t *testing.T) {
 			pdPayload.Knowledge.InjectedBytes, len("AAA")+len("BBBB"))
 	}
 }
+
+func TestOrchestrator_MessagesTruncated_EmittedWhenSlidingWindowCuts(t *testing.T) {
+	// Sliding window: when sess.Messages exceeds ContextMessages, the
+	// orchestrator drops the oldest N entries and emits one
+	// messages_truncated event carrying the dropped index range and
+	// count. Phase 2 leaves the knowledge fields (released_knowledge_ids,
+	// remaining_known_knowledge_count) empty — Phase 3 wires them.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	// Seed sess.Messages with 6 user/assistant pairs (12 messages) so the
+	// cutter has work to do. ContextMessages = 4 → expect 8 dropped.
+	for i := 0; i < 6; i++ {
+		_ = sessions.AddMessage("s1", provider.Message{Role: provider.RoleUser, Content: "user-msg"})
+		_ = sessions.AddMessage("s1", provider.Message{Role: provider.RoleAssistant, Content: "asst-msg"})
+	}
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:       sink,
+		ContextMessages: 4,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "next message"); err != nil {
+		t.Fatal(err)
+	}
+
+	mt := findEventByType(sink.snapshot(), events.TypeMessagesTruncated)
+	if mt == nil {
+		t.Fatal("messages_truncated event not emitted")
+	}
+	var p events.MessagesTruncatedPayload
+	if err := json.Unmarshal(mt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal messages_truncated payload: %v", err)
+	}
+	// 12 seeded + 1 current-turn user message (added before buildMessages
+	// runs) = 13; ContextMessages = 4 → drop 9 oldest (indices 0..8).
+	if p.DroppedCount != 9 {
+		t.Errorf("DroppedCount = %d, want 9 (12 seeded + 1 current = 13, keep 4)", p.DroppedCount)
+	}
+	if len(p.DroppedSeqRange) != 2 || p.DroppedSeqRange[0] != 0 || p.DroppedSeqRange[1] != 8 {
+		t.Errorf("DroppedSeqRange = %v, want [0, 8]", p.DroppedSeqRange)
+	}
+}
+
+func TestOrchestrator_MessagesTruncated_NotEmittedWhenWithinWindow(t *testing.T) {
+	// Sliding window does not fire when len(messages) <= ContextMessages.
+	// No messages_truncated event must reach the sink in that case.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	// Only one prior exchange — well below the window.
+	_ = sessions.AddMessage("s1", provider.Message{Role: provider.RoleUser, Content: "u"})
+	_ = sessions.AddMessage("s1", provider.Message{Role: provider.RoleAssistant, Content: "a"})
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:       sink,
+		ContextMessages: 10,
+	})
+	if _, err := orch.Run(context.Background(), "s1", "next"); err != nil {
+		t.Fatal(err)
+	}
+	if mt := findEventByType(sink.snapshot(), events.TypeMessagesTruncated); mt != nil {
+		t.Errorf("messages_truncated must not emit when within window; got payload: %s", mt.Payload)
+	}
+}

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -1650,6 +1650,63 @@ func TestOrchestrator_Summarization_EmitsTriggeredAndCompleted(t *testing.T) {
 	}
 }
 
+func TestOrchestrator_Summarization_PopulatesReleasedKnowledgeIDs(t *testing.T) {
+	// When summarization replaces a message range that carried tagged
+	// [knowledge_context] blocks, summarization_completed lists the
+	// released article_ids so consumers correlate with InjectionState
+	// without diffing two reconciliation snapshots.
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	kc := func(id, sha string) string {
+		return "[knowledge_context id=\"" + id + "\" sha=\"" + sha + "\"]body[/knowledge_context]\n\nuser text"
+	}
+	// 10 seeded; SummarizeAfterMessages=5, MaxMessagesAfterSummary=3 →
+	// kept = last 3, summarized-away = first 7. Seed two KC-bearing
+	// user messages in the first half (will be summarized away) plus
+	// a duplicate article_id to verify dedup.
+	toSummarize := []provider.Message{
+		{Role: provider.RoleUser, Content: kc("kb_a", "sha_a1")},
+		{Role: provider.RoleAssistant, Content: "answer-a"},
+		{Role: provider.RoleUser, Content: kc("kb_b", "sha_b1")},
+		{Role: provider.RoleAssistant, Content: "answer-b"},
+		{Role: provider.RoleUser, Content: kc("kb_a", "sha_a2")}, // duplicate article_id
+		{Role: provider.RoleAssistant, Content: "answer-a2"},
+		{Role: provider.RoleUser, Content: "plain text"},
+	}
+	keep := []provider.Message{
+		{Role: provider.RoleUser, Content: kc("kb_c", "sha_c1")},
+		{Role: provider.RoleAssistant, Content: "answer-c"},
+		{Role: provider.RoleUser, Content: "tail"},
+	}
+	for _, m := range append(toSummarize, keep...) {
+		_ = sessions.AddMessage("sess", m)
+	}
+
+	llm := &fakeLLM{responses: []string{"summary of older turns"}}
+	orch := NewWithRules(llm, DefaultParser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:               sink,
+		SummarizeAfterMessages:  5,
+		MaxMessagesAfterSummary: 3,
+	})
+
+	orch.maybeSummarizeSession(context.Background(), "sess")
+
+	comp := findPayloadsByType(t, sink.snapshot(), events.TypeSummarizationCompleted)
+	if len(comp) != 1 {
+		t.Fatalf("summarization_completed count = %d, want 1", len(comp))
+	}
+	var cp events.SummarizationCompletedPayload
+	_ = json.Unmarshal(comp[0], &cp)
+	want := []string{"kb_a", "kb_b"}
+	if !reflect.DeepEqual(cp.ReleasedKnowledgeIDs, want) {
+		t.Errorf("ReleasedKnowledgeIDs = %v, want %v (dedup of kb_a + kb_b in summarized range; kb_c is in kept and must not appear)",
+			cp.ReleasedKnowledgeIDs, want)
+	}
+}
+
 func TestOrchestrator_Summarization_NoCompletedOnLLMError(t *testing.T) {
 	// LLM errors on summarization → triggered fires, completed does not.
 	// Consumer-side analytics counts "triggered minus completed" as failure rate.
@@ -3339,8 +3396,10 @@ func TestOrchestrator_MessagesTruncated_EmittedWhenSlidingWindowCuts(t *testing.
 	// Sliding window: when sess.Messages exceeds ContextMessages, the
 	// orchestrator drops the oldest N entries and emits one
 	// messages_truncated event carrying the dropped index range and
-	// count. Phase 2 leaves the knowledge fields (released_knowledge_ids,
-	// remaining_known_knowledge_count) empty — Phase 3 wires them.
+	// count. With no [knowledge_context] blocks in the dropped slice,
+	// ReleasedKnowledgeIDs stays nil and RemainingKnownKnowledgeCount
+	// stays 0 — both omitted under `omitempty`. The KC-bearing case is
+	// covered by TestOrchestrator_MessagesTruncated_PopulatesReleasedKnowledgeIDs.
 	sink := &recordingEventSink{}
 	llm := &fakeLLM{responses: []string{"answer"}}
 	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
@@ -3381,6 +3440,75 @@ func TestOrchestrator_MessagesTruncated_EmittedWhenSlidingWindowCuts(t *testing.
 	}
 	if len(p.DroppedSeqRange) != 2 || p.DroppedSeqRange[0] != 0 || p.DroppedSeqRange[1] != 8 {
 		t.Errorf("DroppedSeqRange = %v, want [0, 8]", p.DroppedSeqRange)
+	}
+}
+
+func TestOrchestrator_MessagesTruncated_PopulatesReleasedKnowledgeIDs(t *testing.T) {
+	// When the sliding-window cutter drops messages that carry tagged
+	// [knowledge_context id="..." sha="..."] blocks, the emitted
+	// messages_truncated event lists the released article_ids (deduped,
+	// in-order) and the remaining KC-bearing article count among the
+	// kept messages. RFC #249 Pillar C — consumers correlate with
+	// InjectionState without re-reconciling.
+	sink := &recordingEventSink{}
+	llm := &fakeLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	// Seed: 8 messages. Run() adds 1 current-turn user message before
+	// applySlidingWindow fires → 9 total. ContextMessages=4 → drop the
+	// first 5 (indices 0..4), keep the last 4 (indices 5..8). Place two
+	// distinct + one duplicate article_id in the dropped range; one
+	// fresh article_id in the kept range.
+	kc := func(id, sha string) string {
+		return "[knowledge_context id=\"" + id + "\" sha=\"" + sha + "\"]body[/knowledge_context]\n\nuser text"
+	}
+	seed := []provider.Message{
+		{Role: provider.RoleUser, Content: kc("kb_a", "sha_a1")}, // 0 dropped
+		{Role: provider.RoleAssistant, Content: "answer-1"},      // 1 dropped
+		{Role: provider.RoleUser, Content: kc("kb_b", "sha_b1")}, // 2 dropped
+		{Role: provider.RoleUser, Content: kc("kb_a", "sha_a2")}, // 3 dropped — duplicate article_id
+		{Role: provider.RoleAssistant, Content: "answer-b"},      // 4 dropped
+		{Role: provider.RoleUser, Content: kc("kb_c", "sha_c1")}, // 5 kept
+		{Role: provider.RoleAssistant, Content: "answer-c"},      // 6 kept
+		{Role: provider.RoleUser, Content: "plain follow-up"},    // 7 kept
+		// index 8 is the "next message" Run() prepends — kept, no KC
+	}
+	for _, m := range seed {
+		_ = sessions.AddMessage("s1", m)
+	}
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:       sink,
+		ContextMessages: 4,
+	})
+
+	if _, err := orch.Run(context.Background(), "s1", "next message"); err != nil {
+		t.Fatal(err)
+	}
+
+	mt := findEventByType(sink.snapshot(), events.TypeMessagesTruncated)
+	if mt == nil {
+		t.Fatal("messages_truncated event not emitted")
+	}
+	var p events.MessagesTruncatedPayload
+	if err := json.Unmarshal(mt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal messages_truncated payload: %v", err)
+	}
+	want := []string{"kb_a", "kb_b"}
+	if !reflect.DeepEqual(p.ReleasedKnowledgeIDs, want) {
+		t.Errorf("ReleasedKnowledgeIDs = %v, want %v (dedup of kb_a + kb_b in dropped range)",
+			p.ReleasedKnowledgeIDs, want)
+	}
+	// Kept slice has one KC-bearing message (kb_c); the current-turn
+	// user message added by Run is plain — remaining = 1.
+	if p.RemainingKnownKnowledgeCount != 1 {
+		t.Errorf("RemainingKnownKnowledgeCount = %d, want 1 (kb_c in kept range)",
+			p.RemainingKnownKnowledgeCount)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -3494,6 +3494,104 @@ func TestOrchestrator_PreparerPhase_ToolTiersSecondTurnLRUCarriesOver(t *testing
 	}
 }
 
+func TestOrchestrator_PreparerPhase_ToolTiersSystemPromptHasTier2AndTier3Sections(t *testing.T) {
+	// RFC #249 Phase 4 D3: with tier decision active, the system
+	// prompt sent to the LLM must include "## Available tools —
+	// summary tier" (Tier 2 name + 1-liner) and "## Other available
+	// tools" (Tier 3 names-only grouped). Tier 0+1 stay in the per-
+	// plugin sections (the existing relevant_tools narrowing handles
+	// them, now driven by Tier 0+1 names from the decision).
+	sink := &recordingEventSink{}
+	llm := &capturingLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+	tierStore := &fakeInjectionStateStore{}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, preparerJSONForTierTests)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:           sink,
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: true, Tier1Cap: 2, Tier2Cap: 1},
+		InjectionStateStore: tierStore,
+	})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(llm.requests) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	var sysMsg string
+	for _, m := range llm.requests[0].Messages {
+		if m.Role == provider.RoleSystem {
+			sysMsg = m.Content
+		}
+	}
+	if sysMsg == "" {
+		t.Fatal("system message missing in LLM request")
+	}
+	if !strings.Contains(sysMsg, "## Available tools — summary tier") {
+		t.Errorf("system prompt missing Tier 2 header, got:\n%s", sysMsg)
+	}
+	if !strings.Contains(sysMsg, "## Other available tools (request details before use)") {
+		t.Errorf("system prompt missing Tier 3 header, got:\n%s", sysMsg)
+	}
+	// Tier 3 includes t4 (overflow of Tier 1+2 caps) and t5 (never a
+	// candidate). Both must appear under the tools-plugin group.
+	if !strings.Contains(sysMsg, "tools-plugin:") {
+		t.Errorf("Tier 3 plugin group header missing, got:\n%s", sysMsg)
+	}
+	if !strings.Contains(sysMsg, "t4") || !strings.Contains(sysMsg, "t5") {
+		t.Errorf("Tier 3 missing t4 / t5, got:\n%s", sysMsg)
+	}
+	// Tier 2 has exactly one entry (Tier2Cap=1): tools-plugin.t3.
+	if !strings.Contains(sysMsg, "tools-plugin.t3") {
+		t.Errorf("Tier 2 must list tools-plugin.t3, got:\n%s", sysMsg)
+	}
+}
+
+func TestOrchestrator_PreparerPhase_ToolTiersDisabledNoTierSectionsInPrompt(t *testing.T) {
+	// Regression guard: with tier_tiers.enabled=false, the system
+	// prompt must NOT contain the Phase-4 "Available tools — summary
+	// tier" or "Other available tools (request details before use)"
+	// sections. The pre-Phase-4 prompt structure is fully preserved.
+	sink := &recordingEventSink{}
+	llm := &capturingLLM{responses: []string{"answer"}}
+	parser := &fakeParser{parseFn: func(string) []ToolCall { return nil }}
+
+	registry := NewToolRegistry()
+	registerTierTestPlugins(t, registry, preparerJSONForTierTests)
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	orch := NewWithRules(llm, parser, registry, memory, sessions, OrchestratorOpts{
+		EventSink:        sink,
+		ContentPreparers: []ContentPreparerEntry{{Plugin: "rag-plugin", Action: "prepare"}},
+		ToolTiers:        ToolTiersConfig{Enabled: false},
+	})
+	if _, err := orch.Run(context.Background(), "s1", "ask"); err != nil {
+		t.Fatal(err)
+	}
+
+	var sysMsg string
+	for _, m := range llm.requests[0].Messages {
+		if m.Role == provider.RoleSystem {
+			sysMsg = m.Content
+		}
+	}
+	if strings.Contains(sysMsg, "## Available tools — summary tier") {
+		t.Errorf("Tier 2 section must NOT appear when tier logic off, got:\n%s", sysMsg)
+	}
+	if strings.Contains(sysMsg, "## Other available tools (request details before use)") {
+		t.Errorf("Tier 3 section must NOT appear when tier logic off, got:\n%s", sysMsg)
+	}
+}
+
 func TestOrchestrator_PreparerPhase_ToolTiersWithDedupSingleStateWrite(t *testing.T) {
 	// When BOTH dedup and tier decisions run, the tier preparer merges
 	// its KnownTools delta into the dedup decision's UpdatedState so a

--- a/internal/orchestrator/plugin_filter_test.go
+++ b/internal/orchestrator/plugin_filter_test.go
@@ -256,6 +256,41 @@ func TestPluginAllowed_StrictMode_AliasInAllowlist(t *testing.T) {
 	}
 }
 
+// --- meta-plugin special-case ---
+
+func TestPluginAllowed_MetaPluginAlwaysAllowed(t *testing.T) {
+	// The orchestrator-owned `_meta` namespace must never be blocked by
+	// the profile / WhoAmI gate. The customer's WhoAmI response never
+	// lists `_meta` because it isn't a plugin they own — it's
+	// host-internal. Without this special-case the LLM sees the
+	// meta-tool in the prompt (AlwaysInclude=true pins it to Tier 0),
+	// tries to call it on the LLM-driven path, and the call gets
+	// refused with "plugin '_meta' is not available for this profile" —
+	// breaking the get_tool_details promotion contract for every
+	// non-permissive profile.
+	o := newFilterOrch(buildFilterRegistry(), nil)
+	metaCap := PluginCapability{Name: metaPluginName}
+
+	tests := []struct {
+		name    string
+		allowed cachedAllowedPlugins
+	}{
+		{"strict mode without _meta in allowlist",
+			cachedAllowedPlugins{m: map[string]bool{"timly": true}, strict: true}},
+		{"non-strict mode with AllowedGroups set",
+			cachedAllowedPlugins{m: map[string]bool{"timly": true}, strict: false}},
+		{"empty allowlist in strict mode",
+			cachedAllowedPlugins{m: map[string]bool{}, strict: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if !o.pluginAllowed(metaCap, tc.allowed) {
+				t.Errorf("_meta must be allowed regardless of profile (%s)", tc.name)
+			}
+		})
+	}
+}
+
 // --- end-to-end: system prompt ---
 
 func TestSystemPrompt_StrictMode_OnlyListedPluginsVisible(t *testing.T) {

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -243,6 +243,9 @@ func buildToolsBlock(agg preparerAggregate) events.PreparerDecisionToolsBlock {
 		Tier1DemotedSticky:        d.Tier1DemotedSticky,
 		Tier1SizeAfter:            d.Tier1SizeAfter,
 		Tier1Cap:                  d.Tier1Cap,
+		Tier2Tools:                d.Tier2,
+		Tier2SizeAfter:            len(d.Tier2),
+		Tier2Cap:                  d.Tier2Cap,
 		Tier3TotalVisible:         len(d.Tier3),
 		PromotedViaGetToolDetails: d.PromotedViaGetToolDetails,
 	}

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -1,0 +1,269 @@
+package orchestrator
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+	"github.com/opentalon/opentalon/internal/state/store/events/emit"
+)
+
+// Preparer-phase event-emission helpers (RFC #249 Phase 2). Pulled out
+// of orchestrator.go so the hot-path preparer loop reads as
+//
+//	outcome := runSinglePreparer(...)
+//	emitPreparerRetrievals(...)
+//	accumulate(...)
+//
+// instead of inlining ~80 lines of candidate-to-hit conversion. The
+// helpers themselves are pure functions over preparerResponse — no
+// orchestrator state mutation, no plugin calls — so the same logic is
+// reusable in Phase 3+ once `mode: full` starts driving real decisions.
+
+// preparerAggregate accumulates candidate data across all preparers in
+// one turn so emitPreparerDecision can publish the composite outcome
+// once at the end of the loop.
+type preparerAggregate struct {
+	Knowledge []KnowledgeCandidate
+	Glossary  []GlossaryCandidate
+	Tools     []ToolCandidate
+
+	// LegacyRelevantTools captures `pr.RelevantTools` for plugins that
+	// haven't migrated to the structured ToolCandidates shape yet.
+	// preparer_decision still surfaces them under tools.tier1_new so
+	// instrumentation does not blank out on legacy plugins.
+	LegacyRelevantTools []string
+}
+
+// append pulls the candidate slices off one preparer's response into
+// the aggregate. Safe to call with a zero-valued response (no-op).
+func (a *preparerAggregate) append(pr preparerResponse) {
+	a.Knowledge = append(a.Knowledge, pr.KnowledgeCandidates...)
+	a.Glossary = append(a.Glossary, pr.GlossaryCandidates...)
+	a.Tools = append(a.Tools, pr.ToolCandidates...)
+	if len(pr.ToolCandidates) == 0 && len(pr.RelevantTools) > 0 {
+		a.LegacyRelevantTools = append(a.LegacyRelevantTools, pr.RelevantTools...)
+	}
+}
+
+// emitPreparerRetrievals fires the per-corpus *_retrieval events for
+// one preparer pass. Each event is emitted via the existing emit
+// helpers and inherits ctx's ParentID (which the caller has wrapped to
+// point at user_message). Search-text dimensions come from the
+// plugin's RetrievalMetrics if present, otherwise defaulted from the
+// orchestrator's enrichment state.
+func (o *Orchestrator) emitPreparerRetrievals(ctx context.Context, query string, defaultSource string, pr preparerResponse) {
+	if o.eventSink == nil {
+		return
+	}
+
+	km, gm, tm := splitCorpusMetrics(pr.RetrievalMetrics)
+
+	if len(pr.KnowledgeCandidates) > 0 || km != nil {
+		args := emit.KnowledgeRetrievalArgs{
+			Query:            query,
+			SearchTextSource: defaultSource,
+			Hits:             knowledgeCandidatesToHits(pr.KnowledgeCandidates),
+		}
+		applyCorpusMetrics(km, &args.SearchTextSource, &args.TopK, &args.MinScore, &args.LatencyMS)
+		emit.EmitKnowledgeRetrieval(ctx, o.eventSink, args)
+	}
+
+	if len(pr.GlossaryCandidates) > 0 || gm != nil {
+		args := emit.GlossaryRetrievalArgs{
+			Query:            query,
+			SearchTextSource: defaultSource,
+			Hits:             glossaryCandidatesToHits(pr.GlossaryCandidates),
+		}
+		applyCorpusMetrics(gm, &args.SearchTextSource, &args.TopK, &args.MinScore, &args.LatencyMS)
+		emit.EmitGlossaryRetrieval(ctx, o.eventSink, args)
+	}
+
+	// Tools: emit when the plugin returned ToolCandidates, metrics, OR
+	// the legacy relevant_tools list. The legacy path produces hits
+	// with score=0 so the event still reflects "this many tools came
+	// out of the retrieval", just without per-tool ranking.
+	hasToolSignal := len(pr.ToolCandidates) > 0 || tm != nil || len(pr.RelevantTools) > 0
+	if hasToolSignal {
+		hits := toolCandidatesToHits(pr.ToolCandidates)
+		if len(hits) == 0 && len(pr.RelevantTools) > 0 {
+			hits = make([]events.ToolRetrievalHit, 0, len(pr.RelevantTools))
+			for _, name := range pr.RelevantTools {
+				hits = append(hits, events.ToolRetrievalHit{ToolName: name})
+			}
+		}
+		args := emit.ToolRetrievalArgs{
+			Query:            query,
+			SearchTextSource: defaultSource,
+			Hits:             hits,
+		}
+		applyCorpusMetrics(tm, &args.SearchTextSource, &args.TopK, &args.MinScore, &args.LatencyMS)
+		emit.EmitToolRetrieval(ctx, o.eventSink, args)
+	}
+}
+
+// emitPreparerDecision publishes the composite preparer-pass outcome
+// once per user turn. Phase 2 always emits with mode =
+// instrumentation_only: every candidate is reported under Knowledge.Injected
+// and every tool under Tools.Tier1New so consumers (api-plugin
+// aggregations, Timly review UI) can render a meaningful payload while
+// the actual dedup/tier logic is still off. Phase 3+ flips the mode
+// and starts populating the SkippedKnown / evicted buckets.
+func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAggregate) {
+	if o.eventSink == nil {
+		return
+	}
+	if len(agg.Knowledge) == 0 && len(agg.Glossary) == 0 && len(agg.Tools) == 0 && len(agg.LegacyRelevantTools) == 0 {
+		// Nothing retrieved from any corpus → skip the event. Avoids
+		// noisy preparer_decision rows on turns where no preparer ran
+		// (toolCallSeeded path, sessions with empty o.preparers, …).
+		return
+	}
+
+	knowledgeBlock := events.PreparerDecisionKnowledgeBlock{
+		CandidateIDs:  knowledgeCandidateIDs(agg.Knowledge),
+		Injected:      knowledgeCandidatesToInjected(agg.Knowledge),
+		InjectedBytes: knowledgeInjectedBytes(agg.Knowledge),
+	}
+
+	toolsBlock := events.PreparerDecisionToolsBlock{
+		Tier1New: toolCandidateNames(agg.Tools, agg.LegacyRelevantTools),
+	}
+
+	emit.EmitPreparerDecision(ctx, o.eventSink, emit.PreparerDecisionArgs{
+		Mode:      events.PreparerDecisionModeInstrumentationOnly,
+		Knowledge: knowledgeBlock,
+		Tools:     toolsBlock,
+	})
+}
+
+// ----- Pure conversion helpers (no orchestrator state) -----
+
+func knowledgeCandidatesToHits(cands []KnowledgeCandidate) []events.KnowledgeRetrievalHit {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]events.KnowledgeRetrievalHit, len(cands))
+	for i, c := range cands {
+		out[i] = events.KnowledgeRetrievalHit{
+			ArticleID:     c.ArticleID,
+			Title:         c.Title,
+			Score:         c.Score,
+			ContentSHA256: c.ContentSHA256,
+			Source:        c.Source,
+		}
+	}
+	return out
+}
+
+func glossaryCandidatesToHits(cands []GlossaryCandidate) []events.GlossaryRetrievalHit {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]events.GlossaryRetrievalHit, len(cands))
+	for i, c := range cands {
+		out[i] = events.GlossaryRetrievalHit{
+			Term:          c.Term,
+			Score:         c.Score,
+			ContentSHA256: c.ContentSHA256,
+			Source:        c.Source,
+		}
+	}
+	return out
+}
+
+func toolCandidatesToHits(cands []ToolCandidate) []events.ToolRetrievalHit {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]events.ToolRetrievalHit, len(cands))
+	for i, c := range cands {
+		out[i] = events.ToolRetrievalHit{
+			ToolName: c.ToolName,
+			Score:    c.Score,
+		}
+	}
+	return out
+}
+
+func knowledgeCandidateIDs(cands []KnowledgeCandidate) []string {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]string, len(cands))
+	for i, c := range cands {
+		out[i] = c.ArticleID
+	}
+	return out
+}
+
+func knowledgeCandidatesToInjected(cands []KnowledgeCandidate) []events.PreparerDecisionInjectedItem {
+	if len(cands) == 0 {
+		return nil
+	}
+	out := make([]events.PreparerDecisionInjectedItem, len(cands))
+	for i, c := range cands {
+		out[i] = events.PreparerDecisionInjectedItem{
+			ArticleID:     c.ArticleID,
+			ContentSHA256: c.ContentSHA256,
+			// Phase 2 has no dedup state, so every candidate is reported
+			// as if newly injected. Phase 3+ will switch to "new" /
+			// "score_override" / "top_k_force" per the dedup decision.
+			Reason: "instrumentation_only",
+		}
+	}
+	return out
+}
+
+func knowledgeInjectedBytes(cands []KnowledgeCandidate) int {
+	total := 0
+	for _, c := range cands {
+		total += len(c.Content)
+	}
+	return total
+}
+
+func toolCandidateNames(cands []ToolCandidate, legacy []string) []string {
+	if len(cands) == 0 && len(legacy) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(cands)+len(legacy))
+	for _, c := range cands {
+		out = append(out, c.ToolName)
+	}
+	out = append(out, legacy...)
+	return out
+}
+
+// splitCorpusMetrics returns the three per-corpus metric pointers from
+// the optional RetrievalMetrics envelope. Each can be nil
+// independently, mirroring the plugin's "set only what you measured"
+// contract.
+func splitCorpusMetrics(rm *PreparerRetrievalMetrics) (k, g, t *PreparerCorpusMetrics) {
+	if rm == nil {
+		return nil, nil, nil
+	}
+	return rm.Knowledge, rm.Glossary, rm.Tools
+}
+
+// applyCorpusMetrics copies the populated fields from m into the
+// retrieval-args pointers when m is non-nil. SearchTextSource only
+// overrides the caller-provided default when the plugin set a
+// non-empty value, so the orchestrator's enrichment-state default
+// (user_input vs enriched) stays as fallback.
+func applyCorpusMetrics(m *PreparerCorpusMetrics, searchTextSource *string, topK *int, minScore *float64, latencyMS *int64) {
+	if m == nil {
+		return
+	}
+	if m.SearchTextSource != "" {
+		*searchTextSource = m.SearchTextSource
+	}
+	if m.TopK != 0 {
+		*topK = m.TopK
+	}
+	if m.MinScore != 0 {
+		*minScore = m.MinScore
+	}
+	if m.LatencyMS != 0 {
+		*latencyMS = m.LatencyMS
+	}
+}

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -32,6 +32,13 @@ type preparerAggregate struct {
 	// preparer_decision still surfaces them under tools.tier1_new so
 	// instrumentation does not blank out on legacy plugins.
 	LegacyRelevantTools []string
+
+	// KnowledgeDedup, when non-nil, switches emitPreparerDecision into
+	// the Phase-3 "full" mode: the injected/skipped/score-override
+	// buckets reflect the actual dedup outcome rather than the
+	// instrumentation_only pass-through. Nil means dedup didn't run
+	// (config disabled, no store wired, or no knowledge candidates).
+	KnowledgeDedup *knowledgeDedupDecision
 }
 
 // append pulls the candidate slices off one preparer's response into
@@ -102,12 +109,21 @@ func (o *Orchestrator) emitPreparerRetrievals(ctx context.Context, query string,
 }
 
 // emitPreparerDecision publishes the composite preparer-pass outcome
-// once per user turn. Phase 2 always emits with mode =
-// instrumentation_only: every candidate is reported under Knowledge.Injected
-// and every tool under Tools.Tier1New so consumers (api-plugin
-// aggregations, Timly review UI) can render a meaningful payload while
-// the actual dedup/tier logic is still off. Phase 3+ flips the mode
-// and starts populating the SkippedKnown / evicted buckets.
+// once per user turn. The shape of the Knowledge block depends on
+// whether agg.KnowledgeDedup is set:
+//
+//   - nil: Phase 2 / instrumentation_only mode. Every candidate is
+//     reported under Knowledge.Injected with reason
+//     "instrumentation_only"; the skipped / score-override buckets
+//     stay empty.
+//   - non-nil: Phase 3 / full mode. Injected / Skipped /
+//     ScoreOverridesApplied reflect the dedup decision exactly; the
+//     reason on each injected entry is "new" / "score_override" /
+//     "top_k_force"; cap-exceeded entries land in Skipped.
+//
+// In both modes Tools.Tier1New surfaces every ToolCandidate plus any
+// legacy relevant_tools fallback list so the event stays meaningful
+// while Phase 4's tier logic is off.
 func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAggregate) {
 	if o.eventSink == nil {
 		return
@@ -119,10 +135,23 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 		return
 	}
 
-	knowledgeBlock := events.PreparerDecisionKnowledgeBlock{
-		CandidateIDs:  knowledgeCandidateIDs(agg.Knowledge),
-		Injected:      knowledgeCandidatesToInjected(agg.Knowledge),
-		InjectedBytes: knowledgeInjectedBytes(agg.Knowledge),
+	var knowledgeBlock events.PreparerDecisionKnowledgeBlock
+	mode := events.PreparerDecisionModeInstrumentationOnly
+	if agg.KnowledgeDedup != nil {
+		mode = events.PreparerDecisionModeFull
+		knowledgeBlock = events.PreparerDecisionKnowledgeBlock{
+			CandidateIDs:          knowledgeCandidateIDs(agg.Knowledge),
+			Injected:              dedupInjectedItems(agg.KnowledgeDedup),
+			SkippedKnown:          dedupSkippedItems(agg.KnowledgeDedup),
+			ScoreOverridesApplied: agg.KnowledgeDedup.ScoreOverrides,
+			InjectedBytes:         agg.KnowledgeDedup.InjectedBytes(),
+		}
+	} else {
+		knowledgeBlock = events.PreparerDecisionKnowledgeBlock{
+			CandidateIDs:  knowledgeCandidateIDs(agg.Knowledge),
+			Injected:      knowledgeCandidatesToInjected(agg.Knowledge),
+			InjectedBytes: knowledgeInjectedBytes(agg.Knowledge),
+		}
 	}
 
 	toolsBlock := events.PreparerDecisionToolsBlock{
@@ -130,10 +159,43 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 	}
 
 	emit.EmitPreparerDecision(ctx, o.eventSink, emit.PreparerDecisionArgs{
-		Mode:      events.PreparerDecisionModeInstrumentationOnly,
+		Mode:      mode,
 		Knowledge: knowledgeBlock,
 		Tools:     toolsBlock,
 	})
+}
+
+// dedupInjectedItems converts the dedup decision's parallel
+// Injected/InjectedReasons slices into the event payload shape.
+func dedupInjectedItems(d *knowledgeDedupDecision) []events.PreparerDecisionInjectedItem {
+	if len(d.Injected) == 0 {
+		return nil
+	}
+	out := make([]events.PreparerDecisionInjectedItem, len(d.Injected))
+	for i, c := range d.Injected {
+		out[i] = events.PreparerDecisionInjectedItem{
+			ArticleID:     c.ArticleID,
+			ContentSHA256: c.ContentSHA256,
+			Reason:        d.InjectedReasons[i],
+		}
+	}
+	return out
+}
+
+// dedupSkippedItems converts the dedup decision's parallel
+// Skipped/SkippedReasons slices into the event payload shape.
+func dedupSkippedItems(d *knowledgeDedupDecision) []events.PreparerDecisionSkippedItem {
+	if len(d.Skipped) == 0 {
+		return nil
+	}
+	out := make([]events.PreparerDecisionSkippedItem, len(d.Skipped))
+	for i, c := range d.Skipped {
+		out[i] = events.PreparerDecisionSkippedItem{
+			ArticleID: c.ArticleID,
+			Reason:    d.SkippedReasons[i],
+		}
+	}
+	return out
 }
 
 // ----- Pure conversion helpers (no orchestrator state) -----
@@ -206,9 +268,10 @@ func knowledgeCandidatesToInjected(cands []KnowledgeCandidate) []events.Preparer
 			ArticleID:     c.ArticleID,
 			ContentSHA256: c.ContentSHA256,
 			// Phase 2 has no dedup state, so every candidate is reported
-			// as if newly injected. Phase 3+ will switch to "new" /
-			// "score_override" / "top_k_force" per the dedup decision.
-			Reason: "instrumentation_only",
+			// as if newly injected. Phase 3+ switches to "new" /
+			// "score_override" / "top_k_force" per the dedup decision
+			// (see dedupInjectedItems).
+			Reason: events.PreparerDecisionReasonInstrumentationOnly,
 		}
 	}
 	return out

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -39,17 +39,45 @@ type preparerAggregate struct {
 	// instrumentation_only pass-through. Nil means dedup didn't run
 	// (config disabled, no store wired, or no knowledge candidates).
 	KnowledgeDedup *knowledgeDedupDecision
+
+	// LegacyKnowledgePlugins lists plugin names whose response carried
+	// a legacy [knowledge_context] injection (pr.Message contains the
+	// envelope) without the structured KnowledgeCandidates that Phase 3
+	// dedup needs. When non-empty AND dedup is enabled, the orchestrator
+	// switches the whole turn to mode=legacy_fallback — dedup is
+	// skipped and the plugin's pr.Message passes through verbatim.
+	LegacyKnowledgePlugins []string
 }
 
 // append pulls the candidate slices off one preparer's response into
 // the aggregate. Safe to call with a zero-valued response (no-op).
-func (a *preparerAggregate) append(pr preparerResponse) {
+// pluginName identifies the source plugin so legacy-injection
+// fallback can name the affected plugin in the deprecation warning.
+func (a *preparerAggregate) append(pluginName string, pr preparerResponse) {
 	a.Knowledge = append(a.Knowledge, pr.KnowledgeCandidates...)
 	a.Glossary = append(a.Glossary, pr.GlossaryCandidates...)
 	a.Tools = append(a.Tools, pr.ToolCandidates...)
 	if len(pr.ToolCandidates) == 0 && len(pr.RelevantTools) > 0 {
 		a.LegacyRelevantTools = append(a.LegacyRelevantTools, pr.RelevantTools...)
 	}
+	if responseUsesLegacyKnowledgeInjection(pr) {
+		a.LegacyKnowledgePlugins = append(a.LegacyKnowledgePlugins, pluginName)
+	}
+}
+
+// responseUsesLegacyKnowledgeInjection returns true when the plugin
+// returned a [knowledge_context] block in pr.Message without the
+// structured KnowledgeCandidates slice that Phase 3 dedup needs.
+// Detection is content-based (parser recognizes both legacy bare
+// and tagged forms) so a plugin that started emitting tagged blocks
+// without populating candidates still triggers the fallback path —
+// dedup can only run when the per-candidate identity is in the
+// structured field.
+func responseUsesLegacyKnowledgeInjection(pr preparerResponse) bool {
+	if len(pr.KnowledgeCandidates) > 0 {
+		return false
+	}
+	return len(parseKnowledgeContextBlocks(pr.Message)) > 0
 }
 
 // emitPreparerRetrievals fires the per-corpus *_retrieval events for
@@ -128,16 +156,37 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 	if o.eventSink == nil {
 		return
 	}
-	if len(agg.Knowledge) == 0 && len(agg.Glossary) == 0 && len(agg.Tools) == 0 && len(agg.LegacyRelevantTools) == 0 {
-		// Nothing retrieved from any corpus → skip the event. Avoids
-		// noisy preparer_decision rows on turns where no preparer ran
-		// (toolCallSeeded path, sessions with empty o.preparers, …).
+	hasSignal := len(agg.Knowledge) > 0 ||
+		len(agg.Glossary) > 0 ||
+		len(agg.Tools) > 0 ||
+		len(agg.LegacyRelevantTools) > 0 ||
+		len(agg.LegacyKnowledgePlugins) > 0
+	if !hasSignal {
+		// Nothing retrieved from any corpus and no legacy-fallback
+		// trigger → skip the event. Avoids noisy preparer_decision
+		// rows on turns where no preparer ran (toolCallSeeded path,
+		// sessions with empty o.preparers, …). Legacy-fallback is
+		// counted as signal because the audit trail benefits from
+		// recording the fallback even if no candidates surfaced.
 		return
 	}
 
 	var knowledgeBlock events.PreparerDecisionKnowledgeBlock
-	mode := events.PreparerDecisionModeInstrumentationOnly
-	if agg.KnowledgeDedup != nil {
+	var mode string
+	switch {
+	case o.knowledgeDedup.Enabled && len(agg.LegacyKnowledgePlugins) > 0:
+		// A plugin still uses the legacy [knowledge_context]-in-Message
+		// shape, so dedup can't decide on a per-candidate basis. Report
+		// fallback mode; Injected/Skipped stay empty since dedup didn't
+		// run. CandidateIDs are surfaced for any non-legacy plugin that
+		// did return structured candidates — the consumer can still
+		// see what was retrieved even though the decision was forced
+		// to pass-through.
+		mode = events.PreparerDecisionModeLegacyFallback
+		knowledgeBlock = events.PreparerDecisionKnowledgeBlock{
+			CandidateIDs: knowledgeCandidateIDs(agg.Knowledge),
+		}
+	case agg.KnowledgeDedup != nil:
 		mode = events.PreparerDecisionModeFull
 		knowledgeBlock = events.PreparerDecisionKnowledgeBlock{
 			CandidateIDs:          knowledgeCandidateIDs(agg.Knowledge),
@@ -146,7 +195,8 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 			ScoreOverridesApplied: agg.KnowledgeDedup.ScoreOverrides,
 			InjectedBytes:         agg.KnowledgeDedup.InjectedBytes(),
 		}
-	} else {
+	default:
+		mode = events.PreparerDecisionModeInstrumentationOnly
 		knowledgeBlock = events.PreparerDecisionKnowledgeBlock{
 			CandidateIDs:  knowledgeCandidateIDs(agg.Knowledge),
 			Injected:      knowledgeCandidatesToInjected(agg.Knowledge),

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -161,9 +161,13 @@ func (o *Orchestrator) emitPreparerRetrievals(ctx context.Context, query string,
 // In both modes Tools.Tier1New surfaces every ToolCandidate plus any
 // legacy relevant_tools fallback list so the event stays meaningful
 // while Phase 4's tier logic is off.
-func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAggregate) {
+//
+// Returns the emitted event id so the caller can chain it as
+// TurnStartPayload.PreparerDecisionID — empty when no event was
+// emitted (no signal in the aggregate).
+func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAggregate) string {
 	if o.eventSink == nil {
-		return
+		return ""
 	}
 	hasSignal := len(agg.Knowledge) > 0 ||
 		len(agg.Glossary) > 0 ||
@@ -177,7 +181,7 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 		// sessions with empty o.preparers, …). Legacy-fallback is
 		// counted as signal because the audit trail benefits from
 		// recording the fallback even if no candidates surfaced.
-		return
+		return ""
 	}
 
 	var knowledgeBlock events.PreparerDecisionKnowledgeBlock
@@ -215,11 +219,54 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 
 	toolsBlock := buildToolsBlock(agg)
 
-	emit.EmitPreparerDecision(ctx, o.eventSink, emit.PreparerDecisionArgs{
+	return emit.EmitPreparerDecision(ctx, o.eventSink, emit.PreparerDecisionArgs{
 		Mode:      mode,
 		Knowledge: knowledgeBlock,
 		Tools:     toolsBlock,
 	})
+}
+
+// turnStartRefsFromAggregate extracts the Pillar-C fields the
+// turn_start event references back from the preparer aggregate:
+// the injected-knowledge ref list and the tier1/tier3 counts. Each
+// is mode-aware:
+//
+//   - InjectedKnowledge in full mode = the dedup decision's Injected
+//     slice (the deduped set the LLM actually sees this turn).
+//   - InjectedKnowledge in instrumentation_only mode = every
+//     retrieved candidate (Phase 2 passes everything through).
+//   - InjectedKnowledge in legacy_fallback mode = empty — the plugin
+//     handed the orchestrator a pre-rendered block with no
+//     structured handle, so no ref list can be assembled without
+//     re-parsing.
+//
+// Tier counts mirror agg.ToolTier when Phase 4 ran (counts of the
+// Tier1 / Tier3 slices respectively); zero when it didn't. Zero
+// values are omitted from the emitted payload by `omitempty` so
+// pre-Phase-4 turns stay byte-identical to the original shape.
+func turnStartRefsFromAggregate(agg preparerAggregate) (refs []events.KnowledgeRef, tier1Count, tier3Count int) {
+	switch {
+	case agg.KnowledgeDedup != nil:
+		for _, c := range agg.KnowledgeDedup.Injected {
+			refs = append(refs, events.KnowledgeRef{
+				ArticleID:     c.ArticleID,
+				ContentSHA256: c.ContentSHA256,
+			})
+		}
+	case len(agg.LegacyKnowledgePlugins) == 0:
+		// instrumentation_only — emit every candidate as injected.
+		for _, c := range agg.Knowledge {
+			refs = append(refs, events.KnowledgeRef{
+				ArticleID:     c.ArticleID,
+				ContentSHA256: c.ContentSHA256,
+			})
+		}
+	}
+	if agg.ToolTier != nil {
+		tier1Count = len(agg.ToolTier.Tier1)
+		tier3Count = len(agg.ToolTier.Tier3)
+	}
+	return refs, tier1Count, tier3Count
 }
 
 // buildToolsBlock returns the preparer_decision.tools payload for the

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -40,6 +40,15 @@ type preparerAggregate struct {
 	// (config disabled, no store wired, or no knowledge candidates).
 	KnowledgeDedup *knowledgeDedupDecision
 
+	// ToolTier, when non-nil, drives the Phase-4 tier-aware Tools
+	// block of preparer_decision. Nil means tier logic didn't run
+	// (config disabled or no store wired) — emitPreparerDecision then
+	// falls back to the Phase-2 pass-through (every candidate name in
+	// tools.tier1_new). The decision also feeds the system-prompt
+	// renderer (D3) and persists KnownTools via the dedup persist when
+	// both ran in the same turn.
+	ToolTier *toolTierDecision
+
 	// LegacyKnowledgePlugins lists plugin names whose response carried
 	// a legacy [knowledge_context] injection (pr.Message contains the
 	// envelope) without the structured KnowledgeCandidates that Phase 3
@@ -204,15 +213,39 @@ func (o *Orchestrator) emitPreparerDecision(ctx context.Context, agg preparerAgg
 		}
 	}
 
-	toolsBlock := events.PreparerDecisionToolsBlock{
-		Tier1New: toolCandidateNames(agg.Tools, agg.LegacyRelevantTools),
-	}
+	toolsBlock := buildToolsBlock(agg)
 
 	emit.EmitPreparerDecision(ctx, o.eventSink, emit.PreparerDecisionArgs{
 		Mode:      mode,
 		Knowledge: knowledgeBlock,
 		Tools:     toolsBlock,
 	})
+}
+
+// buildToolsBlock returns the preparer_decision.tools payload for the
+// current aggregate. With ToolTier set (Phase 4 enabled + ran), each
+// tier bucket is reported separately + the LRU/eviction telemetry
+// + the get_tool_details promotion list. Without ToolTier (Phase 2 /
+// Phase 3 fall-through), every candidate appears in tier1_new — the
+// instrumentation_only behaviour Phase 2 introduced.
+func buildToolsBlock(agg preparerAggregate) events.PreparerDecisionToolsBlock {
+	if agg.ToolTier == nil {
+		return events.PreparerDecisionToolsBlock{
+			Tier1New: toolCandidateNames(agg.Tools, agg.LegacyRelevantTools),
+		}
+	}
+	d := agg.ToolTier
+	return events.PreparerDecisionToolsBlock{
+		Tier0Count:                len(d.Tier0),
+		Tier1New:                  d.Tier1New,
+		Tier1Carried:              d.Tier1Carried,
+		Tier1EvictedToTier3:       d.Tier1EvictedToTier3,
+		Tier1DemotedSticky:        d.Tier1DemotedSticky,
+		Tier1SizeAfter:            d.Tier1SizeAfter,
+		Tier1Cap:                  d.Tier1Cap,
+		Tier3TotalVisible:         len(d.Tier3),
+		PromotedViaGetToolDetails: d.PromotedViaGetToolDetails,
+	}
 }
 
 // dedupInjectedItems converts the dedup decision's parallel

--- a/internal/orchestrator/preparer_events_test.go
+++ b/internal/orchestrator/preparer_events_test.go
@@ -1,0 +1,95 @@
+package orchestrator
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// TestTurnStartRefsFromAggregate covers the four input modes the
+// preparer aggregate can be in by the time turn_start needs its
+// Pillar-C back-references:
+//
+//   - full dedup mode (KnowledgeDedup set) → InjectedKnowledge from the decision's Injected slice
+//   - instrumentation_only mode (no dedup, no legacy plugin) → every retrieved candidate
+//   - legacy_fallback mode (any legacy plugin returned a pre-rendered block) → empty (no structured handle)
+//   - no preparer ran (aggregate empty) → nothing
+//
+// Plus the tier-count derivation: zero when ToolTier is nil (Phase 4
+// off), len(Tier1) / len(Tier3) when set.
+func TestTurnStartRefsFromAggregate(t *testing.T) {
+	candA := KnowledgeCandidate{ArticleID: "kb_a", ContentSHA256: "sha_a"}
+	candB := KnowledgeCandidate{ArticleID: "kb_b", ContentSHA256: "sha_b"}
+	candC := KnowledgeCandidate{ArticleID: "kb_c", ContentSHA256: "sha_c"}
+
+	tests := []struct {
+		name           string
+		agg            preparerAggregate
+		wantRefs       []events.KnowledgeRef
+		wantTier1Count int
+		wantTier3Count int
+	}{
+		{
+			name: "full dedup mode — refs from KnowledgeDedup.Injected",
+			agg: preparerAggregate{
+				Knowledge: []KnowledgeCandidate{candA, candB, candC}, // retrieved set
+				KnowledgeDedup: &knowledgeDedupDecision{
+					Injected: []KnowledgeCandidate{candA, candC}, // deduped: B was already known
+				},
+			},
+			wantRefs: []events.KnowledgeRef{
+				{ArticleID: "kb_a", ContentSHA256: "sha_a"},
+				{ArticleID: "kb_c", ContentSHA256: "sha_c"},
+			},
+		},
+		{
+			name: "instrumentation_only mode — refs from every retrieved candidate",
+			agg: preparerAggregate{
+				Knowledge: []KnowledgeCandidate{candA, candB},
+				// KnowledgeDedup nil, LegacyKnowledgePlugins empty → Phase 2
+			},
+			wantRefs: []events.KnowledgeRef{
+				{ArticleID: "kb_a", ContentSHA256: "sha_a"},
+				{ArticleID: "kb_b", ContentSHA256: "sha_b"},
+			},
+		},
+		{
+			name: "legacy_fallback mode — refs empty (no structured handle for the rendered block)",
+			agg: preparerAggregate{
+				Knowledge:              []KnowledgeCandidate{candA},
+				LegacyKnowledgePlugins: []string{"legacy_plugin"},
+			},
+			wantRefs: nil,
+		},
+		{
+			name: "no preparer ran — empty aggregate yields no refs",
+			agg:  preparerAggregate{},
+		},
+		{
+			name: "tier counts surface when ToolTier is set",
+			agg: preparerAggregate{
+				ToolTier: &toolTierDecision{
+					Tier1: []string{"t1", "t2", "t3"},
+					Tier3: []string{"t4", "t5"},
+				},
+			},
+			wantTier1Count: 3,
+			wantTier3Count: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, tier1, tier3 := turnStartRefsFromAggregate(tc.agg)
+			if !reflect.DeepEqual(refs, tc.wantRefs) {
+				t.Errorf("refs = %+v, want %+v", refs, tc.wantRefs)
+			}
+			if tier1 != tc.wantTier1Count {
+				t.Errorf("tier1Count = %d, want %d", tier1, tc.wantTier1Count)
+			}
+			if tier3 != tc.wantTier3Count {
+				t.Errorf("tier3Count = %d, want %d", tier3, tc.wantTier3Count)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/preparer_response_test.go
+++ b/internal/orchestrator/preparer_response_test.go
@@ -1,0 +1,156 @@
+package orchestrator
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// preparerResponse is the JSON contract between RAG plugins (weaviate,
+// future per-tenant corpora, …) and Core's preparer-loop. RFC #249 Phase
+// 2 extends it with optional `knowledge_candidates` / `glossary_candidates`
+// / `tool_candidates` slices plus a `retrieval_metrics` summary so Phase
+// 3+ can apply session-aware dedup + tier-promotion logic. The contract
+// must stay strictly backwards-compatible: legacy plugins emitting only
+// the old fields keep working as if nothing changed.
+
+func TestPreparerResponse_LegacyShapeStillUnmarshals(t *testing.T) {
+	// A pre-RFC plugin response: only message + send_to_llm +
+	// relevant_tools. The orchestrator must continue to parse this
+	// without errors and leave the new candidate slices as nil so
+	// existing call sites (which check `len(pr.KnowledgeCandidates) > 0`)
+	// fall through to the legacy path.
+	raw := `{
+		"send_to_llm": true,
+		"message": "user content with [knowledge_context]...[/knowledge_context]",
+		"relevant_tools": ["plugin.show", "plugin.list"]
+	}`
+
+	var pr preparerResponse
+	if err := json.Unmarshal([]byte(raw), &pr); err != nil {
+		t.Fatalf("legacy shape failed to unmarshal: %v", err)
+	}
+	if pr.SendToLLM == nil || !*pr.SendToLLM {
+		t.Errorf("SendToLLM = %v, want pointer-to-true", pr.SendToLLM)
+	}
+	if pr.Message == "" {
+		t.Error("Message empty after unmarshal")
+	}
+	if len(pr.RelevantTools) != 2 {
+		t.Errorf("RelevantTools len = %d, want 2", len(pr.RelevantTools))
+	}
+	if pr.KnowledgeCandidates != nil || pr.GlossaryCandidates != nil || pr.ToolCandidates != nil {
+		t.Errorf("legacy plugin must leave candidate slices nil; got %d/%d/%d",
+			len(pr.KnowledgeCandidates), len(pr.GlossaryCandidates), len(pr.ToolCandidates))
+	}
+	if pr.RetrievalMetrics != nil {
+		t.Errorf("legacy plugin must leave RetrievalMetrics nil; got %+v", pr.RetrievalMetrics)
+	}
+}
+
+func TestPreparerResponse_FullCandidatesShape(t *testing.T) {
+	// A new RFC-aware plugin response: structured candidates plus
+	// retrieval_metrics. The orchestrator must round-trip every field
+	// so Phase 3's dedup logic sees what the plugin sent.
+	raw := `{
+		"send_to_llm": true,
+		"message": "user content",
+		"knowledge_candidates": [
+			{
+				"article_id": "kb_recurring",
+				"title": "Recurring Tickets",
+				"content": "Body of the article...",
+				"content_sha256": "9f3a000000000000000000000000000000000000000000000000000000000000",
+				"score": 0.91,
+				"source": "knowledge_base",
+				"position_in_results": 0
+			}
+		],
+		"glossary_candidates": [
+			{
+				"term": "ticket",
+				"content": "A ticket is...",
+				"score": 0.71
+			}
+		],
+		"tool_candidates": [
+			{"tool_name": "timly.list-tickets", "score": 0.89, "position_in_results": 0},
+			{"tool_name": "timly.show-ticket", "score": 0.71, "position_in_results": 1}
+		],
+		"retrieval_metrics": {
+			"knowledge": {"search_text_source": "enriched", "top_k": 5, "min_score": 0.45, "latency_ms": 142},
+			"tools":     {"search_text_source": "user_input", "top_k": 8, "min_score": 0.50, "latency_ms": 98}
+		}
+	}`
+
+	var pr preparerResponse
+	if err := json.Unmarshal([]byte(raw), &pr); err != nil {
+		t.Fatalf("RFC shape failed to unmarshal: %v", err)
+	}
+
+	if len(pr.KnowledgeCandidates) != 1 {
+		t.Fatalf("KnowledgeCandidates len = %d, want 1", len(pr.KnowledgeCandidates))
+	}
+	k := pr.KnowledgeCandidates[0]
+	if k.ArticleID != "kb_recurring" || k.Title != "Recurring Tickets" || k.Score != 0.91 {
+		t.Errorf("KnowledgeCandidate scalar fields mismatch: %+v", k)
+	}
+	if k.ContentSHA256 == "" || k.Content == "" {
+		t.Error("KnowledgeCandidate.Content / ContentSHA256 must round-trip; got empty values")
+	}
+	if k.PositionInResults != 0 || k.Source != "knowledge_base" {
+		t.Errorf("KnowledgeCandidate Position/Source mismatch: pos=%d source=%q", k.PositionInResults, k.Source)
+	}
+
+	if len(pr.GlossaryCandidates) != 1 || pr.GlossaryCandidates[0].Term != "ticket" {
+		t.Errorf("GlossaryCandidates mismatch: %+v", pr.GlossaryCandidates)
+	}
+
+	if len(pr.ToolCandidates) != 2 {
+		t.Fatalf("ToolCandidates len = %d, want 2", len(pr.ToolCandidates))
+	}
+	if pr.ToolCandidates[1].PositionInResults != 1 {
+		t.Errorf("ToolCandidates[1].PositionInResults = %d, want 1", pr.ToolCandidates[1].PositionInResults)
+	}
+
+	if pr.RetrievalMetrics == nil {
+		t.Fatal("RetrievalMetrics nil; want populated")
+	}
+	if pr.RetrievalMetrics.Knowledge == nil || pr.RetrievalMetrics.Knowledge.LatencyMS != 142 {
+		t.Errorf("RetrievalMetrics.Knowledge mismatch: %+v", pr.RetrievalMetrics.Knowledge)
+	}
+	if pr.RetrievalMetrics.Glossary != nil {
+		t.Errorf("RetrievalMetrics.Glossary must stay nil when plugin omits it; got %+v", pr.RetrievalMetrics.Glossary)
+	}
+	if pr.RetrievalMetrics.Tools == nil || pr.RetrievalMetrics.Tools.TopK != 8 {
+		t.Errorf("RetrievalMetrics.Tools mismatch: %+v", pr.RetrievalMetrics.Tools)
+	}
+}
+
+func TestPreparerResponse_PartialCandidatesOmitted(t *testing.T) {
+	// A plugin can opt into the new contract per-corpus — e.g. ship
+	// knowledge candidates structured while leaving tools on the legacy
+	// `relevant_tools` path. The orchestrator must accept that and not
+	// confuse "absent" with "empty".
+	raw := `{
+		"message": "...",
+		"knowledge_candidates": [{"article_id": "kb_a", "content": "body", "score": 0.7}],
+		"relevant_tools": ["plugin.show"]
+	}`
+
+	var pr preparerResponse
+	if err := json.Unmarshal([]byte(raw), &pr); err != nil {
+		t.Fatalf("partial shape failed to unmarshal: %v", err)
+	}
+	if len(pr.KnowledgeCandidates) != 1 {
+		t.Errorf("KnowledgeCandidates len = %d, want 1", len(pr.KnowledgeCandidates))
+	}
+	if pr.GlossaryCandidates != nil {
+		t.Errorf("GlossaryCandidates must stay nil when omitted, got len=%d", len(pr.GlossaryCandidates))
+	}
+	if pr.ToolCandidates != nil {
+		t.Errorf("ToolCandidates must stay nil when omitted, got len=%d", len(pr.ToolCandidates))
+	}
+	if len(pr.RelevantTools) != 1 || pr.RelevantTools[0] != "plugin.show" {
+		t.Errorf("legacy relevant_tools must still parse alongside structured candidates; got %v", pr.RelevantTools)
+	}
+}

--- a/internal/orchestrator/registry.go
+++ b/internal/orchestrator/registry.go
@@ -166,6 +166,30 @@ func (r *ToolRegistry) ListCapabilities() []PluginCapability {
 	return caps
 }
 
+// IsActionReadOnly reports whether the named action on the named plugin
+// is declared read-only in its capability manifest. Unknown plugin or
+// unknown action returns false — the confirmation gate then runs as
+// usual (fail-safe: an action the registry doesn't recognise is treated
+// as a potential write).
+//
+// Used by the per-call confirmation path in orchestrator.Run to skip
+// the "I'm about to execute X" prompt + planner-narration LLM round-
+// trip for pure-query actions. The metadata originates from the plugin
+// manifest (e.g. an MCP tool with `annotations.readOnlyHint = true`)
+// and flows through pluginpb.Action.ReadOnly into Action.ReadOnly.
+func (r *ToolRegistry) IsActionReadOnly(plugin, action string) bool {
+	cap, ok := r.GetCapability(plugin)
+	if !ok {
+		return false
+	}
+	for _, a := range cap.Actions {
+		if a.Name == action {
+			return a.ReadOnly
+		}
+	}
+	return false
+}
+
 func (r *ToolRegistry) HasAction(plugin, action string) bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/orchestrator/registry.go
+++ b/internal/orchestrator/registry.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -177,14 +178,33 @@ func (r *ToolRegistry) ListCapabilities() []PluginCapability {
 // trip for pure-query actions. The metadata originates from the plugin
 // manifest (e.g. an MCP tool with `annotations.readOnlyHint = true`)
 // and flows through pluginpb.Action.ReadOnly into Action.ReadOnly.
+//
+// Action-name lookup mirrors the normalization that executeCall's
+// resolve loop applies later in the dispatch path: the LLM may emit
+// the bare action ("list-items") while the manifest carries the
+// mcp-plugin-style prefixed form ("timly__list-items"), and
+// hyphen/underscore variants are tolerated either way. Without this
+// matching the short-circuit would silently miss every mcp-plugin
+// tool — the data would flow through end-to-end but the gate would
+// still fire because the lookup couldn't see it.
 func (r *ToolRegistry) IsActionReadOnly(plugin, action string) bool {
 	cap, ok := r.GetCapability(plugin)
 	if !ok {
 		return false
 	}
-	for _, a := range cap.Actions {
-		if a.Name == action {
-			return a.ReadOnly
+	candidates := []string{
+		action,
+		plugin + "__" + action,
+		strings.ReplaceAll(action, "_", "-"),
+		plugin + "__" + strings.ReplaceAll(action, "_", "-"),
+		strings.ReplaceAll(action, "-", "_"),
+		plugin + "__" + strings.ReplaceAll(action, "-", "_"),
+	}
+	for _, name := range candidates {
+		for _, a := range cap.Actions {
+			if a.Name == name {
+				return a.ReadOnly
+			}
 		}
 	}
 	return false

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -181,7 +181,36 @@ func (o *Orchestrator) persistToolPromotion(ctx context.Context, sessionID, name
 	if err := o.injectionStateStore.UpdateInjectionState(ctx, sessionID, updated); err != nil {
 		slog.WarnContext(ctx, "get_tool_details: write state failed, promotion will not survive turn",
 			"component", "orchestrator", "session", sessionID, "tool", name, "error", err)
+		// Skip the recent-promotions cache when the persist failed: the
+		// next preparer pass will read stale InjectionState that doesn't
+		// have this tool at LRURank=turn, so flagging the tool as
+		// "promoted via get_tool_details" in the event payload would
+		// be misleading provenance.
+		return
 	}
+	// Record the promotion in the per-session recents cache so the
+	// NEXT preparer pass can surface it via promoted_via_get_tool_details
+	// in preparer_decision. The InjectionState write above puts the
+	// tool into Tier 1 via LRU rank regardless; this cache is purely
+	// the provenance signal.
+	o.recordRecentPromotion(sessionID, name)
+}
+
+// recordRecentPromotion appends a tool name to the per-session
+// recents cache. Duplicate names within the same window are
+// deduplicated — if the LLM calls get_tool_details for the same
+// tool twice in one turn (unlikely but possible), the next preparer
+// surfaces it once.
+func (o *Orchestrator) recordRecentPromotion(sessionID, name string) {
+	o.recentToolPromotionsMu.Lock()
+	defer o.recentToolPromotionsMu.Unlock()
+	existing := o.recentToolPromotions[sessionID]
+	for _, n := range existing {
+		if n == name {
+			return
+		}
+	}
+	o.recentToolPromotions[sessionID] = append(existing, name)
 }
 
 // registerGetToolDetailsTool wires the meta-tool into the registry

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -1,0 +1,207 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// RFC #249 Phase 4 D4 meta-tool: orchestrator-owned built-in that
+// returns the full description + parameter schema for a Tier-2 or
+// Tier-3 tool the LLM wants to call.
+//
+// Tier 2 / Tier 3 entries surface in the system prompt with only a
+// one-line summary (Tier 2) or bare name (Tier 3), which is enough
+// for the LLM to know they EXIST but not enough to invoke them
+// safely. Calling _meta.get_tool_details(name="plugin.action")
+// returns the full description + parameter schema AND persists a
+// Tier-1 promotion in the session's KnownTools so the tool stays
+// front-and-center for the rest of the session.
+//
+// Registration is gated by ToolTiersConfig.EnableGetToolDetails (the
+// runtime-normalization step in NewWithRules upgrades the master
+// switch when the meta-tool flag is set, so an operator who only
+// enables this flag still gets the tier rendering it depends on).
+// The action is marked AlwaysInclude=true so the tier decision pins
+// it to Tier 0 regardless of RAG scoring — losing it would break
+// the LLM's only on-demand schema-expansion path.
+//
+// Known limitation (deferred from RFC §"get_tool_details meta-tool"
+// step 4): the promotion is durable across turns via KnownTools, but
+// the SAME-turn next-iteration tools array isn't rebuilt — the LLM
+// sees the description in this round-trip's tool_call_result and
+// can act on it (especially in text-tool-call mode), but the native
+// tools array refresh after a promotion is a separate follow-up
+// (would require invalidating the agent loop's cachedTools and
+// re-running buildToolDefinitions per iteration after a meta-call).
+
+// metaPluginName is the orchestrator-owned plugin namespace for
+// system meta-tools. Underscore prefix mirrors the existing
+// _subprocess precedent — distinguishes a built-in from a user-
+// configured plugin and keeps the namespace clear of collisions.
+const metaPluginName = "_meta"
+
+// metaGetToolDetails is the action name within the meta plugin. The
+// fully-qualified name LLMs see is "_meta.get_tool_details".
+const metaGetToolDetails = "get_tool_details"
+
+// getToolDetailsExecutor implements PluginExecutor for the meta-tool.
+// The closure-over-Orchestrator pattern matches subprocessExecutor —
+// the handler needs registry + state-store access plus the per-call
+// session id (pulled from ctx via actor.SessionID).
+type getToolDetailsExecutor struct {
+	orch *Orchestrator
+}
+
+// Execute looks up the named action in the registry, returns its
+// full description + parameter schema as plain text, and persists a
+// Tier-1 promotion so future turns keep the tool visible.
+// Validation errors are returned as ToolResult.Error so the LLM sees
+// the message and can correct its call (rather than the orchestrator
+// silently swallowing it). The promotion-write side effect is
+// best-effort: a store failure logs a warning and doesn't fail the
+// call — the LLM already has the description in this round-trip.
+func (e *getToolDetailsExecutor) Execute(ctx context.Context, call ToolCall) ToolResult {
+	name := strings.TrimSpace(call.Args["name"])
+	if name == "" {
+		return ToolResult{CallID: call.ID, Error: `missing "name" parameter (expected "plugin.action")`}
+	}
+	plugin, action, err := parseToolName(name)
+	if err != nil {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("invalid tool name %q: %v", name, err)}
+	}
+	cap, ok := e.orch.registry.GetCapability(plugin)
+	if !ok {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("plugin %q not found", plugin)}
+	}
+	var found *Action
+	for i := range cap.Actions {
+		if cap.Actions[i].Name == action {
+			found = &cap.Actions[i]
+			break
+		}
+	}
+	if found == nil {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("action %q not found in plugin %q", action, plugin)}
+	}
+
+	if sessionID := actor.SessionID(ctx); sessionID != "" && e.orch.injectionStateStore != nil {
+		e.orch.persistToolPromotion(ctx, sessionID, name)
+	}
+
+	return ToolResult{
+		CallID:  call.ID,
+		Content: renderToolDescription(plugin, *found),
+	}
+}
+
+// renderToolDescription formats one action as a plain-text block —
+// "Tool: …", "Description: …", "Parameters: …". The LLM consumes
+// the text directly via its tool_call_result, so the format
+// prioritizes legibility over machine-parseability (it's not
+// expected to be re-parsed).
+func renderToolDescription(plugin string, a Action) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Tool: %s.%s\n\n", plugin, a.Name)
+	fmt.Fprintf(&sb, "Description:\n%s\n", a.Description)
+	if len(a.Parameters) == 0 {
+		sb.WriteString("\nParameters: (none)\n")
+		return sb.String()
+	}
+	sb.WriteString("\nParameters:\n")
+	for _, p := range a.Parameters {
+		req := ""
+		if p.Required {
+			req = " (required)"
+		}
+		fmt.Fprintf(&sb, "- %s%s: %s\n", p.Name, req, p.Description)
+	}
+	return sb.String()
+}
+
+// persistToolPromotion upserts a Tier-1 entry for the named tool in
+// the session's KnownTools. Existing entries get their tier bumped
+// to "tier1", LRURank refreshed to the current turn (so they win
+// the next LRU sort), and Demoted=false — an explicit
+// schema-request via get_tool_details is a strong relevance signal,
+// matching the spirit of RFC §"Tool error handling" self-healing
+// even though the tool itself hasn't been invoked yet. Missing
+// entries are appended.
+//
+// Defensive copy of KnownTools mirrors the Phase-3
+// applyKnowledgeDedup pattern: stores may return slices that share
+// the backing array with their internal cache (the in-process
+// fakeInjectionStateStore does, the DB-backed one in production
+// doesn't), and mutating the read snapshot in place before a write
+// could leave partially-applied state visible to a concurrent
+// reader if the write later fails. Copying once keeps the path
+// uniform across both store implementations.
+//
+// Read failures log a warning and return — the next turn's lazy
+// reconciliation cannot recover a lost promotion, so we surface the
+// failure for operator follow-up but don't fail the LLM's call.
+// Write failures log similarly; the LLM still has the description
+// from this round-trip.
+func (o *Orchestrator) persistToolPromotion(ctx context.Context, sessionID, name string) {
+	existing, err := o.injectionStateStore.GetInjectionState(ctx, sessionID)
+	if err != nil {
+		slog.WarnContext(ctx, "get_tool_details: read state failed, promotion skipped",
+			"component", "orchestrator", "session", sessionID, "tool", name, "error", err)
+		return
+	}
+	updated := state.InjectionState{
+		KnownKnowledge: existing.KnownKnowledge,
+		KnownTools:     append([]state.KnownToolEntry(nil), existing.KnownTools...),
+	}
+	turn := o.turnNumberForDedup(sessionID)
+	found := false
+	for i := range updated.KnownTools {
+		if updated.KnownTools[i].ToolName != name {
+			continue
+		}
+		updated.KnownTools[i].Tier = "tier1"
+		if turn > updated.KnownTools[i].LRURank {
+			updated.KnownTools[i].LRURank = turn
+		}
+		updated.KnownTools[i].Demoted = false
+		found = true
+		break
+	}
+	if !found {
+		updated.KnownTools = append(updated.KnownTools, state.KnownToolEntry{
+			ToolName: name,
+			Tier:     "tier1",
+			LRURank:  turn,
+		})
+	}
+	if err := o.injectionStateStore.UpdateInjectionState(ctx, sessionID, updated); err != nil {
+		slog.WarnContext(ctx, "get_tool_details: write state failed, promotion will not survive turn",
+			"component", "orchestrator", "session", sessionID, "tool", name, "error", err)
+	}
+}
+
+// registerGetToolDetailsTool wires the meta-tool into the registry
+// so the LLM sees _meta.get_tool_details in its tools array and the
+// Tier 2/3 hint text becomes actionable. Called from NewWithRules
+// when ToolTiersConfig.EnableGetToolDetails is true.
+func (o *Orchestrator) registerGetToolDetailsTool() {
+	cap := PluginCapability{
+		Name:        metaPluginName,
+		Description: "Orchestrator-owned meta-tools.",
+		Actions: []Action{{
+			Name:          metaGetToolDetails,
+			Description:   "Returns the full description and parameter schema for any tool listed in the system prompt's summary or other-tools sections. Calling it also promotes the tool back to the LLM's tools array for the rest of the session.",
+			AlwaysInclude: true,
+			Parameters: []Parameter{{
+				Name:        "name",
+				Description: `Fully-qualified tool name, e.g. "plugin.action".`,
+				Required:    true,
+			}},
+		}},
+	}
+	_ = o.registry.Register(cap, &getToolDetailsExecutor{orch: o})
+}

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -196,6 +196,14 @@ func (o *Orchestrator) registerGetToolDetailsTool() {
 			Name:          metaGetToolDetails,
 			Description:   "Returns the full description and parameter schema for any tool listed in the system prompt's summary or other-tools sections. Calling it also promotes the tool back to the LLM's tools array for the rest of the session.",
 			AlwaysInclude: true,
+			// Pure lookup: returns a description string, mutates no
+			// user-visible state. The state change (Tier-3 → Tier-1
+			// promotion of the inspected tool) is orchestrator-internal
+			// bookkeeping for the next turn, not an action the user
+			// would want to confirm. Skipping the confirmation gate
+			// here removes a noise prompt + planner-narration LLM call
+			// every time the LLM asks for tool details.
+			ReadOnly: true,
 			Parameters: []Parameter{{
 				Name:        "name",
 				Description: `Fully-qualified tool name, e.g. "plugin.action".`,

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -177,7 +177,7 @@ func (o *Orchestrator) persistToolPromotion(ctx context.Context, sessionID, name
 		if updated.KnownTools[i].ToolName != name {
 			continue
 		}
-		updated.KnownTools[i].Tier = "tier1"
+		updated.KnownTools[i].Tier = state.KnownToolTier1
 		if turn > updated.KnownTools[i].LRURank {
 			updated.KnownTools[i].LRURank = turn
 		}
@@ -188,7 +188,7 @@ func (o *Orchestrator) persistToolPromotion(ctx context.Context, sessionID, name
 	if !found {
 		updated.KnownTools = append(updated.KnownTools, state.KnownToolEntry{
 			ToolName: name,
-			Tier:     "tier1",
+			Tier:     state.KnownToolTier1,
 			LRURank:  turn,
 		})
 	}

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -78,6 +78,20 @@ func (e *getToolDetailsExecutor) Execute(ctx context.Context, call ToolCall) Too
 	if !ok {
 		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("plugin %q not found", plugin)}
 	}
+	// Profile-gate the INSPECTED plugin (not the _meta route-through, which
+	// pluginAllowed always passes). Without this, an LLM in a profile-
+	// restricted multi-tenant deployment could enumerate descriptions and
+	// parameter schemas of plugins the operator hid via WhoAmI.Plugins /
+	// AllowedGroups. Invocation is already blocked downstream by
+	// executeCall's own gate, so this is information-disclosure-only — but
+	// the disclosed surface IS what the operator's profile gate exists to
+	// hide. Mirror the "plugin not found" branch shape so denied and non-
+	// existent plugins are indistinguishable to the LLM. Denial happens
+	// before persistToolPromotion below, so the side-effect write does
+	// not fire on blocked requests.
+	if !e.orch.pluginAllowed(cap, e.orch.resolveAllowedPlugins(ctx)) {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("plugin %q not found", plugin)}
+	}
 	var found *Action
 	for i := range cap.Actions {
 		if cap.Actions[i].Name == action {

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -185,6 +185,55 @@ func TestGetToolDetails_PromotionPersistsTier1Entry(t *testing.T) {
 	if found.LRURank < 1 {
 		t.Errorf("LRURank = %d, want >= 1", found.LRURank)
 	}
+	// The promoted name must also land in the recent-promotions cache
+	// so the next preparer pass surfaces it via
+	// promoted_via_get_tool_details. promotedToolsThisTurn drains the
+	// cache on read, so a single call returns the slice and a second
+	// returns empty.
+	got := orch.promotedToolsThisTurn(ctx, "s1")
+	if len(got) != 1 || got[0] != "tools-plugin.t1" {
+		t.Errorf("promotedToolsThisTurn = %v, want [tools-plugin.t1] (the just-promoted tool)", got)
+	}
+	if again := orch.promotedToolsThisTurn(ctx, "s1"); len(again) != 0 {
+		t.Errorf("promotedToolsThisTurn drain failed: second call returned %v, want empty", again)
+	}
+}
+
+func TestGetToolDetails_PromotionRecentsCache_DedupsRepeatedPromotion(t *testing.T) {
+	// Two get_tool_details calls for the SAME tool in one turn must
+	// land in the recent-promotions cache only once. Drain returns
+	// a single entry, not duplicates.
+	store := &fakeInjectionStateStore{}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+
+	for i := 0; i < 2; i++ {
+		res := exec.Execute(ctx, ToolCall{
+			ID:   "c-repeat",
+			Args: map[string]string{"name": "tools-plugin.t1"},
+		})
+		if res.Error != "" {
+			t.Fatalf("execute %d failed: %q", i, res.Error)
+		}
+	}
+	got := orch.promotedToolsThisTurn(ctx, "s1")
+	if len(got) != 1 || got[0] != "tools-plugin.t1" {
+		t.Errorf("promotedToolsThisTurn = %v, want exactly [tools-plugin.t1] (deduped)", got)
+	}
+}
+
+func TestPromotedToolsThisTurn_EmptyBeforeAnyPromotion(t *testing.T) {
+	// The pre-promotion path: promotedToolsThisTurn on a fresh session
+	// returns nil, not a partial state. Pins the contract that an
+	// empty / missing entry is a clean "no promotions yet" signal.
+	orch := newOrchForMetaTests(t, &fakeInjectionStateStore{}, true)
+	if got := orch.promotedToolsThisTurn(context.Background(), "fresh"); len(got) != 0 {
+		t.Errorf("promotedToolsThisTurn on fresh session = %v, want empty", got)
+	}
+	if got := orch.promotedToolsThisTurn(context.Background(), ""); len(got) != 0 {
+		t.Errorf("promotedToolsThisTurn with empty sessionID = %v, want empty", got)
+	}
 }
 
 func TestGetToolDetails_PromotionClearsDemotedFlag(t *testing.T) {

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/profile"
 	"github.com/opentalon/opentalon/internal/state"
 )
 
@@ -147,6 +148,39 @@ func TestGetToolDetails_UnknownActionReturnsError(t *testing.T) {
 	})
 	if !strings.Contains(res.Error, "action") {
 		t.Errorf("error must mention unknown action, got: %q", res.Error)
+	}
+}
+
+func TestGetToolDetails_ProfileRestrictedPluginReturnsNotFound(t *testing.T) {
+	// The inspected plugin runs through the profile gate; a plugin hidden
+	// by WhoAmI.Plugins must return the same "plugin not found" shape as
+	// a non-existent plugin so the LLM can't distinguish restricted-but-
+	// existing from missing. Promotion side-effect must also not fire on
+	// denial.
+	store := &fakeInjectionStateStore{}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	// Strict mode: profile allowlist excludes the registered "tools-plugin".
+	p := &profile.Profile{EntityID: "u1", Plugins: []string{"something-else"}}
+	ctx := actor.WithSessionID(profile.WithProfile(context.Background(), p), "s1")
+
+	res := exec.Execute(ctx, ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.t1"},
+	})
+
+	if res.Error == "" {
+		t.Fatalf("expected error, got content: %q", res.Content)
+	}
+	if !strings.Contains(res.Error, "plugin") || !strings.Contains(res.Error, "not found") {
+		t.Errorf("error must mimic 'plugin … not found' shape, got: %q", res.Error)
+	}
+	if strings.Contains(res.Error, "t1") {
+		t.Errorf("error must not leak the action name (would distinguish gated-but-existing from missing), got: %q", res.Error)
+	}
+	if store.updateCalls != 0 {
+		t.Errorf("denied call must not write to InjectionState, got %d UpdateInjectionState calls", store.updateCalls)
 	}
 }
 

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -1,0 +1,301 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+func newOrchForMetaTests(t *testing.T, store *fakeInjectionStateStore, enable bool) *Orchestrator {
+	t.Helper()
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "tools-plugin", Description: "Five business tools",
+		Actions: []Action{
+			{Name: "t1", Description: "Tool one detailed description.", Parameters: []Parameter{
+				{Name: "arg1", Description: "first arg", Required: true},
+				{Name: "arg2", Description: "second arg", Required: false},
+			}},
+			{Name: "t2", Description: "Tool two."},
+		},
+	}, &fixedResultExecutor{content: "result"})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	opts := OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{Enabled: true, EnableGetToolDetails: enable},
+	}
+	if store != nil {
+		opts.InjectionStateStore = store
+	}
+	return NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, opts)
+}
+
+func TestRegisterGetToolDetails_RegistersMetaPluginWithAlwaysInclude(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	cap, ok := orch.registry.GetCapability(metaPluginName)
+	if !ok {
+		t.Fatalf("meta plugin %q must be registered when EnableGetToolDetails=true", metaPluginName)
+	}
+	if len(cap.Actions) != 1 || cap.Actions[0].Name != metaGetToolDetails {
+		t.Fatalf("meta plugin must expose exactly %q action, got %+v", metaGetToolDetails, cap.Actions)
+	}
+	if !cap.Actions[0].AlwaysInclude {
+		t.Errorf("get_tool_details action must be AlwaysInclude=true so the tier decision pins it to Tier 0")
+	}
+	if len(cap.Actions[0].Parameters) != 1 || !cap.Actions[0].Parameters[0].Required {
+		t.Errorf("get_tool_details must require a single 'name' parameter, got %+v", cap.Actions[0].Parameters)
+	}
+}
+
+func TestRegisterGetToolDetails_NotRegisteredWhenFlagOff(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, false)
+	if _, ok := orch.registry.GetCapability(metaPluginName); ok {
+		t.Errorf("meta plugin must NOT be registered when EnableGetToolDetails=false")
+	}
+}
+
+func TestGetToolDetails_ReturnsFormattedDescription(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, ok := orch.registry.GetExecutor(metaPluginName)
+	if !ok {
+		t.Fatal("meta plugin executor missing")
+	}
+	res := exec.Execute(context.Background(), ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.t1"},
+	})
+	if res.Error != "" {
+		t.Fatalf("expected no error, got %q", res.Error)
+	}
+	if !strings.Contains(res.Content, "Tool: tools-plugin.t1") {
+		t.Errorf("output missing Tool: header, got: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "Tool one detailed description.") {
+		t.Errorf("output missing description, got: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "- arg1 (required): first arg") {
+		t.Errorf("output missing required-marker for arg1, got: %q", res.Content)
+	}
+	if !strings.Contains(res.Content, "- arg2: second arg") {
+		t.Errorf("output missing arg2, got: %q", res.Content)
+	}
+	if strings.Contains(res.Content, "arg2 (required)") {
+		t.Errorf("non-required arg must NOT carry (required) suffix, got: %q", res.Content)
+	}
+}
+
+func TestGetToolDetails_ParameterlessActionRendersNoneSentinel(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	res := exec.Execute(context.Background(), ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.t2"},
+	})
+	if !strings.Contains(res.Content, "Parameters: (none)") {
+		t.Errorf("zero-param action must render 'Parameters: (none)', got: %q", res.Content)
+	}
+}
+
+func TestGetToolDetails_MissingNameArgReturnsError(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	res := exec.Execute(context.Background(), ToolCall{ID: "c1", Args: map[string]string{}})
+	if res.Error == "" || !strings.Contains(res.Error, "name") {
+		t.Errorf(`error must mention missing "name", got: %q`, res.Error)
+	}
+}
+
+func TestGetToolDetails_MalformedFQNReturnsError(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	res := exec.Execute(context.Background(), ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "no-dot-here"},
+	})
+	if res.Error == "" {
+		t.Errorf("malformed FQN must produce an error result")
+	}
+}
+
+func TestGetToolDetails_UnknownPluginReturnsError(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	res := exec.Execute(context.Background(), ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "missing.action"},
+	})
+	if !strings.Contains(res.Error, "plugin") {
+		t.Errorf("error must mention unknown plugin, got: %q", res.Error)
+	}
+}
+
+func TestGetToolDetails_UnknownActionReturnsError(t *testing.T) {
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	res := exec.Execute(context.Background(), ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.unknown"},
+	})
+	if !strings.Contains(res.Error, "action") {
+		t.Errorf("error must mention unknown action, got: %q", res.Error)
+	}
+}
+
+func TestGetToolDetails_PromotionPersistsTier1Entry(t *testing.T) {
+	// Calling get_tool_details for a tool not yet in KnownTools must
+	// add a tier="tier1" entry with LRURank=currentTurn so the next
+	// turn's tier decision keeps it visible. The previously-empty
+	// state path covers the "fresh promotion" branch.
+	store := &fakeInjectionStateStore{}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	res := exec.Execute(ctx, ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.t1"},
+	})
+	if res.Error != "" {
+		t.Fatalf("execute failed: %q", res.Error)
+	}
+	if store.updateCalls != 1 {
+		t.Fatalf("UpdateInjectionState calls = %d, want 1", store.updateCalls)
+	}
+	var found *state.KnownToolEntry
+	for i := range store.lastWritten.KnownTools {
+		if store.lastWritten.KnownTools[i].ToolName == "tools-plugin.t1" {
+			found = &store.lastWritten.KnownTools[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("promoted tool missing from KnownTools, got %+v", store.lastWritten.KnownTools)
+	}
+	if found.Tier != "tier1" {
+		t.Errorf("Tier = %q, want %q", found.Tier, "tier1")
+	}
+	if found.LRURank < 1 {
+		t.Errorf("LRURank = %d, want >= 1", found.LRURank)
+	}
+}
+
+func TestGetToolDetails_PromotionClearsDemotedFlag(t *testing.T) {
+	// An existing Demoted=true entry must self-heal to Demoted=false
+	// on explicit promotion — RFC: "any successful invocation clears
+	// the demoted flag", and an explicit user-driven promotion is an
+	// even stronger signal.
+	store := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownTools: []state.KnownToolEntry{
+				{ToolName: "tools-plugin.t1", Tier: "tier3", LRURank: 1, Demoted: true},
+			}},
+		},
+	}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = exec.Execute(ctx, ToolCall{ID: "c1", Args: map[string]string{"name": "tools-plugin.t1"}})
+
+	for _, kt := range store.lastWritten.KnownTools {
+		if kt.ToolName == "tools-plugin.t1" {
+			if kt.Demoted {
+				t.Errorf("Demoted must clear on promotion, got Demoted=true")
+			}
+			if kt.Tier != "tier1" {
+				t.Errorf("Tier must upgrade to tier1, got %q", kt.Tier)
+			}
+		}
+	}
+}
+
+func TestGetToolDetails_StoreReadFailureSkipsPromotionButReturnsDescription(t *testing.T) {
+	// Read failure must NOT abort the call — the LLM still gets the
+	// description in the tool result. Only the promotion side effect
+	// is skipped (logged as warn).
+	store := &fakeInjectionStateStore{failGetErr: errors.New("simulated db read failure")}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	res := exec.Execute(ctx, ToolCall{ID: "c1", Args: map[string]string{"name": "tools-plugin.t1"}})
+
+	if res.Error != "" {
+		t.Errorf("read failure must NOT bubble up to LLM, got error: %q", res.Error)
+	}
+	if !strings.Contains(res.Content, "Tool: tools-plugin.t1") {
+		t.Errorf("description must still be returned, got: %q", res.Content)
+	}
+	if store.updateCalls != 0 {
+		t.Errorf("read failure must skip the write, got %d update calls", store.updateCalls)
+	}
+}
+
+func TestGetToolDetails_PromotionWriteFailureLogsAndContinues(t *testing.T) {
+	// Write failure must NOT bubble up to the LLM — the description
+	// is already produced. The handler logs a warning and continues
+	// so the round-trip stays useful even when the store is
+	// transiently misbehaving. The next turn's tier decision will
+	// see the un-promoted state but the LLM still received the
+	// schema in the current round-trip.
+	store := &fakeInjectionStateStore{failUpdateErr: errors.New("simulated db write failure")}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	res := exec.Execute(ctx, ToolCall{ID: "c1", Args: map[string]string{"name": "tools-plugin.t1"}})
+	if res.Error != "" {
+		t.Errorf("write failure must NOT surface to LLM, got error: %q", res.Error)
+	}
+	if !strings.Contains(res.Content, "Tool: tools-plugin.t1") {
+		t.Errorf("description must still render, got: %q", res.Content)
+	}
+	if store.updateCalls != 1 {
+		t.Errorf("expected one update attempt, got %d", store.updateCalls)
+	}
+}
+
+func TestGetToolDetails_PromotionDoesNotRegressLRURank(t *testing.T) {
+	// Existing tier="tier1" entry at LRURank >= currentTurn must not
+	// have its rank decreased on a re-promotion (guards the
+	// "rank only bumps upward" branch in persistToolPromotion).
+	store := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownTools: []state.KnownToolEntry{
+				{ToolName: "tools-plugin.t1", Tier: "tier1", LRURank: 99},
+			}},
+		},
+	}
+	orch := newOrchForMetaTests(t, store, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = exec.Execute(ctx, ToolCall{ID: "c1", Args: map[string]string{"name": "tools-plugin.t1"}})
+
+	for _, kt := range store.lastWritten.KnownTools {
+		if kt.ToolName == "tools-plugin.t1" && kt.LRURank < 99 {
+			t.Errorf("LRURank regressed from 99 to %d on re-promotion", kt.LRURank)
+		}
+	}
+}
+
+func TestGetToolDetails_NoStoreWiredStillReturnsDescription(t *testing.T) {
+	// Some tests / minimal deploys wire the meta-tool without an
+	// InjectionStateStore. The handler must gracefully degrade —
+	// description still served, promotion silently skipped.
+	orch := newOrchForMetaTests(t, nil, true)
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	res := exec.Execute(ctx, ToolCall{ID: "c1", Args: map[string]string{"name": "tools-plugin.t1"}})
+	if res.Error != "" {
+		t.Errorf("no-store path must not error, got: %q", res.Error)
+	}
+	if !strings.Contains(res.Content, "Tool: tools-plugin.t1") {
+		t.Errorf("description must still render, got: %q", res.Content)
+	}
+}

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -47,6 +47,9 @@ func TestRegisterGetToolDetails_RegistersMetaPluginWithAlwaysInclude(t *testing.
 	if !cap.Actions[0].AlwaysInclude {
 		t.Errorf("get_tool_details action must be AlwaysInclude=true so the tier decision pins it to Tier 0")
 	}
+	if !cap.Actions[0].ReadOnly {
+		t.Errorf("get_tool_details action must be ReadOnly=true — it's a pure schema-lookup tool, no user-confirmation gate makes sense")
+	}
 	if len(cap.Actions[0].Parameters) != 1 || !cap.Actions[0].Parameters[0].Required {
 		t.Errorf("get_tool_details must require a single 'name' parameter, got %+v", cap.Actions[0].Parameters)
 	}

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -233,6 +234,111 @@ func TestPromotedToolsThisTurn_EmptyBeforeAnyPromotion(t *testing.T) {
 	}
 	if got := orch.promotedToolsThisTurn(context.Background(), ""); len(got) != 0 {
 		t.Errorf("promotedToolsThisTurn with empty sessionID = %v, want empty", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// withPromotedTool + same-turn cachedTools refresh
+// ---------------------------------------------------------------------------
+
+func TestWithPromotedTool_AppendsWhenRelevantToolsSet(t *testing.T) {
+	// The happy path: a preparer-provided relevant-tools list gets the
+	// promoted tool appended. The resulting ctx is what buildToolDefinitions
+	// reads to filter — putting the promoted tool here is what makes the
+	// next agent-loop round expose it with its full schema.
+	ctx := withRelevantTools(context.Background(), []string{"timly.list-items"})
+	got := withPromotedTool(ctx, "timly.show-item")
+
+	tools, ok := relevantToolsFromContext(got)
+	if !ok {
+		t.Fatal("relevant-tools list missing after withPromotedTool")
+	}
+	want := []string{"timly.list-items", "timly.show-item"}
+	if !reflect.DeepEqual(tools, want) {
+		t.Errorf("relevant tools = %v, want %v", tools, want)
+	}
+}
+
+func TestWithPromotedTool_DedupsExistingEntry(t *testing.T) {
+	// A second promotion of the same name in one turn must not double the
+	// entry. Native-tools-mode providers de-dupe `tools[]` themselves, but
+	// keeping the list canonical avoids the round-trip and any vendor-side
+	// surprises.
+	ctx := withRelevantTools(context.Background(), []string{"timly.list-items"})
+	got := withPromotedTool(ctx, "timly.list-items")
+
+	tools, _ := relevantToolsFromContext(got)
+	want := []string{"timly.list-items"}
+	if !reflect.DeepEqual(tools, want) {
+		t.Errorf("relevant tools = %v, want %v (dedup failed)", tools, want)
+	}
+}
+
+func TestWithPromotedTool_NoRelevantToolsSet_ReturnsCtxUnchanged(t *testing.T) {
+	// When no preparer ran (no relevant-tools list on ctx),
+	// buildToolDefinitions already exposes every allowed tool — there's
+	// nothing to promote. withPromotedTool must short-circuit and return
+	// the original ctx; otherwise we'd inadvertently SET the list to a
+	// non-nil singleton and flip the filter from "show all" to "show only
+	// this one tool".
+	ctx := context.Background()
+	got := withPromotedTool(ctx, "timly.show-item")
+
+	if _, ok := relevantToolsFromContext(got); ok {
+		t.Error("withPromotedTool must not seed a relevant-tools list when none was set")
+	}
+}
+
+func TestWithPromotedTool_EmptyName_ReturnsCtxUnchanged(t *testing.T) {
+	// Defense in depth: an empty toolName must not silently corrupt the
+	// list with a blank entry. Caller responsibility, but we double-gate
+	// at the helper since the agent-loop trigger already pulls call.Args
+	// dynamically.
+	ctx := withRelevantTools(context.Background(), []string{"timly.list-items"})
+	got := withPromotedTool(ctx, "")
+
+	tools, _ := relevantToolsFromContext(got)
+	if !reflect.DeepEqual(tools, []string{"timly.list-items"}) {
+		t.Errorf("empty-name promotion mutated the list: %v", tools)
+	}
+}
+
+func TestBuildToolDefinitions_AfterWithPromotedTool_IncludesPromotedToolFullSchema(t *testing.T) {
+	// Composition: relevant-tools filter narrows to [A], then a
+	// _meta.get_tool_details promotion adds [B]. The rebuild driven from
+	// the agent loop calls buildToolDefinitions with the post-promotion
+	// ctx; the resulting tools-array must contain BOTH A and B (with
+	// full schemas). This is the property the native-tools-mode LLM
+	// relies on to call the promoted tool in the SAME turn.
+	orch := newOrchForMetaTests(t, &fakeInjectionStateStore{}, true)
+
+	// The fixture registers tools-plugin with two actions: t1 and t2.
+	// Profile filter starts with only t1 visible.
+	ctx := withAllowedPlugins(context.Background(), cachedAllowedPlugins{
+		m:      map[string]bool{"tools-plugin": true},
+		strict: false,
+	})
+	ctx = withRelevantTools(ctx, []string{"tools-plugin.t1"})
+
+	before := orch.buildToolDefinitions(ctx)
+	if len(before) != 1 || before[0].Name != "tools-plugin.t1" {
+		t.Fatalf("pre-promotion tools = %+v, want exactly [tools-plugin.t1]", before)
+	}
+
+	ctx = withPromotedTool(ctx, "tools-plugin.t2")
+	after := orch.buildToolDefinitions(ctx)
+	names := make([]string, len(after))
+	for i, td := range after {
+		names[i] = td.Name
+	}
+	wantNames := map[string]bool{"tools-plugin.t1": true, "tools-plugin.t2": true}
+	if len(names) != 2 {
+		t.Fatalf("post-promotion tools = %v, want exactly 2 entries", names)
+	}
+	for _, n := range names {
+		if !wantNames[n] {
+			t.Errorf("unexpected tool %q in post-promotion array, wanted only %v", n, wantNames)
+		}
 	}
 }
 

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -214,8 +214,8 @@ func TestGetToolDetails_PromotionPersistsTier1Entry(t *testing.T) {
 	if found == nil {
 		t.Fatalf("promoted tool missing from KnownTools, got %+v", store.lastWritten.KnownTools)
 	}
-	if found.Tier != "tier1" {
-		t.Errorf("Tier = %q, want %q", found.Tier, "tier1")
+	if found.Tier != state.KnownToolTier1 {
+		t.Errorf("Tier = %q, want %q", found.Tier, state.KnownToolTier1)
 	}
 	if found.LRURank < 1 {
 		t.Errorf("LRURank = %d, want >= 1", found.LRURank)
@@ -384,7 +384,7 @@ func TestGetToolDetails_PromotionClearsDemotedFlag(t *testing.T) {
 	store := &fakeInjectionStateStore{
 		store: map[string]state.InjectionState{
 			"s1": {KnownTools: []state.KnownToolEntry{
-				{ToolName: "tools-plugin.t1", Tier: "tier3", LRURank: 1, Demoted: true},
+				{ToolName: "tools-plugin.t1", Tier: state.KnownToolTier3, LRURank: 1, Demoted: true},
 			}},
 		},
 	}
@@ -399,7 +399,7 @@ func TestGetToolDetails_PromotionClearsDemotedFlag(t *testing.T) {
 			if kt.Demoted {
 				t.Errorf("Demoted must clear on promotion, got Demoted=true")
 			}
-			if kt.Tier != "tier1" {
+			if kt.Tier != state.KnownToolTier1 {
 				t.Errorf("Tier must upgrade to tier1, got %q", kt.Tier)
 			}
 		}
@@ -459,7 +459,7 @@ func TestGetToolDetails_PromotionDoesNotRegressLRURank(t *testing.T) {
 	store := &fakeInjectionStateStore{
 		store: map[string]state.InjectionState{
 			"s1": {KnownTools: []state.KnownToolEntry{
-				{ToolName: "tools-plugin.t1", Tier: "tier1", LRURank: 99},
+				{ToolName: "tools-plugin.t1", Tier: state.KnownToolTier1, LRURank: 99},
 			}},
 		},
 	}

--- a/internal/orchestrator/tool_error_tracking.go
+++ b/internal/orchestrator/tool_error_tracking.go
@@ -1,0 +1,216 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// RFC #249 Phase 4 D5: tool error tracking + sticky demotion.
+//
+// Two protections against runaway tool-failure loops:
+//
+//   - Loop-cap per tool per turn: at LoopCapPerTurn (default 2)
+//     consecutive identical-tool errors in the same turn, the
+//     orchestrator injects a system message — "Tool X failed N
+//     times in this turn — consider a different approach." — into
+//     the next LLM call so the LLM stops slamming the same broken
+//     tool.
+//   - Session-level sticky demotion: at StickyDemotionThreshold
+//     (default 3) consecutive errors for a tool across the entire
+//     session, the orchestrator flips Demoted=true on the tool's
+//     KnownToolEntry so the next turn's tier decision prefers it
+//     for eviction. RAG can still re-promote on a higher score —
+//     demotion is a soft penalty, not a permanent block.
+//
+// Self-healing (RFC): "any successful invocation clears the demoted
+// flag." We reset BOTH the per-turn and per-session counters on
+// success AND flip Demoted=false in KnownTools (best-effort: a
+// transient store failure logs and continues, same robustness
+// contract as Phase-3 write paths).
+//
+// State location: in-memory sync.Map keyed by sessionID. Counters
+// are NOT persisted — a process restart resets them, matching the
+// Phase-3 legacyKnowledgeWarnings precedent. The persisted artifact
+// is only the Demoted flag (which lives in state.InjectionState
+// alongside the rest of KnownTools).
+
+// sessionErrorState holds the per-session error counters. Guarded
+// by an internal mutex so concurrent tool-result handlers (rare —
+// the agent loop is sequential — but possible across overlapping
+// sessions sharing the same Orchestrator) don't race.
+type sessionErrorState struct {
+	mu            sync.Mutex
+	currentTurn   int
+	turnErrors    map[string]int // toolFQN → consecutive errors in currentTurn
+	sessionErrors map[string]int // toolFQN → consecutive errors across session
+}
+
+func newSessionErrorState() *sessionErrorState {
+	return &sessionErrorState{
+		turnErrors:    make(map[string]int),
+		sessionErrors: make(map[string]int),
+	}
+}
+
+// record atomically applies one tool-outcome update: roll the
+// per-turn counters when the turn number changed, then either bump
+// both counters (error) or reset them (success). Returns the
+// post-update (turnCount, sessionCount) on error and
+// (0, 0, wasFailing) on success — the caller uses wasFailing to
+// decide whether a self-heal write is warranted.
+//
+// One lock acquisition for the whole transition guarantees the
+// turn-rollover and the increment/reset can't be split by a
+// concurrent caller, even though the current agent loop is
+// sequential per session: future architectures (parallel sub-agents,
+// concurrent tool dispatch) shouldn't break the counter semantics.
+func (s *sessionErrorState) record(turn int, fqn string, success bool) (turnCount, sessionCount int, wasFailing bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if turn != s.currentTurn {
+		s.currentTurn = turn
+		s.turnErrors = make(map[string]int)
+	}
+	if success {
+		wasFailing = s.sessionErrors[fqn] > 0
+		delete(s.turnErrors, fqn)
+		delete(s.sessionErrors, fqn)
+		return 0, 0, wasFailing
+	}
+	s.turnErrors[fqn]++
+	s.sessionErrors[fqn]++
+	return s.turnErrors[fqn], s.sessionErrors[fqn], false
+}
+
+// toolErrorTracker holds per-session counter state. Sync.Map keyed
+// by sessionID matches the legacyKnowledgeWarnings precedent. Not
+// persisted — a process restart resets all counters, accepted as a
+// trade-off for not pinning observability state to the DB.
+type toolErrorTracker struct {
+	sessions sync.Map // sessionID → *sessionErrorState
+}
+
+func newToolErrorTracker() *toolErrorTracker {
+	return &toolErrorTracker{}
+}
+
+// stateFor returns (and lazily creates) the per-session counter
+// struct. Safe under concurrent access via LoadOrStore.
+func (t *toolErrorTracker) stateFor(sessionID string) *sessionErrorState {
+	if val, ok := t.sessions.Load(sessionID); ok {
+		return val.(*sessionErrorState)
+	}
+	candidate := newSessionErrorState()
+	actual, _ := t.sessions.LoadOrStore(sessionID, candidate)
+	return actual.(*sessionErrorState)
+}
+
+// recordToolOutcome is called after every executeCall in the agent
+// loop. Updates the in-memory counters and returns:
+//   - a system message to inject into the next LLM iteration when
+//     the loop_cap_per_turn threshold trips, otherwise nil
+//   - whether the caller should persist a Demoted=true flip
+//     (sticky_demotion_threshold tripped this call) or
+//     Demoted=false self-heal (success on a previously-failing tool)
+//
+// Tracking is gated by ToolTiersConfig.Enabled so deployments that
+// haven't opted into the tier model don't also pay for the tracker.
+// The cost is trivial (two integer increments + a map lookup per
+// tool call), but coupling stays clear.
+func (o *Orchestrator) recordToolOutcome(ctx context.Context, sessionID string, call ToolCall, result ToolResult) *provider.Message {
+	if !o.toolTiers.Enabled || sessionID == "" {
+		return nil
+	}
+	fqn := call.Plugin + "." + call.Action
+	st := o.toolErrorTracker.stateFor(sessionID)
+	turnCount, sessionCount, wasFailing := st.record(o.turnNumberForDedup(sessionID), fqn, result.Error == "")
+
+	if result.Error == "" {
+		if wasFailing && o.injectionStateStore != nil {
+			o.clearDemotedFlag(ctx, sessionID, fqn)
+		}
+		return nil
+	}
+
+	if sessionCount >= o.toolErrorHandling.StickyDemotionThreshold && o.injectionStateStore != nil {
+		o.markDemotedFlag(ctx, sessionID, fqn)
+	}
+
+	if turnCount >= o.toolErrorHandling.LoopCapPerTurn {
+		return &provider.Message{
+			Role:    provider.RoleSystem,
+			Content: fmt.Sprintf("Tool %s failed %d times in this turn — consider a different approach.", fqn, turnCount),
+		}
+	}
+	return nil
+}
+
+// markDemotedFlag flips KnownToolEntry.Demoted=true for fqn. If the
+// entry doesn't exist yet (the tool was never RAG-matched / Tier-1-
+// resident), the function still inserts a tier="tier3" + Demoted=true
+// row so the next turn's tier decision sees the flag. Same
+// defensive copy + warn-and-continue contract as
+// persistToolPromotion.
+func (o *Orchestrator) markDemotedFlag(ctx context.Context, sessionID, fqn string) {
+	o.updateToolDemotion(ctx, sessionID, fqn, true)
+}
+
+// clearDemotedFlag flips KnownToolEntry.Demoted=false for fqn. No-op
+// when the entry doesn't exist or the flag is already false (avoids
+// a wasted write).
+func (o *Orchestrator) clearDemotedFlag(ctx context.Context, sessionID, fqn string) {
+	o.updateToolDemotion(ctx, sessionID, fqn, false)
+}
+
+// updateToolDemotion is the shared core for mark / clear: read state,
+// upsert the entry's Demoted flag, write back. Skips the write when
+// the requested flag value already matches.
+func (o *Orchestrator) updateToolDemotion(ctx context.Context, sessionID, fqn string, demoted bool) {
+	existing, err := o.injectionStateStore.GetInjectionState(ctx, sessionID)
+	if err != nil {
+		slog.WarnContext(ctx, "tool_error_tracking: read state failed, demotion update skipped",
+			"component", "orchestrator", "session", sessionID, "tool", fqn, "demoted", demoted, "error", err)
+		return
+	}
+
+	updated := state.InjectionState{
+		KnownKnowledge: existing.KnownKnowledge,
+		KnownTools:     append([]state.KnownToolEntry(nil), existing.KnownTools...),
+	}
+	changed := false
+	found := false
+	for i := range updated.KnownTools {
+		if updated.KnownTools[i].ToolName != fqn {
+			continue
+		}
+		found = true
+		if updated.KnownTools[i].Demoted != demoted {
+			updated.KnownTools[i].Demoted = demoted
+			changed = true
+		}
+		break
+	}
+	if !found && demoted {
+		// Only create a fresh entry when we're SETTING the flag —
+		// clearing a non-existent flag is a no-op (no entry, no
+		// demotion to clear).
+		updated.KnownTools = append(updated.KnownTools, state.KnownToolEntry{
+			ToolName: fqn,
+			Tier:     "tier3",
+			Demoted:  true,
+		})
+		changed = true
+	}
+	if !changed {
+		return
+	}
+	if err := o.injectionStateStore.UpdateInjectionState(ctx, sessionID, updated); err != nil {
+		slog.WarnContext(ctx, "tool_error_tracking: write state failed, demotion not persisted",
+			"component", "orchestrator", "session", sessionID, "tool", fqn, "demoted", demoted, "error", err)
+	}
+}

--- a/internal/orchestrator/tool_error_tracking.go
+++ b/internal/orchestrator/tool_error_tracking.go
@@ -201,7 +201,7 @@ func (o *Orchestrator) updateToolDemotion(ctx context.Context, sessionID, fqn st
 		// demotion to clear).
 		updated.KnownTools = append(updated.KnownTools, state.KnownToolEntry{
 			ToolName: fqn,
-			Tier:     "tier3",
+			Tier:     state.KnownToolTier3,
 			Demoted:  true,
 		})
 		changed = true

--- a/internal/orchestrator/tool_error_tracking_test.go
+++ b/internal/orchestrator/tool_error_tracking_test.go
@@ -1,0 +1,239 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/actor"
+	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+func newOrchForErrorTrackingTests(t *testing.T, store *fakeInjectionStateStore) *Orchestrator {
+	t.Helper()
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	opts := OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{Enabled: true},
+		ToolErrorHandling: ToolErrorHandlingConfig{
+			LoopCapPerTurn:          2,
+			StickyDemotionThreshold: 3,
+		},
+	}
+	if store != nil {
+		opts.InjectionStateStore = store
+	}
+	return NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, opts)
+}
+
+func errorResult() ToolResult { return ToolResult{Error: "boom"} }
+func okResult() ToolResult    { return ToolResult{Content: "fine"} }
+func sampleCall() ToolCall    { return ToolCall{Plugin: "p", Action: "a"} }
+
+func TestRecordToolOutcome_FirstErrorBelowLoopCapEmitsNoWarning(t *testing.T) {
+	orch := newOrchForErrorTrackingTests(t, nil)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	warning := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	if warning != nil {
+		t.Errorf("first error (count=1, cap=2) must NOT emit warning, got %+v", warning)
+	}
+}
+
+func TestRecordToolOutcome_AtLoopCapEmitsWarning(t *testing.T) {
+	orch := newOrchForErrorTrackingTests(t, nil)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult()) // count=1
+	warning := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	if warning == nil {
+		t.Fatal("second error (count=2, cap=2) must emit a warning")
+	}
+	if !strings.Contains(warning.Content, "p.a") || !strings.Contains(warning.Content, "failed 2 times") {
+		t.Errorf("warning content lacks tool name or count, got %q", warning.Content)
+	}
+	if warning.Role == "" {
+		t.Errorf("warning must carry a Role, got empty")
+	}
+}
+
+func TestRecordToolOutcome_AdditionalErrorsAboveCapKeepEmittingWithUpdatedCount(t *testing.T) {
+	// The RFC's "N times" wording is dynamic — every error past the
+	// cap re-injects with the current count, so the LLM sees the
+	// growing failure trail and doesn't miss the nudge.
+	orch := newOrchForErrorTrackingTests(t, nil)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	w := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	if w == nil || !strings.Contains(w.Content, "failed 3 times") {
+		t.Errorf("third error must re-warn with count=3, got %+v", w)
+	}
+}
+
+func TestRecordToolOutcome_SuccessResetsCounters(t *testing.T) {
+	orch := newOrchForErrorTrackingTests(t, nil)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), okResult())
+	// Counter reset — next error must NOT immediately re-trip the warning.
+	w := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	if w != nil {
+		t.Errorf("post-success error (count=1) must NOT re-trip warning, got %+v", w)
+	}
+}
+
+func TestRecordToolOutcome_DifferentToolsCountIndependently(t *testing.T) {
+	orch := newOrchForErrorTrackingTests(t, nil)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = orch.recordToolOutcome(ctx, "s1", ToolCall{Plugin: "p", Action: "a"}, errorResult())
+	w := orch.recordToolOutcome(ctx, "s1", ToolCall{Plugin: "p", Action: "b"}, errorResult())
+	if w != nil {
+		t.Errorf("p.b first-error must NOT re-trip warning (independent counter), got %+v", w)
+	}
+}
+
+func TestRecordToolOutcome_TierLogicOffShortCircuits(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{Enabled: false},
+	})
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	for i := 0; i < 5; i++ {
+		w := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+		if w != nil {
+			t.Errorf("tier-off must short-circuit tracking, got warning iter %d: %+v", i, w)
+		}
+	}
+}
+
+func TestRecordToolOutcome_StickyDemotionFlipsDemotedFlag(t *testing.T) {
+	store := &fakeInjectionStateStore{}
+	orch := newOrchForErrorTrackingTests(t, store)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+
+	for i := 0; i < 3; i++ { // threshold=3
+		_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	}
+	// After 3rd error: sticky-demotion threshold trips, write should fire.
+	if store.updateCalls == 0 {
+		t.Fatal("sticky-demotion must persist via UpdateInjectionState")
+	}
+	found := false
+	for _, kt := range store.lastWritten.KnownTools {
+		if kt.ToolName == "p.a" && kt.Demoted {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("p.a must be Demoted=true after threshold, got %+v", store.lastWritten.KnownTools)
+	}
+}
+
+func TestRecordToolOutcome_SuccessAfterDemotionSelfHeals(t *testing.T) {
+	store := &fakeInjectionStateStore{
+		store: map[string]state.InjectionState{
+			"s1": {KnownTools: []state.KnownToolEntry{
+				{ToolName: "p.a", Tier: "tier3", Demoted: true},
+			}},
+		},
+	}
+	orch := newOrchForErrorTrackingTests(t, store)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	// Prime an error so the in-memory session counter is non-zero
+	// (recordSuccess returns wasFailing=true only when the session
+	// counter had ticked at least once — i.e. the tracker remembers
+	// the failure that demoted it before the process restart). For
+	// this test the simulated demotion came from a prior session
+	// state load + an error this turn.
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), okResult())
+
+	// The clear write should have fired and reset Demoted.
+	if store.updateCalls < 1 {
+		t.Fatal("self-heal must write the cleared state")
+	}
+	for _, kt := range store.lastWritten.KnownTools {
+		if kt.ToolName == "p.a" && kt.Demoted {
+			t.Errorf("self-heal must clear Demoted, got Demoted=true")
+		}
+	}
+}
+
+func TestRecordToolOutcome_NewTurnResetsTurnCounter(t *testing.T) {
+	// A new turn (different turn number) must reset the per-turn
+	// counter so a single failure in the previous turn doesn't
+	// short-circuit the cap calculation now.
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{Enabled: true},
+		ToolErrorHandling: ToolErrorHandlingConfig{
+			LoopCapPerTurn:          2,
+			StickyDemotionThreshold: 99,
+		},
+	})
+
+	// Turn 1: one error
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+
+	// Simulate next turn by adding a user message — turnNumberForDedup
+	// counts user messages + 1, so this bumps the orchestrator's view
+	// of "current turn" without going through the full agent loop.
+	_ = sessions.AddMessage("s1", provider.Message{Role: provider.RoleUser, Content: "next"})
+
+	// Turn 2 (now): first error — turn counter reset, so no warning yet.
+	w := orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	if w != nil {
+		t.Errorf("first error of a new turn must NOT warn (turn counter reset), got %+v", w)
+	}
+}
+
+func TestRecordToolOutcome_StoreWriteFailureDoesNotBubble(t *testing.T) {
+	// A transient store-write failure must not propagate back to the
+	// agent loop — it's logged and dropped. The error tracker's
+	// in-memory state advances either way; the missing persistence
+	// will resync the next time the threshold trips OR the tool
+	// self-heals.
+	store := &fakeInjectionStateStore{failUpdateErr: errors.New("simulated write failure")}
+	orch := newOrchForErrorTrackingTests(t, store)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	for i := 0; i < 3; i++ { // hit sticky threshold
+		_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), errorResult())
+	}
+	// No panic, no crash. Test passes if we got here.
+}
+
+func TestRecordToolOutcome_FirstCallSuccessNoClearWrite(t *testing.T) {
+	// First-ever recordToolOutcome call on a session is a success
+	// (no prior failures): wasFailing=false → no clear-write fires.
+	// Guards against accidentally writing on every success when the
+	// tool was never demoted.
+	store := &fakeInjectionStateStore{}
+	orch := newOrchForErrorTrackingTests(t, store)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+
+	_ = orch.recordToolOutcome(ctx, "s1", sampleCall(), okResult())
+
+	if store.updateCalls != 0 {
+		t.Errorf("first-call success on a clean session must not write state, got %d update calls", store.updateCalls)
+	}
+}
+
+func TestRecordToolOutcome_NoSessionIDShortCircuits(t *testing.T) {
+	// An empty session id means we can't address a tracker. Skip
+	// quietly rather than synthesizing an "anonymous" bucket.
+	orch := newOrchForErrorTrackingTests(t, nil)
+	w := orch.recordToolOutcome(context.Background(), "", sampleCall(), errorResult())
+	if w != nil {
+		t.Errorf("empty sessionID must short-circuit, got %+v", w)
+	}
+}

--- a/internal/orchestrator/tool_error_tracking_test.go
+++ b/internal/orchestrator/tool_error_tracking_test.go
@@ -139,7 +139,7 @@ func TestRecordToolOutcome_SuccessAfterDemotionSelfHeals(t *testing.T) {
 	store := &fakeInjectionStateStore{
 		store: map[string]state.InjectionState{
 			"s1": {KnownTools: []state.KnownToolEntry{
-				{ToolName: "p.a", Tier: "tier3", Demoted: true},
+				{ToolName: "p.a", Tier: state.KnownToolTier3, Demoted: true},
 			}},
 		},
 	}

--- a/internal/orchestrator/tool_tier_decision.go
+++ b/internal/orchestrator/tool_tier_decision.go
@@ -183,7 +183,7 @@ func applyToolTierDecision(
 		addToPool(name, currentTurn, true)
 	}
 	for _, kt := range prior.KnownTools {
-		if kt.Tier == "tier1" {
+		if kt.Tier == state.KnownToolTier1 {
 			addToPool(kt.ToolName, 0, false)
 		}
 	}
@@ -214,7 +214,7 @@ func applyToolTierDecision(
 	// Tier1EvictedToTier3: pool overflow that was tier="tier1" before.
 	var evicted []string
 	for _, p := range overflow {
-		if existing, ok := priorByName[p.Name]; ok && existing.Tier == "tier1" {
+		if existing, ok := priorByName[p.Name]; ok && existing.Tier == state.KnownToolTier1 {
 			evicted = append(evicted, p.Name)
 		}
 	}
@@ -224,7 +224,7 @@ func applyToolTierDecision(
 	// so payload buckets remain stable across turns).
 	var tier1New, tier1Carried []string
 	for _, name := range tier1 {
-		if existing, ok := priorByName[name]; ok && existing.Tier == "tier1" {
+		if existing, ok := priorByName[name]; ok && existing.Tier == state.KnownToolTier1 {
 			tier1Carried = append(tier1Carried, name)
 		} else {
 			tier1New = append(tier1New, name)
@@ -300,7 +300,7 @@ func buildUpdatedKnownTools(
 ) []state.KnownToolEntry {
 	entry := make(map[string]state.KnownToolEntry, len(pool)+len(tier0)+len(tier2))
 
-	upsertWithRank := func(name, tier string, rank int, demoted bool) {
+	upsertWithRank := func(name string, tier state.KnownToolTier, rank int, demoted bool) {
 		cur, ok := entry[name]
 		if !ok {
 			cur = priorByName[name]
@@ -319,20 +319,20 @@ func buildUpdatedKnownTools(
 	for _, name := range tier0 {
 		// Tier 0 is "always referenced" — bump to currentTurn so
 		// downstream LRU sees them as freshest.
-		upsertWithRank(name, "tier0", currentTurn, false)
+		upsertWithRank(name, state.KnownToolTier0, currentTurn, false)
 	}
 	tier1Set := stringSet(tier1)
 	for _, p := range pool {
-		t := "tier3"
+		t := state.KnownToolTier3
 		if tier1Set[p.Name] {
-			t = "tier1"
+			t = state.KnownToolTier1
 		}
 		upsertWithRank(p.Name, t, p.LRURank, p.Demoted)
 	}
 	for _, name := range tier2 {
 		// Tier 2 is also a "reference" per RFC ("RAG-match above
 		// threshold") so bump rank.
-		upsertWithRank(name, "tier2", currentTurn, false)
+		upsertWithRank(name, state.KnownToolTier2, currentTurn, false)
 	}
 	// Carry forward prior entries whose tool is still available but
 	// didn't land in any tier above (i.e. they're effectively Tier 3
@@ -345,7 +345,7 @@ func buildUpdatedKnownTools(
 		if !availSet[name] {
 			continue
 		}
-		kt.Tier = "tier3"
+		kt.Tier = state.KnownToolTier3
 		entry[name] = kt
 	}
 
@@ -484,24 +484,7 @@ func (o *Orchestrator) persistToolTierDecision(ctx context.Context, sessionID st
 // run pre-LLM-call to sanitise messages and never produce a
 // user-callable surface.
 func (o *Orchestrator) availableToolNames(ctx context.Context) []string {
-	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
-	preparerAction := preparerActionSet(o.preparers, o.guards)
-
-	var names []string
-	for _, cap := range o.registry.ListCapabilities() {
-		if !o.pluginAllowed(cap, allowedPlugins) {
-			continue
-		}
-		for _, action := range cap.Actions {
-			fqn := cap.Name + "." + action.Name
-			if preparerAction[fqn] || action.UserOnly {
-				continue
-			}
-			names = append(names, fqn)
-		}
-	}
-	sort.Strings(names)
-	return names
+	return o.listProfileToolNames(ctx, false)
 }
 
 // alwaysIncludeToolNames returns the subset of available tool names
@@ -509,6 +492,15 @@ func (o *Orchestrator) availableToolNames(ctx context.Context) []string {
 // The get_tool_details meta-tool (D4 registers it) lands here via the
 // same path.
 func (o *Orchestrator) alwaysIncludeToolNames(ctx context.Context) []string {
+	return o.listProfileToolNames(ctx, true)
+}
+
+// listProfileToolNames is the shared walk for availableToolNames and
+// alwaysIncludeToolNames. One pass over the registry honours the same
+// profile / preparer / user-only filter chain buildToolDefinitions and
+// buildSystemPrompt use; alwaysIncludeOnly narrows the result to the
+// Tier-0 pinned subset.
+func (o *Orchestrator) listProfileToolNames(ctx context.Context, alwaysIncludeOnly bool) []string {
 	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
 	preparerAction := preparerActionSet(o.preparers, o.guards)
 
@@ -518,7 +510,7 @@ func (o *Orchestrator) alwaysIncludeToolNames(ctx context.Context) []string {
 			continue
 		}
 		for _, action := range cap.Actions {
-			if !action.AlwaysInclude {
+			if alwaysIncludeOnly && !action.AlwaysInclude {
 				continue
 			}
 			fqn := cap.Name + "." + action.Name

--- a/internal/orchestrator/tool_tier_decision.go
+++ b/internal/orchestrator/tool_tier_decision.go
@@ -1,0 +1,553 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"sort"
+
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+// RFC #249 Phase 4 three-tier tool visibility decision logic.
+//
+// Pure functions over the per-turn candidate list, the persisted
+// per-session known_tools state, and the available-tools universe —
+// mirroring the Phase-3 knowledge_dedup pattern. The decision drives
+// (a) which tool definitions land in the LLM-visible `tools` array
+// with full schemas (Tier 0 + Tier 1), (b) which surface in the
+// system prompt with a 1-line summary (Tier 2, D3 renders), (c)
+// which surface as names-only grouped by capability (Tier 3, D3
+// renders), and (d) the preparer_decision.tools event payload.
+//
+// Tier assignments per RFC:
+//   - Tier 0: action.AlwaysInclude=true (manifest pin) + the
+//     get_tool_details meta-tool (D4 registers it). Always present
+//     in the LLM tools array.
+//   - Tier 1: the RAG-top-K + LRU survivors + this-turn-promoted set,
+//     capped at ToolTiersConfig.Tier1Cap. Full schemas in tools array.
+//   - Tier 2: the next slice of RAG candidates (those not already in
+//     Tier 0/1), capped at ToolTiersConfig.Tier2Cap. Surfaces as name
+//     + 1-liner in the system prompt.
+//   - Tier 3: every remaining available action, names-only in the
+//     system prompt.
+//
+// LRU contract for Tier 1 (RFC §"Three-tier tool visibility"):
+// `lru_rank` is the turn number of the tool's most recent reference,
+// where "reference" = RAG-match above threshold this turn OR an LLM
+// invocation OR a get_tool_details promotion. D2 implements the RAG-
+// match + promotion path; D5 (in-loop invocation bump) and D4
+// (promotion plumbing) wire the other two via the same KnownToolEntry
+// fields.
+//
+// State persistence is shared with knowledge_dedup via
+// state.InjectionState — KnownKnowledge stays the dedup decision's
+// concern, KnownTools is owned here. The prepare/persist split
+// honours RFC #249's EMIT→PERSIST ordering invariant.
+
+// toolTierDecision is the per-turn tier outcome. Slices preserve a
+// stable order (sorted alphabetically except where the RAG ranking
+// is the semantically meaningful order — currently nowhere; Tier 1
+// and Tier 2 are sorted by name to keep the event payload diff-able
+// across turns). The event payload pulls Tier1New / Tier1Carried /
+// Tier1EvictedToTier3 / Tier1SizeAfter / Tier1Cap; the system-prompt
+// renderer (D3) pulls Tier 2 and Tier 3.
+type toolTierDecision struct {
+	// Tier0 is the always_include set ∩ available tools. Always present
+	// in the LLM tools array regardless of RAG score.
+	Tier0 []string
+	// Tier1 is the LRU-managed top tier — full schemas in tools array,
+	// capped at Tier1Cap. Sorted alphabetically.
+	Tier1 []string
+	// Tier2 is the next slice of RAG candidates (≤ Tier2Cap), rendered
+	// as name + 1-liner in the system prompt (D3).
+	Tier2 []string
+	// Tier3 is every remaining available action, rendered as names-only
+	// grouped by capability in the system prompt (D3).
+	Tier3 []string
+
+	// Tier1New is the subset of Tier1 that wasn't tier="tier1" in the
+	// prior known_tools. Promotion paths (Tier 2/3 → Tier 1) land here
+	// alongside genuinely-new tools.
+	Tier1New []string
+	// Tier1Carried is the subset of Tier1 that survived from the prior
+	// turn (was tier="tier1" before and still is). RFC's "tools that
+	// did not need to move" bucket — useful for diff displays.
+	Tier1Carried []string
+	// Tier1EvictedToTier3 lists tools that were tier="tier1" in the
+	// prior state but got pushed out by LRU cap pressure this turn.
+	// Distinct from Tier1DemotedSticky, which is reserved for the D5
+	// error-threshold demotion path (always empty in D2).
+	Tier1EvictedToTier3 []string
+	// Tier1DemotedSticky is the D5 sticky-demotion eviction bucket —
+	// always empty here; D5 fills it when the error threshold trips.
+	Tier1DemotedSticky []string
+	// Tier1SizeAfter snapshots len(Tier1) for the event payload (saves
+	// the consumer re-counting).
+	Tier1SizeAfter int
+	// Tier1Cap snapshots the config value at decision time so the event
+	// stays interpretable even if the operator flips the cap between
+	// turns.
+	Tier1Cap int
+	// PromotedViaGetToolDetails is the D4 input slice — tools the LLM
+	// pulled into Tier 1 via the meta-tool this turn. Echoed into the
+	// event payload so consumers see the promotion provenance.
+	PromotedViaGetToolDetails []string
+
+	// UpdatedState is the post-decision InjectionState the caller
+	// persists. KnownKnowledge is carried through unchanged from the
+	// input (knowledge_dedup owns it); KnownTools is the new bookkeeping.
+	UpdatedState state.InjectionState
+}
+
+// toolTierPoolEntry is one row in the Tier-1 selection pool: a tool
+// name plus the (rank, demoted) snapshot the LRU sort consumes.
+// Defined at file scope so the helpers below can pass slices of it
+// around without anonymous-struct gymnastics.
+type toolTierPoolEntry struct {
+	Name    string
+	LRURank int
+	Demoted bool
+}
+
+// applyToolTierDecision runs the RFC #249 Phase 4 three-tier
+// classification over the per-turn candidate set + LRU state.
+//
+// Algorithm:
+//
+//  1. Tier 0 = alwaysInclude ∩ availableTools (and never demoted by
+//     RAG score; manifest authors are trusted).
+//  2. Build the Tier-1 pool: RAG candidates this turn (rank=currentTurn)
+//     ∪ promoted tools (rank=currentTurn) ∪ prior tier="tier1" entries
+//     (rank=prior.LRURank). Tools also in Tier 0 are excluded.
+//  3. Sort the pool by (Demoted asc, LRURank desc, ToolName asc) so
+//     non-demoted high-rank tools win; demoted tools are eviction
+//     candidates per RFC's "LRU treats demoted as preferred eviction".
+//  4. Top Tier1Cap entries → Tier 1; the rest overflow. Overflow that
+//     was tier="tier1" in prior state → Tier1EvictedToTier3.
+//  5. Tier 2 = the next ≤ Tier2Cap RAG candidates not already in Tier 0
+//     or Tier 1. Order preserves the input candidate ranking so
+//     consumers see the same score-ordered slice the plugin returned.
+//  6. Tier 3 = available - Tier 0 - Tier 1 - Tier 2, sorted by name.
+//
+// The pure-function contract means everything the caller needs to
+// emit the preparer_decision event + render the system prompt is in
+// the returned struct; no further reads are required.
+func applyToolTierDecision(
+	candidates []ToolCandidate,
+	availableTools []string,
+	alwaysInclude []string,
+	promoted []string,
+	prior state.InjectionState,
+	cfg ToolTiersConfig,
+	currentTurn int,
+) toolTierDecision {
+	availSet := stringSet(availableTools)
+	alwaysSet := stringSet(alwaysInclude)
+	promotedSet := stringSet(promoted)
+
+	priorByName := make(map[string]state.KnownToolEntry, len(prior.KnownTools))
+	for _, kt := range prior.KnownTools {
+		priorByName[kt.ToolName] = kt
+	}
+
+	// Tier 0: always-include set intersected with availability.
+	tier0 := sortedIntersection(alwaysSet, availSet)
+	tier0Set := stringSet(tier0)
+
+	// Tier 1 pool: candidates + promoted + prior tier="tier1".
+	pool := make([]toolTierPoolEntry, 0, len(candidates)+len(promoted)+len(prior.KnownTools))
+	inPool := make(map[string]bool, len(candidates)+len(promoted))
+	addToPool := func(name string, freshRank int, useFreshRank bool) {
+		if !availSet[name] || tier0Set[name] || inPool[name] {
+			return
+		}
+		rank, demoted := 0, false
+		if existing, ok := priorByName[name]; ok {
+			rank, demoted = existing.LRURank, existing.Demoted
+		}
+		if useFreshRank && freshRank > rank {
+			rank = freshRank
+		}
+		pool = append(pool, toolTierPoolEntry{Name: name, LRURank: rank, Demoted: demoted})
+		inPool[name] = true
+	}
+	for _, c := range candidates {
+		addToPool(c.ToolName, currentTurn, true)
+	}
+	for name := range promotedSet {
+		addToPool(name, currentTurn, true)
+	}
+	for _, kt := range prior.KnownTools {
+		if kt.Tier == "tier1" {
+			addToPool(kt.ToolName, 0, false)
+		}
+	}
+
+	sort.SliceStable(pool, func(i, j int) bool {
+		if pool[i].Demoted != pool[j].Demoted {
+			return !pool[i].Demoted
+		}
+		if pool[i].LRURank != pool[j].LRURank {
+			return pool[i].LRURank > pool[j].LRURank
+		}
+		return pool[i].Name < pool[j].Name
+	})
+
+	tier1 := make([]string, 0, cfg.Tier1Cap)
+	tier1Set := make(map[string]bool, cfg.Tier1Cap)
+	overflow := make([]toolTierPoolEntry, 0)
+	for i, p := range pool {
+		if i < cfg.Tier1Cap {
+			tier1 = append(tier1, p.Name)
+			tier1Set[p.Name] = true
+			continue
+		}
+		overflow = append(overflow, p)
+	}
+	sort.Strings(tier1)
+
+	// Tier1EvictedToTier3: pool overflow that was tier="tier1" before.
+	var evicted []string
+	for _, p := range overflow {
+		if existing, ok := priorByName[p.Name]; ok && existing.Tier == "tier1" {
+			evicted = append(evicted, p.Name)
+		}
+	}
+	sort.Strings(evicted)
+
+	// Tier1New / Tier1Carried split (operates on the SORTED tier1 slice
+	// so payload buckets remain stable across turns).
+	var tier1New, tier1Carried []string
+	for _, name := range tier1 {
+		if existing, ok := priorByName[name]; ok && existing.Tier == "tier1" {
+			tier1Carried = append(tier1Carried, name)
+		} else {
+			tier1New = append(tier1New, name)
+		}
+	}
+
+	// Tier 2: candidates not in Tier 0/1, in input (= score) order,
+	// capped at Tier2Cap.
+	tier2 := make([]string, 0, cfg.Tier2Cap)
+	tier2Set := make(map[string]bool, cfg.Tier2Cap)
+	for _, c := range candidates {
+		if tier0Set[c.ToolName] || tier1Set[c.ToolName] || tier2Set[c.ToolName] {
+			continue
+		}
+		if !availSet[c.ToolName] {
+			continue
+		}
+		if len(tier2) >= cfg.Tier2Cap {
+			break
+		}
+		tier2 = append(tier2, c.ToolName)
+		tier2Set[c.ToolName] = true
+	}
+
+	// Tier 3: available - Tier 0/1/2.
+	tier3 := make([]string, 0)
+	for _, name := range availableTools {
+		if tier0Set[name] || tier1Set[name] || tier2Set[name] {
+			continue
+		}
+		tier3 = append(tier3, name)
+	}
+	sort.Strings(tier3)
+
+	// Build updated known_tools. Every available tool that's been
+	// "ranked" (Tier 0/1/2) plus every prior entry whose tool is still
+	// available (preserves LRURank + Demoted across turns even if the
+	// tool fell to Tier 3 this turn). Tools whose underlying action is
+	// no longer available are dropped — cleanup for plugin
+	// removal / profile change.
+	updated := buildUpdatedKnownTools(
+		tier0, tier1, tier2, availSet, priorByName, pool, currentTurn,
+	)
+
+	return toolTierDecision{
+		Tier0:                     tier0,
+		Tier1:                     tier1,
+		Tier2:                     tier2,
+		Tier3:                     tier3,
+		Tier1New:                  tier1New,
+		Tier1Carried:              tier1Carried,
+		Tier1EvictedToTier3:       evicted,
+		Tier1SizeAfter:            len(tier1),
+		Tier1Cap:                  cfg.Tier1Cap,
+		PromotedViaGetToolDetails: appendIfPresent(nil, promoted, availSet, tier0Set),
+		UpdatedState: state.InjectionState{
+			KnownKnowledge: append([]state.KnownKnowledgeEntry(nil), prior.KnownKnowledge...),
+			KnownTools:     updated,
+		},
+	}
+}
+
+// buildUpdatedKnownTools assembles the new KnownTools slice from the
+// per-tier results + the Tier-1 pool's accumulated lru_rank/demoted
+// info. Pulled into a helper so the main algorithm reads top-down.
+func buildUpdatedKnownTools(
+	tier0, tier1, tier2 []string,
+	availSet map[string]bool,
+	priorByName map[string]state.KnownToolEntry,
+	pool []toolTierPoolEntry,
+	currentTurn int,
+) []state.KnownToolEntry {
+	entry := make(map[string]state.KnownToolEntry, len(pool)+len(tier0)+len(tier2))
+
+	upsertWithRank := func(name, tier string, rank int, demoted bool) {
+		cur, ok := entry[name]
+		if !ok {
+			cur = priorByName[name]
+		}
+		cur.ToolName = name
+		cur.Tier = tier
+		if rank > cur.LRURank {
+			cur.LRURank = rank
+		}
+		if demoted {
+			cur.Demoted = true
+		}
+		entry[name] = cur
+	}
+
+	for _, name := range tier0 {
+		// Tier 0 is "always referenced" — bump to currentTurn so
+		// downstream LRU sees them as freshest.
+		upsertWithRank(name, "tier0", currentTurn, false)
+	}
+	tier1Set := stringSet(tier1)
+	for _, p := range pool {
+		t := "tier3"
+		if tier1Set[p.Name] {
+			t = "tier1"
+		}
+		upsertWithRank(p.Name, t, p.LRURank, p.Demoted)
+	}
+	for _, name := range tier2 {
+		// Tier 2 is also a "reference" per RFC ("RAG-match above
+		// threshold") so bump rank.
+		upsertWithRank(name, "tier2", currentTurn, false)
+	}
+	// Carry forward prior entries whose tool is still available but
+	// didn't land in any tier above (i.e. they're effectively Tier 3
+	// this turn). Preserves their LRURank + Demoted for future LRU
+	// rounds.
+	for name, kt := range priorByName {
+		if _, already := entry[name]; already {
+			continue
+		}
+		if !availSet[name] {
+			continue
+		}
+		kt.Tier = "tier3"
+		entry[name] = kt
+	}
+
+	out := make([]state.KnownToolEntry, 0, len(entry))
+	for _, kt := range entry {
+		out = append(out, kt)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ToolName < out[j].ToolName })
+	return out
+}
+
+// stringSet builds a presence-only set from a slice. Same shape we
+// already use in knowledge_dedup, but kept package-local because the
+// underlying map[string]bool pattern is idiomatic enough that lifting
+// it would only add indirection.
+func stringSet(items []string) map[string]bool {
+	if len(items) == 0 {
+		return map[string]bool{}
+	}
+	out := make(map[string]bool, len(items))
+	for _, s := range items {
+		out[s] = true
+	}
+	return out
+}
+
+// sortedIntersection returns the intersection of two presence sets,
+// sorted alphabetically for stable rendering.
+func sortedIntersection(a, b map[string]bool) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+	var out []string
+	for k := range a {
+		if b[k] {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// appendIfPresent appends names from src into dst when they're in
+// availSet and NOT in excludeSet. Used to filter the promoted list
+// down to "actually promotable" entries before echoing into the
+// preparer_decision payload.
+func appendIfPresent(dst, src []string, availSet, excludeSet map[string]bool) []string {
+	if len(src) == 0 {
+		return dst
+	}
+	for _, name := range src {
+		if !availSet[name] || excludeSet[name] {
+			continue
+		}
+		dst = append(dst, name)
+	}
+	sort.Strings(dst)
+	return dst
+}
+
+// prepareToolTierDecision is the orchestrator's Phase-4 entry point
+// for READ + COMPUTE of the tier decision. Mirrors the Phase-3
+// prepareDedupDecision split: this method reads state, builds the
+// decision, and stashes it on prepAgg.ToolTier for the emit step;
+// persistToolTierDecision handles the write after the event has been
+// emitted (EMIT→PERSIST invariant).
+//
+// When knowledge_dedup also ran this turn the prior-state-as-of-read
+// comes from agg.KnowledgeDedup.UpdatedState so both decisions see a
+// coherent base; the final persist piggy-backs on the dedup write
+// (avoids double round-trip). When dedup didn't run we read state
+// fresh — same robustness contract as Phase 3 (read error → start
+// from zero so service stays available).
+func (o *Orchestrator) prepareToolTierDecision(ctx context.Context, sessionID string, agg *preparerAggregate) {
+	var prior state.InjectionState
+	switch {
+	case agg.KnowledgeDedup != nil:
+		// Dedup already loaded + updated state; preserve its KnownKnowledge.
+		prior = agg.KnowledgeDedup.UpdatedState
+	default:
+		var err error
+		prior, err = o.injectionStateStore.GetInjectionState(ctx, sessionID)
+		if err != nil {
+			slog.WarnContext(ctx, "tool_tiers: read state failed, starting fresh",
+				"component", "orchestrator", "session", sessionID, "error", err)
+			prior = state.InjectionState{}
+		}
+	}
+
+	available := o.availableToolNames(ctx)
+	alwaysInclude := o.alwaysIncludeToolNames(ctx)
+	promoted := o.promotedToolsThisTurn(ctx, sessionID) // D4 wires; nil here
+	turn := o.turnNumberForDedup(sessionID)
+
+	decision := applyToolTierDecision(
+		agg.Tools, available, alwaysInclude, promoted, prior, o.toolTiers, turn,
+	)
+
+	// When dedup also ran, merge tier's KnownTools delta into the
+	// dedup decision's UpdatedState so persistDedupDecision picks up
+	// both. KnownKnowledge stays as the dedup decision left it.
+	if agg.KnowledgeDedup != nil {
+		merged := agg.KnowledgeDedup.UpdatedState
+		merged.KnownTools = decision.UpdatedState.KnownTools
+		agg.KnowledgeDedup.UpdatedState = merged
+	}
+	agg.ToolTier = &decision
+}
+
+// persistToolTierDecision writes the tier decision back to the
+// session store ONLY when knowledge_dedup didn't run — otherwise the
+// dedup persist already includes the tier's KnownTools delta (merged
+// during prepareToolTierDecision). Same warn-and-continue contract as
+// persistDedupDecision: a transient write failure is reconciled the
+// next turn via the visible-message scan.
+func (o *Orchestrator) persistToolTierDecision(ctx context.Context, sessionID string, agg *preparerAggregate) {
+	if agg.ToolTier == nil || o.injectionStateStore == nil {
+		return
+	}
+	if agg.KnowledgeDedup != nil {
+		// Dedup persist already carries the merged tool state.
+		return
+	}
+	if err := o.injectionStateStore.UpdateInjectionState(ctx, sessionID, agg.ToolTier.UpdatedState); err != nil {
+		slog.WarnContext(ctx, "tool_tiers: write state failed, will reconcile next turn",
+			"component", "orchestrator", "session", sessionID, "error", err)
+	}
+}
+
+// availableToolNames returns the fully-qualified action names the
+// current request can invoke — i.e. profile-allowed, non-preparer,
+// non-guard, non-user-only. Mirrors the filter chain that
+// buildToolDefinitions already runs, hoisted here so the tier
+// decision and the system-prompt renderer (D3) share one source of
+// truth. Guards are excluded for the same reason preparers are: they
+// run pre-LLM-call to sanitise messages and never produce a
+// user-callable surface.
+func (o *Orchestrator) availableToolNames(ctx context.Context) []string {
+	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
+	preparerAction := preparerActionSet(o.preparers, o.guards)
+
+	var names []string
+	for _, cap := range o.registry.ListCapabilities() {
+		if !o.pluginAllowed(cap, allowedPlugins) {
+			continue
+		}
+		for _, action := range cap.Actions {
+			fqn := cap.Name + "." + action.Name
+			if preparerAction[fqn] || action.UserOnly {
+				continue
+			}
+			names = append(names, fqn)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// alwaysIncludeToolNames returns the subset of available tool names
+// the plugin manifest pinned to Tier 0 via action.AlwaysInclude=true.
+// The get_tool_details meta-tool (D4 registers it) lands here via the
+// same path.
+func (o *Orchestrator) alwaysIncludeToolNames(ctx context.Context) []string {
+	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
+	preparerAction := preparerActionSet(o.preparers, o.guards)
+
+	var names []string
+	for _, cap := range o.registry.ListCapabilities() {
+		if !o.pluginAllowed(cap, allowedPlugins) {
+			continue
+		}
+		for _, action := range cap.Actions {
+			if !action.AlwaysInclude {
+				continue
+			}
+			fqn := cap.Name + "." + action.Name
+			if preparerAction[fqn] || action.UserOnly {
+				continue
+			}
+			names = append(names, fqn)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// preparerActionSet pre-computes the FQNs the preparer pipeline
+// itself owns (both pre-LLM preparers and guard preparers) so
+// they're excluded from LLM-visible tier buckets. Used by both
+// availableToolNames and alwaysIncludeToolNames so the filter chain
+// stays consistent with buildToolDefinitions / buildSystemPrompt,
+// which both exclude o.preparers ∪ o.guards from the LLM surface.
+func preparerActionSet(preparers, guards []ContentPreparerEntry) map[string]bool {
+	out := make(map[string]bool, len(preparers)+len(guards))
+	for _, prep := range preparers {
+		out[prep.Plugin+"."+prep.Action] = true
+	}
+	for _, g := range guards {
+		out[g.Plugin+"."+g.Action] = true
+	}
+	return out
+}
+
+// promotedToolsThisTurn is the D4 hook for the get_tool_details
+// promotion path. Returns the set of tool fqns the LLM pulled into
+// Tier 1 via get_tool_details in the current user turn. D2 always
+// returns nil — the meta-tool isn't registered yet — but the tier
+// decision already honours the slice when D4 wires it.
+func (o *Orchestrator) promotedToolsThisTurn(_ context.Context, _ string) []string {
+	return nil
+}

--- a/internal/orchestrator/tool_tier_decision.go
+++ b/internal/orchestrator/tool_tier_decision.go
@@ -49,7 +49,8 @@ import (
 // is the semantically meaningful order — currently nowhere; Tier 1
 // and Tier 2 are sorted by name to keep the event payload diff-able
 // across turns). The event payload pulls Tier1New / Tier1Carried /
-// Tier1EvictedToTier3 / Tier1SizeAfter / Tier1Cap; the system-prompt
+// Tier1EvictedToTier3 / Tier1SizeAfter / Tier1Cap + Tier2 / Tier2Cap
+// (the latter for visibility into D3 promotion); the system-prompt
 // renderer (D3) pulls Tier 2 and Tier 3.
 type toolTierDecision struct {
 	// Tier0 is the always_include set ∩ available tools. Always present
@@ -88,6 +89,10 @@ type toolTierDecision struct {
 	// stays interpretable even if the operator flips the cap between
 	// turns.
 	Tier1Cap int
+	// Tier2Cap mirrors Tier1Cap for the Tier 2 bucket — emitted into the
+	// preparer_decision event so consumers can verify Tier 2 was sized
+	// as configured.
+	Tier2Cap int
 	// PromotedViaGetToolDetails is the D4 input slice — tools the LLM
 	// pulled into Tier 1 via the meta-tool this turn. Echoed into the
 	// event payload so consumers see the promotion provenance.
@@ -274,6 +279,7 @@ func applyToolTierDecision(
 		Tier1EvictedToTier3:       evicted,
 		Tier1SizeAfter:            len(tier1),
 		Tier1Cap:                  cfg.Tier1Cap,
+		Tier2Cap:                  cfg.Tier2Cap,
 		PromotedViaGetToolDetails: appendIfPresent(nil, promoted, availSet, tier0Set),
 		UpdatedState: state.InjectionState{
 			KnownKnowledge: append([]state.KnownKnowledgeEntry(nil), prior.KnownKnowledge...),

--- a/internal/orchestrator/tool_tier_decision.go
+++ b/internal/orchestrator/tool_tier_decision.go
@@ -549,11 +549,26 @@ func preparerActionSet(preparers, guards []ContentPreparerEntry) map[string]bool
 	return out
 }
 
-// promotedToolsThisTurn is the D4 hook for the get_tool_details
-// promotion path. Returns the set of tool fqns the LLM pulled into
-// Tier 1 via get_tool_details in the current user turn. D2 always
-// returns nil — the meta-tool isn't registered yet — but the tier
-// decision already honours the slice when D4 wires it.
-func (o *Orchestrator) promotedToolsThisTurn(_ context.Context, _ string) []string {
-	return nil
+// promotedToolsThisTurn returns the set of tool fqns the LLM pulled
+// into Tier 1 via _meta.get_tool_details since the prior preparer
+// pass on this session. Drained — once returned, the recents cache
+// is cleared for that session so the next preparer pass doesn't
+// see them again. (The InjectionState entry written by
+// persistToolPromotion separately keeps the tool in Tier 1 via LRU
+// rank, so dropping the recent-promotions signal here only loses
+// the provenance flag, not the placement.)
+//
+// In-memory only — across orchestrator restart the LRURank in
+// InjectionState still places the tool in Tier 1; the
+// promoted_via_get_tool_details event field would be empty for
+// one cycle then back to normal.
+func (o *Orchestrator) promotedToolsThisTurn(_ context.Context, sessionID string) []string {
+	if sessionID == "" {
+		return nil
+	}
+	o.recentToolPromotionsMu.Lock()
+	defer o.recentToolPromotionsMu.Unlock()
+	out := o.recentToolPromotions[sessionID]
+	delete(o.recentToolPromotions, sessionID)
+	return out
 }

--- a/internal/orchestrator/tool_tier_decision_test.go
+++ b/internal/orchestrator/tool_tier_decision_test.go
@@ -64,9 +64,9 @@ func TestApplyToolTierDecision_LRUEvictsOldestWhenCapExceeded(t *testing.T) {
 	// candidates push two newcomers in at rank=4. Cap=3 means the two
 	// lowest-rank Tier-1 entries (a.x rank=1, a.y rank=2) get evicted.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.x", Tier: "tier1", LRURank: 1},
-		{ToolName: "a.y", Tier: "tier1", LRURank: 2},
-		{ToolName: "a.z", Tier: "tier1", LRURank: 3},
+		{ToolName: "a.x", Tier: state.KnownToolTier1, LRURank: 1},
+		{ToolName: "a.y", Tier: state.KnownToolTier1, LRURank: 2},
+		{ToolName: "a.z", Tier: state.KnownToolTier1, LRURank: 3},
 	}}
 	candidates := []ToolCandidate{tc("a.new1", 0.9), tc("a.new2", 0.8)}
 	available := []string{"a.x", "a.y", "a.z", "a.new1", "a.new2"}
@@ -93,8 +93,8 @@ func TestApplyToolTierDecision_DemotedAreEvictionPreferred(t *testing.T) {
 	// a.demoted has rank=10 (highest) but Demoted=true, so it should
 	// lose Tier 1 to non-demoted tools even at lower rank.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.demoted", Tier: "tier1", LRURank: 10, Demoted: true},
-		{ToolName: "a.normal", Tier: "tier1", LRURank: 1},
+		{ToolName: "a.demoted", Tier: state.KnownToolTier1, LRURank: 10, Demoted: true},
+		{ToolName: "a.normal", Tier: state.KnownToolTier1, LRURank: 1},
 	}}
 	candidates := []ToolCandidate{tc("a.new1", 0.9), tc("a.new2", 0.8)}
 	available := []string{"a.demoted", "a.normal", "a.new1", "a.new2"}
@@ -137,7 +137,7 @@ func TestApplyToolTierDecision_PromotedJoinsTier1(t *testing.T) {
 	// promoted tools enter the Tier-1 pool at currentTurn rank — should
 	// land in Tier 1 ahead of older candidates.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.old", Tier: "tier1", LRURank: 1},
+		{ToolName: "a.old", Tier: state.KnownToolTier1, LRURank: 1},
 	}}
 	candidates := []ToolCandidate{tc("a.cand", 0.9)}
 	promoted := []string{"a.promo"}
@@ -177,7 +177,7 @@ func TestApplyToolTierDecision_UpdatedStatePreservesKnownKnowledge(t *testing.T)
 
 func TestApplyToolTierDecision_UpdatedStatePersistsDemotedFlag(t *testing.T) {
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.x", Tier: "tier1", LRURank: 1, Demoted: true},
+		{ToolName: "a.x", Tier: state.KnownToolTier1, LRURank: 1, Demoted: true},
 	}}
 	candidates := []ToolCandidate{tc("a.x", 0.9)}
 	got := applyToolTierDecision(candidates, []string{"a.x"}, nil, nil, prior, defaultTierCfg(), 5)
@@ -199,8 +199,8 @@ func TestApplyToolTierDecision_UpdatedStateDropsRemovedTools(t *testing.T) {
 	// A tool that used to be in KnownTools but is no longer in
 	// availableTools (plugin removed, profile changed) should drop out.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.gone", Tier: "tier1", LRURank: 5},
-		{ToolName: "a.here", Tier: "tier3", LRURank: 3},
+		{ToolName: "a.gone", Tier: state.KnownToolTier1, LRURank: 5},
+		{ToolName: "a.here", Tier: state.KnownToolTier3, LRURank: 3},
 	}}
 	got := applyToolTierDecision(nil, []string{"a.here"}, nil, nil, prior, defaultTierCfg(), 6)
 	for _, kt := range got.UpdatedState.KnownTools {
@@ -228,7 +228,7 @@ func TestApplyToolTierDecision_AlwaysIncludeBeatsRAGScore(t *testing.T) {
 
 func TestApplyToolTierDecision_BumpsLRURankOnRAGMatch(t *testing.T) {
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.x", Tier: "tier1", LRURank: 2},
+		{ToolName: "a.x", Tier: state.KnownToolTier1, LRURank: 2},
 	}}
 	candidates := []ToolCandidate{tc("a.x", 0.9)}
 	got := applyToolTierDecision(candidates, []string{"a.x"}, nil, nil, prior, defaultTierCfg(), 7)
@@ -253,7 +253,7 @@ func TestApplyToolTierDecision_LegacyEvictionOnlyWhenWasTier1(t *testing.T) {
 	// A pool overflow that was NOT tier="tier1" in prior state should
 	// not appear in Tier1EvictedToTier3 (it never lost Tier 1 status).
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.was_t3", Tier: "tier3", LRURank: 1},
+		{ToolName: "a.was_t3", Tier: state.KnownToolTier3, LRURank: 1},
 	}}
 	// a.was_t3 is NOT a current candidate, NOT promoted, so it never
 	// even enters the pool. It belongs to Tier 3 directly.
@@ -272,7 +272,7 @@ func TestApplyToolTierDecision_Tier1NewIncludesPromotionsFromTier2(t *testing.T)
 	// known_tools) and is a top-ranked candidate this turn lands in
 	// Tier 1. It should appear as Tier1New, not Tier1Carried.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.moved_up", Tier: "tier2", LRURank: 1},
+		{ToolName: "a.moved_up", Tier: state.KnownToolTier2, LRURank: 1},
 	}}
 	candidates := []ToolCandidate{tc("a.moved_up", 0.99)}
 	got := applyToolTierDecision(candidates, []string{"a.moved_up"}, nil, nil, prior, defaultTierCfg(), 5)
@@ -349,7 +349,7 @@ func TestApplyToolTierDecision_PromotedAlreadyTier1StaysTier1Carried(t *testing.
 	// rather than Tier1New. Otherwise a re-promoted carry-over would
 	// look like a freshly-promoted tool in the event payload.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "a.kept", Tier: "tier1", LRURank: 3},
+		{ToolName: "a.kept", Tier: state.KnownToolTier1, LRURank: 3},
 	}}
 	promoted := []string{"a.kept"}
 	got := applyToolTierDecision(nil, []string{"a.kept"}, nil, promoted, prior, defaultTierCfg(), 7)
@@ -371,9 +371,9 @@ func TestApplyToolTierDecision_SortStableOnEqualRank(t *testing.T) {
 	// (alphabetical) so the event payload is reproducible across
 	// orchestrator restarts and the tier diff stays auditable.
 	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
-		{ToolName: "z.last", Tier: "tier1", LRURank: 5},
-		{ToolName: "a.first", Tier: "tier1", LRURank: 5},
-		{ToolName: "m.middle", Tier: "tier1", LRURank: 5},
+		{ToolName: "z.last", Tier: state.KnownToolTier1, LRURank: 5},
+		{ToolName: "a.first", Tier: state.KnownToolTier1, LRURank: 5},
+		{ToolName: "m.middle", Tier: state.KnownToolTier1, LRURank: 5},
 	}}
 	available := []string{"a.first", "m.middle", "z.last"}
 	got := applyToolTierDecision(nil, available, nil, nil, prior, defaultTierCfg(), 6)

--- a/internal/orchestrator/tool_tier_decision_test.go
+++ b/internal/orchestrator/tool_tier_decision_test.go
@@ -1,0 +1,410 @@
+package orchestrator
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+func defaultTierCfg() ToolTiersConfig {
+	return ToolTiersConfig{
+		Enabled:  true,
+		Tier1Cap: 3,
+		Tier2Cap: 2,
+	}
+}
+
+func tc(name string, score float64) ToolCandidate {
+	return ToolCandidate{ToolName: name, Score: score}
+}
+
+func TestApplyToolTierDecision_NewCandidatesFillTier1UnderCap(t *testing.T) {
+	candidates := []ToolCandidate{tc("a.x", 0.9), tc("a.y", 0.7)}
+	available := []string{"a.x", "a.y", "a.z"}
+	got := applyToolTierDecision(candidates, available, nil, nil, state.InjectionState{}, defaultTierCfg(), 1)
+
+	if !reflect.DeepEqual(got.Tier1, []string{"a.x", "a.y"}) {
+		t.Errorf("Tier1 = %v, want [a.x a.y]", got.Tier1)
+	}
+	if !reflect.DeepEqual(got.Tier1New, []string{"a.x", "a.y"}) {
+		t.Errorf("Tier1New = %v, want both freshly entering", got.Tier1New)
+	}
+	if len(got.Tier1Carried) != 0 {
+		t.Errorf("Tier1Carried must be empty on first turn, got %v", got.Tier1Carried)
+	}
+	if !reflect.DeepEqual(got.Tier3, []string{"a.z"}) {
+		t.Errorf("Tier3 = %v, want [a.z]", got.Tier3)
+	}
+	if got.Tier1SizeAfter != 2 || got.Tier1Cap != 3 {
+		t.Errorf("Tier1SizeAfter/Tier1Cap = %d/%d, want 2/3", got.Tier1SizeAfter, got.Tier1Cap)
+	}
+}
+
+func TestApplyToolTierDecision_AlwaysIncludeLandsInTier0(t *testing.T) {
+	candidates := []ToolCandidate{tc("a.x", 0.9)}
+	available := []string{"a.x", "meta.help"}
+	always := []string{"meta.help"}
+	got := applyToolTierDecision(candidates, available, always, nil, state.InjectionState{}, defaultTierCfg(), 1)
+
+	if !reflect.DeepEqual(got.Tier0, []string{"meta.help"}) {
+		t.Errorf("Tier0 = %v, want [meta.help]", got.Tier0)
+	}
+	if !reflect.DeepEqual(got.Tier1, []string{"a.x"}) {
+		t.Errorf("Tier1 = %v, want [a.x] (always-include excluded)", got.Tier1)
+	}
+	if len(got.Tier3) != 0 {
+		t.Errorf("Tier3 must be empty (everything accounted for), got %v", got.Tier3)
+	}
+}
+
+func TestApplyToolTierDecision_LRUEvictsOldestWhenCapExceeded(t *testing.T) {
+	// Prior turn left tier1=[a.x rank=1, a.y rank=2, a.z rank=3]. New
+	// candidates push two newcomers in at rank=4. Cap=3 means the two
+	// lowest-rank Tier-1 entries (a.x rank=1, a.y rank=2) get evicted.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.x", Tier: "tier1", LRURank: 1},
+		{ToolName: "a.y", Tier: "tier1", LRURank: 2},
+		{ToolName: "a.z", Tier: "tier1", LRURank: 3},
+	}}
+	candidates := []ToolCandidate{tc("a.new1", 0.9), tc("a.new2", 0.8)}
+	available := []string{"a.x", "a.y", "a.z", "a.new1", "a.new2"}
+	got := applyToolTierDecision(candidates, available, nil, nil, prior, defaultTierCfg(), 4)
+
+	wantTier1 := []string{"a.new1", "a.new2", "a.z"}
+	sort.Strings(wantTier1)
+	if !reflect.DeepEqual(got.Tier1, wantTier1) {
+		t.Errorf("Tier1 = %v, want %v", got.Tier1, wantTier1)
+	}
+	wantEvicted := []string{"a.x", "a.y"}
+	if !reflect.DeepEqual(got.Tier1EvictedToTier3, wantEvicted) {
+		t.Errorf("Tier1EvictedToTier3 = %v, want %v", got.Tier1EvictedToTier3, wantEvicted)
+	}
+	if !reflect.DeepEqual(got.Tier1Carried, []string{"a.z"}) {
+		t.Errorf("Tier1Carried = %v, want [a.z]", got.Tier1Carried)
+	}
+	if !reflect.DeepEqual(got.Tier1New, []string{"a.new1", "a.new2"}) {
+		t.Errorf("Tier1New = %v, want [a.new1 a.new2]", got.Tier1New)
+	}
+}
+
+func TestApplyToolTierDecision_DemotedAreEvictionPreferred(t *testing.T) {
+	// a.demoted has rank=10 (highest) but Demoted=true, so it should
+	// lose Tier 1 to non-demoted tools even at lower rank.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.demoted", Tier: "tier1", LRURank: 10, Demoted: true},
+		{ToolName: "a.normal", Tier: "tier1", LRURank: 1},
+	}}
+	candidates := []ToolCandidate{tc("a.new1", 0.9), tc("a.new2", 0.8)}
+	available := []string{"a.demoted", "a.normal", "a.new1", "a.new2"}
+	got := applyToolTierDecision(candidates, available, nil, nil, prior, defaultTierCfg(), 4)
+
+	for _, name := range got.Tier1 {
+		if name == "a.demoted" {
+			t.Errorf("a.demoted should be evicted as preferred candidate, but stayed in Tier1: %v", got.Tier1)
+		}
+	}
+}
+
+func TestApplyToolTierDecision_Tier2FromCandidatesAboveCap(t *testing.T) {
+	cfg := ToolTiersConfig{Enabled: true, Tier1Cap: 2, Tier2Cap: 2}
+	candidates := []ToolCandidate{
+		tc("a.1", 0.9), tc("a.2", 0.8), // Tier 1 (cap=2)
+		tc("a.3", 0.7), tc("a.4", 0.6), // Tier 2 (cap=2)
+		tc("a.5", 0.5), // overflow → Tier 3
+	}
+	available := []string{"a.1", "a.2", "a.3", "a.4", "a.5"}
+	got := applyToolTierDecision(candidates, available, nil, nil, state.InjectionState{}, cfg, 1)
+
+	wantT1 := []string{"a.1", "a.2"}
+	if !reflect.DeepEqual(got.Tier1, wantT1) {
+		t.Errorf("Tier1 = %v, want %v", got.Tier1, wantT1)
+	}
+	wantT2 := []string{"a.3", "a.4"}
+	if !reflect.DeepEqual(got.Tier2, wantT2) {
+		t.Errorf("Tier2 = %v, want %v", got.Tier2, wantT2)
+	}
+	if !reflect.DeepEqual(got.Tier3, []string{"a.5"}) {
+		t.Errorf("Tier3 = %v, want [a.5]", got.Tier3)
+	}
+}
+
+func TestApplyToolTierDecision_PromotedJoinsTier1(t *testing.T) {
+	// promoted tools enter the Tier-1 pool at currentTurn rank — should
+	// land in Tier 1 ahead of older candidates.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.old", Tier: "tier1", LRURank: 1},
+	}}
+	candidates := []ToolCandidate{tc("a.cand", 0.9)}
+	promoted := []string{"a.promo"}
+	available := []string{"a.old", "a.cand", "a.promo"}
+	got := applyToolTierDecision(candidates, available, nil, promoted, prior, defaultTierCfg(), 5)
+
+	if !contains(got.Tier1, "a.promo") {
+		t.Errorf("a.promo should be in Tier1, got %v", got.Tier1)
+	}
+	if !reflect.DeepEqual(got.PromotedViaGetToolDetails, []string{"a.promo"}) {
+		t.Errorf("PromotedViaGetToolDetails = %v, want [a.promo]", got.PromotedViaGetToolDetails)
+	}
+}
+
+func TestApplyToolTierDecision_Tier3IsResidual(t *testing.T) {
+	candidates := []ToolCandidate{tc("a.1", 0.9)}
+	available := []string{"a.1", "a.2", "a.3", "a.4"}
+	got := applyToolTierDecision(candidates, available, nil, nil, state.InjectionState{}, defaultTierCfg(), 1)
+
+	wantT3 := []string{"a.2", "a.3", "a.4"}
+	if !reflect.DeepEqual(got.Tier3, wantT3) {
+		t.Errorf("Tier3 = %v, want %v", got.Tier3, wantT3)
+	}
+}
+
+func TestApplyToolTierDecision_UpdatedStatePreservesKnownKnowledge(t *testing.T) {
+	prior := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
+			{ArticleID: "kb_a", ContentSHA256: "abc", FirstInjectedTurn: 1},
+		},
+	}
+	got := applyToolTierDecision(nil, []string{"a.x"}, nil, nil, prior, defaultTierCfg(), 1)
+	if !reflect.DeepEqual(got.UpdatedState.KnownKnowledge, prior.KnownKnowledge) {
+		t.Errorf("KnownKnowledge clobbered: %v vs %v", got.UpdatedState.KnownKnowledge, prior.KnownKnowledge)
+	}
+}
+
+func TestApplyToolTierDecision_UpdatedStatePersistsDemotedFlag(t *testing.T) {
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.x", Tier: "tier1", LRURank: 1, Demoted: true},
+	}}
+	candidates := []ToolCandidate{tc("a.x", 0.9)}
+	got := applyToolTierDecision(candidates, []string{"a.x"}, nil, nil, prior, defaultTierCfg(), 5)
+	found := false
+	for _, kt := range got.UpdatedState.KnownTools {
+		if kt.ToolName == "a.x" {
+			found = true
+			if !kt.Demoted {
+				t.Errorf("a.x must remain Demoted=true after RAG match")
+			}
+		}
+	}
+	if !found {
+		t.Errorf("a.x missing from updated KnownTools")
+	}
+}
+
+func TestApplyToolTierDecision_UpdatedStateDropsRemovedTools(t *testing.T) {
+	// A tool that used to be in KnownTools but is no longer in
+	// availableTools (plugin removed, profile changed) should drop out.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.gone", Tier: "tier1", LRURank: 5},
+		{ToolName: "a.here", Tier: "tier3", LRURank: 3},
+	}}
+	got := applyToolTierDecision(nil, []string{"a.here"}, nil, nil, prior, defaultTierCfg(), 6)
+	for _, kt := range got.UpdatedState.KnownTools {
+		if kt.ToolName == "a.gone" {
+			t.Errorf("a.gone should drop out of KnownTools, got %v", got.UpdatedState.KnownTools)
+		}
+	}
+}
+
+func TestApplyToolTierDecision_AlwaysIncludeBeatsRAGScore(t *testing.T) {
+	// A tool marked always_include should land in Tier 0, NEVER in
+	// Tier 1, even when also a high-score RAG candidate.
+	candidates := []ToolCandidate{tc("meta.help", 0.95), tc("a.x", 0.4)}
+	available := []string{"a.x", "meta.help"}
+	always := []string{"meta.help"}
+	got := applyToolTierDecision(candidates, available, always, nil, state.InjectionState{}, defaultTierCfg(), 1)
+
+	if !contains(got.Tier0, "meta.help") {
+		t.Errorf("meta.help must be in Tier0, got Tier0=%v", got.Tier0)
+	}
+	if contains(got.Tier1, "meta.help") {
+		t.Errorf("meta.help must NOT be in Tier1, got Tier1=%v", got.Tier1)
+	}
+}
+
+func TestApplyToolTierDecision_BumpsLRURankOnRAGMatch(t *testing.T) {
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.x", Tier: "tier1", LRURank: 2},
+	}}
+	candidates := []ToolCandidate{tc("a.x", 0.9)}
+	got := applyToolTierDecision(candidates, []string{"a.x"}, nil, nil, prior, defaultTierCfg(), 7)
+	for _, kt := range got.UpdatedState.KnownTools {
+		if kt.ToolName == "a.x" && kt.LRURank != 7 {
+			t.Errorf("a.x LRURank = %d, want 7 after RAG match in turn 7", kt.LRURank)
+		}
+	}
+}
+
+func TestApplyToolTierDecision_EmptyCandidatesAndAvailable(t *testing.T) {
+	got := applyToolTierDecision(nil, nil, nil, nil, state.InjectionState{}, defaultTierCfg(), 1)
+	if len(got.Tier0) != 0 || len(got.Tier1) != 0 || len(got.Tier2) != 0 || len(got.Tier3) != 0 {
+		t.Errorf("empty inputs must yield empty tiers, got %+v", got)
+	}
+	if got.Tier1Cap != 3 {
+		t.Errorf("Tier1Cap snapshot = %d, want 3", got.Tier1Cap)
+	}
+}
+
+func TestApplyToolTierDecision_LegacyEvictionOnlyWhenWasTier1(t *testing.T) {
+	// A pool overflow that was NOT tier="tier1" in prior state should
+	// not appear in Tier1EvictedToTier3 (it never lost Tier 1 status).
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.was_t3", Tier: "tier3", LRURank: 1},
+	}}
+	// a.was_t3 is NOT a current candidate, NOT promoted, so it never
+	// even enters the pool. It belongs to Tier 3 directly.
+	candidates := []ToolCandidate{tc("a.1", 0.9), tc("a.2", 0.8), tc("a.3", 0.7), tc("a.4", 0.6)}
+	available := []string{"a.1", "a.2", "a.3", "a.4", "a.was_t3"}
+	got := applyToolTierDecision(candidates, available, nil, nil, prior, defaultTierCfg(), 1)
+	// Tier1Cap=3, so a.4 overflows. But a.4 was never tier="tier1",
+	// so it's not in Tier1EvictedToTier3.
+	if contains(got.Tier1EvictedToTier3, "a.4") {
+		t.Errorf("a.4 should not be in Tier1EvictedToTier3 (never was Tier 1)")
+	}
+}
+
+func TestApplyToolTierDecision_Tier1NewIncludesPromotionsFromTier2(t *testing.T) {
+	// A tool that was Tier 2 last turn (no tier="tier1" entry in
+	// known_tools) and is a top-ranked candidate this turn lands in
+	// Tier 1. It should appear as Tier1New, not Tier1Carried.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.moved_up", Tier: "tier2", LRURank: 1},
+	}}
+	candidates := []ToolCandidate{tc("a.moved_up", 0.99)}
+	got := applyToolTierDecision(candidates, []string{"a.moved_up"}, nil, nil, prior, defaultTierCfg(), 5)
+	if !contains(got.Tier1, "a.moved_up") {
+		t.Errorf("a.moved_up should be in Tier1, got %v", got.Tier1)
+	}
+	if !contains(got.Tier1New, "a.moved_up") {
+		t.Errorf("a.moved_up should be Tier1New (was Tier 2 prior), got Tier1New=%v Tier1Carried=%v",
+			got.Tier1New, got.Tier1Carried)
+	}
+}
+
+func TestBuildToolsBlock_FallbackWhenNoTierDecision(t *testing.T) {
+	agg := preparerAggregate{
+		Tools: []ToolCandidate{tc("a.x", 0.9), tc("a.y", 0.8)},
+	}
+	block := buildToolsBlock(agg)
+	want := []string{"a.x", "a.y"}
+	if !reflect.DeepEqual(block.Tier1New, want) {
+		t.Errorf("fallback Tier1New = %v, want %v", block.Tier1New, want)
+	}
+	if block.Tier1SizeAfter != 0 || block.Tier1Cap != 0 || block.Tier3TotalVisible != 0 {
+		t.Errorf("fallback must leave tier-aware fields zero, got %+v", block)
+	}
+}
+
+func TestBuildToolsBlock_FromTierDecision(t *testing.T) {
+	d := toolTierDecision{
+		Tier0:                     []string{"meta.help"},
+		Tier1New:                  []string{"a.x"},
+		Tier1Carried:              []string{"a.y"},
+		Tier1EvictedToTier3:       []string{"a.z"},
+		Tier1SizeAfter:            2,
+		Tier1Cap:                  10,
+		Tier3:                     []string{"a.lots", "a.more"},
+		PromotedViaGetToolDetails: []string{"a.promo"},
+	}
+	agg := preparerAggregate{ToolTier: &d}
+	block := buildToolsBlock(agg)
+
+	if block.Tier0Count != 1 {
+		t.Errorf("Tier0Count = %d, want 1", block.Tier0Count)
+	}
+	if !reflect.DeepEqual(block.Tier1New, d.Tier1New) || !reflect.DeepEqual(block.Tier1Carried, d.Tier1Carried) {
+		t.Errorf("tier1 subset slices not threaded through: %+v", block)
+	}
+	if block.Tier3TotalVisible != 2 {
+		t.Errorf("Tier3TotalVisible = %d, want 2", block.Tier3TotalVisible)
+	}
+	if !reflect.DeepEqual(block.PromotedViaGetToolDetails, []string{"a.promo"}) {
+		t.Errorf("PromotedViaGetToolDetails not threaded through, got %v", block.PromotedViaGetToolDetails)
+	}
+}
+
+func TestApplyToolTierDecision_PromotedAlreadyTier1StaysTier1Carried(t *testing.T) {
+	// A tool that was tier="tier1" in prior state AND is promoted via
+	// get_tool_details this turn should: (a) end up in Tier 1, and
+	// (b) classify as Tier1Carried (was tier="tier1" before, still is)
+	// rather than Tier1New. Otherwise a re-promoted carry-over would
+	// look like a freshly-promoted tool in the event payload.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "a.kept", Tier: "tier1", LRURank: 3},
+	}}
+	promoted := []string{"a.kept"}
+	got := applyToolTierDecision(nil, []string{"a.kept"}, nil, promoted, prior, defaultTierCfg(), 7)
+
+	if !contains(got.Tier1, "a.kept") {
+		t.Errorf("a.kept must stay in Tier1 after promote, got %v", got.Tier1)
+	}
+	if contains(got.Tier1New, "a.kept") {
+		t.Errorf("a.kept must NOT be Tier1New (was tier1 before), got %v", got.Tier1New)
+	}
+	if !contains(got.Tier1Carried, "a.kept") {
+		t.Errorf("a.kept must be Tier1Carried, got Tier1Carried=%v Tier1New=%v",
+			got.Tier1Carried, got.Tier1New)
+	}
+}
+
+func TestApplyToolTierDecision_SortStableOnEqualRank(t *testing.T) {
+	// Two non-demoted tools with the same LRURank must sort by name
+	// (alphabetical) so the event payload is reproducible across
+	// orchestrator restarts and the tier diff stays auditable.
+	prior := state.InjectionState{KnownTools: []state.KnownToolEntry{
+		{ToolName: "z.last", Tier: "tier1", LRURank: 5},
+		{ToolName: "a.first", Tier: "tier1", LRURank: 5},
+		{ToolName: "m.middle", Tier: "tier1", LRURank: 5},
+	}}
+	available := []string{"a.first", "m.middle", "z.last"}
+	got := applyToolTierDecision(nil, available, nil, nil, prior, defaultTierCfg(), 6)
+	wantTier1 := []string{"a.first", "m.middle", "z.last"}
+	if !reflect.DeepEqual(got.Tier1, wantTier1) {
+		t.Errorf("Tier1 = %v, want alphabetical %v", got.Tier1, wantTier1)
+	}
+}
+
+func TestApplyToolTierDecision_Tier1CapLargerThanAvailable(t *testing.T) {
+	// cfg.Tier1Cap=100, only 2 available — no panic, Tier 1 holds
+	// what's there. Guards against accidental over-allocation in the
+	// pool-slicing path.
+	cfg := ToolTiersConfig{Enabled: true, Tier1Cap: 100, Tier2Cap: 5}
+	candidates := []ToolCandidate{tc("a.x", 0.9), tc("a.y", 0.8)}
+	got := applyToolTierDecision(candidates, []string{"a.x", "a.y"}, nil, nil, state.InjectionState{}, cfg, 1)
+	if len(got.Tier1) != 2 {
+		t.Errorf("Tier1 len = %d, want 2 (cap > pool size)", len(got.Tier1))
+	}
+	if got.Tier1Cap != 100 {
+		t.Errorf("Tier1Cap snapshot = %d, want 100", got.Tier1Cap)
+	}
+}
+
+func TestApplyToolTierDecision_Tier2CapZeroSendsAllToTier3(t *testing.T) {
+	// cfg.Tier2Cap=0 means no Tier 2 entries — every below-Tier-1
+	// candidate falls straight through to Tier 3. Legal edge case
+	// since an operator might want to suppress the system-prompt
+	// "name + 1-liner" block entirely without disabling tier logic.
+	cfg := ToolTiersConfig{Enabled: true, Tier1Cap: 1, Tier2Cap: 0}
+	candidates := []ToolCandidate{tc("a.1", 0.9), tc("a.2", 0.8), tc("a.3", 0.7)}
+	got := applyToolTierDecision(candidates, []string{"a.1", "a.2", "a.3"}, nil, nil, state.InjectionState{}, cfg, 1)
+	if len(got.Tier2) != 0 {
+		t.Errorf("Tier2Cap=0 must produce empty Tier2, got %v", got.Tier2)
+	}
+	wantT3 := []string{"a.2", "a.3"}
+	if !reflect.DeepEqual(got.Tier3, wantT3) {
+		t.Errorf("Tier3 = %v, want %v", got.Tier3, wantT3)
+	}
+}
+
+// contains is a tiny test helper. The orchestrator package already
+// has `slices.Contains` available via Go 1.21+; the local helper is
+// kept for readability of test-only assertions.
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/tool_tier_decision_test.go
+++ b/internal/orchestrator/tool_tier_decision_test.go
@@ -128,6 +128,9 @@ func TestApplyToolTierDecision_Tier2FromCandidatesAboveCap(t *testing.T) {
 	if !reflect.DeepEqual(got.Tier3, []string{"a.5"}) {
 		t.Errorf("Tier3 = %v, want [a.5]", got.Tier3)
 	}
+	if got.Tier2Cap != cfg.Tier2Cap {
+		t.Errorf("Tier2Cap snapshot = %d, want %d (cfg.Tier2Cap)", got.Tier2Cap, cfg.Tier2Cap)
+	}
 }
 
 func TestApplyToolTierDecision_PromotedJoinsTier1(t *testing.T) {
@@ -304,6 +307,8 @@ func TestBuildToolsBlock_FromTierDecision(t *testing.T) {
 		Tier1EvictedToTier3:       []string{"a.z"},
 		Tier1SizeAfter:            2,
 		Tier1Cap:                  10,
+		Tier2:                     []string{"a.t2a", "a.t2b"},
+		Tier2Cap:                  15,
 		Tier3:                     []string{"a.lots", "a.more"},
 		PromotedViaGetToolDetails: []string{"a.promo"},
 	}
@@ -315,6 +320,19 @@ func TestBuildToolsBlock_FromTierDecision(t *testing.T) {
 	}
 	if !reflect.DeepEqual(block.Tier1New, d.Tier1New) || !reflect.DeepEqual(block.Tier1Carried, d.Tier1Carried) {
 		t.Errorf("tier1 subset slices not threaded through: %+v", block)
+	}
+	// Tier 2 fields close the prior observability gap: without them,
+	// consumers had no way to tell from the event log whether Tier 2
+	// was being populated, even though Tier 2 actually drives the
+	// "name + 1-line summary" block in the rendered system prompt.
+	if !reflect.DeepEqual(block.Tier2Tools, []string{"a.t2a", "a.t2b"}) {
+		t.Errorf("Tier2Tools = %v, want [a.t2a a.t2b]", block.Tier2Tools)
+	}
+	if block.Tier2SizeAfter != 2 {
+		t.Errorf("Tier2SizeAfter = %d, want 2", block.Tier2SizeAfter)
+	}
+	if block.Tier2Cap != 15 {
+		t.Errorf("Tier2Cap = %d, want 15", block.Tier2Cap)
 	}
 	if block.Tier3TotalVisible != 2 {
 		t.Errorf("Tier3TotalVisible = %d, want 2", block.Tier3TotalVisible)

--- a/internal/orchestrator/tool_tier_render.go
+++ b/internal/orchestrator/tool_tier_render.go
@@ -61,7 +61,7 @@ func renderTier2Section(decision *toolTierDecision, registry *ToolRegistry) stri
 	descByFQN := actionDescriptionMap(registry, decision.Tier2)
 	var sb strings.Builder
 	sb.WriteString("## Available tools — summary tier\n")
-	sb.WriteString("These tools are likely relevant. Use them directly when appropriate; call `get_tool_details(name=\"…\")` for the full schema before invocation.\n")
+	sb.WriteString("These tools are likely relevant. Use them directly when appropriate; call `_meta.get_tool_details(name=\"plugin.action\")` for the full schema before invocation.\n")
 	for _, fqn := range decision.Tier2 {
 		summary := firstLine(descByFQN[fqn])
 		if summary == "" {
@@ -95,7 +95,7 @@ func renderTier3Section(decision *toolTierDecision) string {
 	plugins := sortedKeys(byPlugin)
 	var sb strings.Builder
 	sb.WriteString("## Other available tools (request details before use)\n")
-	sb.WriteString("These tools exist but their full schemas aren't loaded. Call `get_tool_details(name=\"plugin.action\")` to see parameters before invoking.\n")
+	sb.WriteString("These tools exist but their full schemas aren't loaded. Call `_meta.get_tool_details(name=\"plugin.action\")` to see parameters before invoking.\n")
 	for _, plugin := range plugins {
 		actions := byPlugin[plugin]
 		fmt.Fprintf(&sb, "- %s: %s\n", plugin, strings.Join(actions, ", "))

--- a/internal/orchestrator/tool_tier_render.go
+++ b/internal/orchestrator/tool_tier_render.go
@@ -1,0 +1,157 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// RFC #249 Phase 4 system-prompt rendering for Tier 2 + Tier 3.
+//
+// Tier 0 + Tier 1 tools land in the LLM's native `tools` array with
+// full schemas (buildToolDefinitions filters by the relevant_tools
+// set that prepareToolTierDecision narrows to Tier 0 + Tier 1).
+// Tier 2 + Tier 3 land in the system prompt as text so the LLM
+// knows they exist without paying the per-tool full-schema cost:
+//
+//   - Tier 2: name + one-line summary (~20 tokens per tool)
+//   - Tier 3: names-only, grouped by plugin (~8 tokens per tool)
+//
+// Both tier sections nudge the LLM to call `get_tool_details(name=…)`
+// before invoking a not-yet-fully-defined tool — that meta-tool is
+// the D4 promotion path. D3 lands the system-prompt copy + the
+// surrounding plumbing; D4 will register the actual meta-tool so
+// the nudge is actionable.
+
+// toolTierDecisionKey is the context key the orchestrator uses to
+// stash the per-turn tier decision so buildSystemPrompt can read it
+// during agent-loop iterations. Mirrors the relevantToolsKey
+// precedent — empty struct, pointer value.
+type toolTierDecisionKey struct{}
+
+// withToolTierDecision stores the tier decision in ctx so the
+// system-prompt builder can render Tier 2 + Tier 3 sections from it.
+// Pass nil to clear (rare — used by tests that need to invalidate a
+// previously-stashed decision).
+func withToolTierDecision(ctx context.Context, d *toolTierDecision) context.Context {
+	return context.WithValue(ctx, toolTierDecisionKey{}, d)
+}
+
+// toolTierDecisionFromContext returns the tier decision stashed by
+// the preparer-loop wiring, or nil when tiers weren't active this
+// turn. Callers must tolerate nil (the pre-Phase-4 path doesn't
+// produce one).
+func toolTierDecisionFromContext(ctx context.Context) *toolTierDecision {
+	d, _ := ctx.Value(toolTierDecisionKey{}).(*toolTierDecision)
+	return d
+}
+
+// renderTier2Section returns a markdown block listing Tier 2 tools
+// with one-line summaries. Each line: "- plugin.action: <summary>".
+// The summary is the first line of the action's description so a
+// multi-paragraph description (typically intended for the full
+// schema) doesn't bloat the system prompt. Returns an empty string
+// when the tier has no entries — the caller can append unconditionally
+// without producing a stray header.
+func renderTier2Section(decision *toolTierDecision, registry *ToolRegistry) string {
+	if decision == nil || len(decision.Tier2) == 0 {
+		return ""
+	}
+	descByFQN := actionDescriptionMap(registry, decision.Tier2)
+	var sb strings.Builder
+	sb.WriteString("## Available tools — summary tier\n")
+	sb.WriteString("These tools are likely relevant. Use them directly when appropriate; call `get_tool_details(name=\"…\")` for the full schema before invocation.\n")
+	for _, fqn := range decision.Tier2 {
+		summary := firstLine(descByFQN[fqn])
+		if summary == "" {
+			fmt.Fprintf(&sb, "- %s\n", fqn)
+			continue
+		}
+		fmt.Fprintf(&sb, "- %s: %s\n", fqn, summary)
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// renderTier3Section returns a names-only block grouped by plugin.
+// Format:
+//
+//	## Other available tools (request details before use)
+//	- <plugin>: action1, action2, …
+//
+// Plugins (groups) and actions within a plugin are sorted
+// alphabetically so the system prompt is reproducible across
+// orchestrator restarts. The header nudges the LLM toward
+// get_tool_details for any Tier-3 entry it wants to actually call.
+func renderTier3Section(decision *toolTierDecision) string {
+	if decision == nil || len(decision.Tier3) == 0 {
+		return ""
+	}
+	byPlugin := groupTier3ByPlugin(decision.Tier3)
+	if len(byPlugin) == 0 {
+		return ""
+	}
+	plugins := sortedKeys(byPlugin)
+	var sb strings.Builder
+	sb.WriteString("## Other available tools (request details before use)\n")
+	sb.WriteString("These tools exist but their full schemas aren't loaded. Call `get_tool_details(name=\"plugin.action\")` to see parameters before invoking.\n")
+	for _, plugin := range plugins {
+		actions := byPlugin[plugin]
+		fmt.Fprintf(&sb, "- %s: %s\n", plugin, strings.Join(actions, ", "))
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// groupTier3ByPlugin splits the Tier 3 fqn list into a
+// plugin→[action,…] map, sorting the actions within each group so
+// the output is stable. fqns that don't parse as plugin.action are
+// silently skipped — those would be a malformed input.
+func groupTier3ByPlugin(fqns []string) map[string][]string {
+	out := make(map[string][]string)
+	for _, fqn := range fqns {
+		plugin, action, err := parseToolName(fqn)
+		if err != nil {
+			continue
+		}
+		out[plugin] = append(out[plugin], action)
+	}
+	for plugin := range out {
+		sort.Strings(out[plugin])
+	}
+	return out
+}
+
+// actionDescriptionMap walks the registry once to collect
+// fqn→description entries for the subset named in fqns. The
+// registry iteration is O(plugins × actions) but the result map is
+// O(|fqns|), so callers can do a fast lookup per Tier-2 entry
+// without re-scanning the registry for each.
+func actionDescriptionMap(registry *ToolRegistry, fqns []string) map[string]string {
+	want := make(map[string]bool, len(fqns))
+	for _, fqn := range fqns {
+		want[fqn] = true
+	}
+	out := make(map[string]string, len(fqns))
+	for _, cap := range registry.ListCapabilities() {
+		for _, a := range cap.Actions {
+			fqn := cap.Name + "." + a.Name
+			if want[fqn] {
+				out[fqn] = a.Description
+			}
+		}
+	}
+	return out
+}
+
+// firstLine returns the part of s before the first newline,
+// trimmed of leading / trailing whitespace. Used to keep Tier 2
+// summaries to a single line even when the underlying action
+// description spans multiple paragraphs of markdown.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/orchestrator/tool_tier_render_test.go
+++ b/internal/orchestrator/tool_tier_render_test.go
@@ -1,0 +1,156 @@
+package orchestrator
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRenderTier2Section_EmptyTierReturnsEmptyString(t *testing.T) {
+	registry := NewToolRegistry()
+	if got := renderTier2Section(nil, registry); got != "" {
+		t.Errorf("nil decision must return empty string, got %q", got)
+	}
+	if got := renderTier2Section(&toolTierDecision{}, registry); got != "" {
+		t.Errorf("empty Tier2 must return empty string, got %q", got)
+	}
+}
+
+func TestRenderTier2Section_NameAndOneLinerPerEntry(t *testing.T) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "p", Description: "P",
+		Actions: []Action{
+			{Name: "a", Description: "First action description."},
+			{Name: "b", Description: "Second action.\nWith a second paragraph that must be dropped."},
+		},
+	}, &fixedResultExecutor{content: ""})
+
+	d := &toolTierDecision{Tier2: []string{"p.a", "p.b"}}
+	got := renderTier2Section(d, registry)
+
+	if !strings.Contains(got, "## Available tools — summary tier") {
+		t.Errorf("missing header, got: %q", got)
+	}
+	if !strings.Contains(got, "- p.a: First action description.") {
+		t.Errorf("missing first-line summary for p.a, got: %q", got)
+	}
+	// Second paragraph must be dropped.
+	if !strings.Contains(got, "- p.b: Second action.") {
+		t.Errorf("missing first-line summary for p.b, got: %q", got)
+	}
+	if strings.Contains(got, "second paragraph") {
+		t.Errorf("second paragraph must be stripped from Tier 2 summary, got: %q", got)
+	}
+	if !strings.Contains(got, "get_tool_details") {
+		t.Errorf("Tier 2 section must mention get_tool_details, got: %q", got)
+	}
+}
+
+func TestRenderTier2Section_FQNWithoutDescriptionStillListed(t *testing.T) {
+	// A tier-2 fqn whose action isn't found in the registry (race:
+	// registry change between tier decision and prompt build) should
+	// still render as a bare name — no panic, no empty trailing colon.
+	registry := NewToolRegistry()
+	d := &toolTierDecision{Tier2: []string{"unknown.x"}}
+	got := renderTier2Section(d, registry)
+	if !strings.Contains(got, "- unknown.x\n") {
+		t.Errorf("missing-description fqn should render as bare name, got: %q", got)
+	}
+	if strings.Contains(got, "- unknown.x: \n") {
+		t.Errorf("must not render empty trailing colon, got: %q", got)
+	}
+}
+
+func TestRenderTier3Section_EmptyTierReturnsEmptyString(t *testing.T) {
+	if got := renderTier3Section(nil); got != "" {
+		t.Errorf("nil decision must return empty string, got %q", got)
+	}
+	if got := renderTier3Section(&toolTierDecision{}); got != "" {
+		t.Errorf("empty Tier3 must return empty string, got %q", got)
+	}
+}
+
+func TestRenderTier3Section_GroupsByPluginSorted(t *testing.T) {
+	d := &toolTierDecision{Tier3: []string{
+		"timly.list-items", "timly.show-item", "weather.forecast", "timly.create-ticket",
+	}}
+	got := renderTier3Section(d)
+
+	if !strings.Contains(got, "## Other available tools (request details before use)") {
+		t.Errorf("missing header, got: %q", got)
+	}
+	// timly group has 3 entries sorted alphabetically.
+	wantTimly := "- timly: create-ticket, list-items, show-item"
+	if !strings.Contains(got, wantTimly) {
+		t.Errorf("missing or wrong-order timly entry, got: %q want substring %q", got, wantTimly)
+	}
+	// weather group has 1 entry.
+	if !strings.Contains(got, "- weather: forecast") {
+		t.Errorf("missing weather entry, got: %q", got)
+	}
+	// Plugin order: timly before weather (alphabetical).
+	tIdx := strings.Index(got, "- timly:")
+	wIdx := strings.Index(got, "- weather:")
+	if tIdx < 0 || wIdx < 0 || tIdx > wIdx {
+		t.Errorf("plugin groups must be alphabetical: timly idx %d, weather idx %d", tIdx, wIdx)
+	}
+}
+
+func TestRenderTier3Section_SkipsMalformedFQNs(t *testing.T) {
+	// "bareName" without a plugin separator can't be parsed. Skipped
+	// silently — Tier 3 is best-effort context for the LLM, not a
+	// safety surface.
+	d := &toolTierDecision{Tier3: []string{"bareName", "p.a"}}
+	got := renderTier3Section(d)
+	if !strings.Contains(got, "- p: a") {
+		t.Errorf("valid entry missing, got: %q", got)
+	}
+	if strings.Contains(got, "bareName") {
+		t.Errorf("malformed fqn must be dropped, got: %q", got)
+	}
+}
+
+func TestFirstLine(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"single line", "single line"},
+		{"first\nsecond", "first"},
+		{"  trim me  \nrest", "trim me"},
+		{"\nempty first line", ""},
+		{"trailing newline\n", "trailing newline"},
+	}
+	for _, c := range cases {
+		if got := firstLine(c.in); got != c.want {
+			t.Errorf("firstLine(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestToolTierDecisionContextRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := toolTierDecisionFromContext(ctx); got != nil {
+		t.Errorf("empty ctx must yield nil, got %+v", got)
+	}
+	d := &toolTierDecision{Tier1: []string{"a.x"}}
+	ctx = withToolTierDecision(ctx, d)
+	got := toolTierDecisionFromContext(ctx)
+	if got != d {
+		t.Errorf("ctx round-trip lost the pointer: got %+v want %+v", got, d)
+	}
+}
+
+func TestGroupTier3ByPlugin(t *testing.T) {
+	got := groupTier3ByPlugin([]string{"a.x", "a.y", "b.z", "malformed"})
+	if len(got["a"]) != 2 || got["a"][0] != "x" || got["a"][1] != "y" {
+		t.Errorf("plugin a should have [x, y], got %v", got["a"])
+	}
+	if len(got["b"]) != 1 || got["b"][0] != "z" {
+		t.Errorf("plugin b should have [z], got %v", got["b"])
+	}
+	if _, ok := got["malformed"]; ok {
+		t.Errorf("malformed fqn must not produce a plugin entry, got %v", got)
+	}
+}

--- a/internal/orchestrator/tool_tier_render_test.go
+++ b/internal/orchestrator/tool_tier_render_test.go
@@ -42,8 +42,8 @@ func TestRenderTier2Section_NameAndOneLinerPerEntry(t *testing.T) {
 	if strings.Contains(got, "second paragraph") {
 		t.Errorf("second paragraph must be stripped from Tier 2 summary, got: %q", got)
 	}
-	if !strings.Contains(got, "get_tool_details") {
-		t.Errorf("Tier 2 section must mention get_tool_details, got: %q", got)
+	if !strings.Contains(got, "_meta.get_tool_details") {
+		t.Errorf("Tier 2 section must mention _meta.get_tool_details, got: %q", got)
 	}
 }
 

--- a/internal/orchestrator/tool_tiers_config_test.go
+++ b/internal/orchestrator/tool_tiers_config_test.go
@@ -1,0 +1,107 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state"
+)
+
+func TestToolTiersConfig_NormalizesZeroValuesToRFCDefaults(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		// ToolTiers + ToolErrorHandling intentionally left zero-valued.
+	})
+	got := orch.toolTiers
+	if got.Enabled {
+		t.Error("zero-value ToolTiers must keep Enabled=false")
+	}
+	if got.Tier1Cap != 10 {
+		t.Errorf("Tier1Cap default = %d, want 10", got.Tier1Cap)
+	}
+	if got.Tier2Cap != 15 {
+		t.Errorf("Tier2Cap default = %d, want 15", got.Tier2Cap)
+	}
+	if got.EnableGetToolDetails {
+		t.Error("EnableGetToolDetails must default to false")
+	}
+	errGot := orch.toolErrorHandling
+	if errGot.LoopCapPerTurn != 2 {
+		t.Errorf("LoopCapPerTurn default = %d, want 2", errGot.LoopCapPerTurn)
+	}
+	if errGot.StickyDemotionThreshold != 3 {
+		t.Errorf("StickyDemotionThreshold default = %d, want 3", errGot.StickyDemotionThreshold)
+	}
+}
+
+func TestToolTiersConfig_PreservesExplicitValues(t *testing.T) {
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{
+			Enabled:              true,
+			Tier1Cap:             12,
+			Tier2Cap:             18,
+			EnableGetToolDetails: true,
+		},
+		ToolErrorHandling: ToolErrorHandlingConfig{
+			LoopCapPerTurn:          4,
+			StickyDemotionThreshold: 6,
+		},
+	})
+	got := orch.toolTiers
+	if !got.Enabled || got.Tier1Cap != 12 || got.Tier2Cap != 18 || !got.EnableGetToolDetails {
+		t.Errorf("explicit ToolTiers values clobbered: %+v", got)
+	}
+	errGot := orch.toolErrorHandling
+	if errGot.LoopCapPerTurn != 4 || errGot.StickyDemotionThreshold != 6 {
+		t.Errorf("explicit ToolErrorHandling values clobbered: %+v", errGot)
+	}
+}
+
+func TestToolTiersConfig_EnableGetToolDetailsImpliesEnabled(t *testing.T) {
+	// Enabling the meta-tool without the master switch would register
+	// a Tier-0 tool that no one can use. The normalization step
+	// upgrades Enabled→true in that case so the YAML "set just the
+	// meta-tool flag" shorthand stays operator-friendly.
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{
+			Enabled:              false,
+			EnableGetToolDetails: true,
+		},
+	})
+	if !orch.toolTiers.Enabled {
+		t.Error("EnableGetToolDetails=true must upgrade Enabled to true")
+	}
+	if !orch.toolTiers.EnableGetToolDetails {
+		t.Error("EnableGetToolDetails must remain true after normalization")
+	}
+}
+
+func TestToolTiersConfig_DisabledStaysDisabled(t *testing.T) {
+	// Inverse of the upgrade rule: with both flags false (the safe
+	// default) Enabled must stay false even after normalization, so
+	// the orchestrator falls through to the pre-Phase-4 single-tier
+	// behaviour. Caps are still normalized so any later toggle of
+	// Enabled gets sane numbers without restart.
+	registry := NewToolRegistry()
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers: ToolTiersConfig{
+			Enabled:              false,
+			EnableGetToolDetails: false,
+		},
+	})
+	if orch.toolTiers.Enabled {
+		t.Error("Enabled=false + EnableGetToolDetails=false must stay disabled")
+	}
+	if orch.toolTiers.Tier1Cap != 10 || orch.toolTiers.Tier2Cap != 15 {
+		t.Errorf("caps must still normalize even when disabled, got %+v", orch.toolTiers)
+	}
+}

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -16,6 +16,12 @@ type Parameter struct {
 // array with its full schema regardless of RAG score, so a plugin can
 // guarantee critical capabilities (e.g. emergency-stop) are never demoted
 // to a name-only system-prompt entry.
+// ReadOnly is the per-call confirmation-gate hint: when true the
+// orchestrator skips the "I'm about to execute X" user prompt that
+// normally precedes a tool call, and the planner-narration LLM call
+// that builds that prompt. Set for actions that don't mutate user-
+// visible state (list/show/get/query). Default false — fail-safe to
+// "treat as potential write".
 type Action struct {
 	Name              string      `yaml:"name"`
 	Description       string      `yaml:"description"`
@@ -24,6 +30,7 @@ type Action struct {
 	AuditLog          bool        `yaml:"audit_log,omitempty"`      // if true, log invocation for audit
 	UserOnly          bool        `yaml:"user_only,omitempty"`      // if true, hidden from LLM and blocked from LLM-sourced calls
 	AlwaysInclude     bool        `yaml:"always_include,omitempty"` // RFC #249 Phase 4: pin to Tier 0 regardless of RAG score
+	ReadOnly          bool        `yaml:"read_only,omitempty"`      // if true, skip per-call user-confirmation gate (pure query)
 }
 
 type PluginCapability struct {

--- a/internal/orchestrator/types.go
+++ b/internal/orchestrator/types.go
@@ -11,13 +11,19 @@ type Parameter struct {
 // before calling the executor. The orchestrator resolves them via ContextArgProviders.
 // AuditLog, when true, causes the orchestrator to log each invocation (actor, plugin, action, args) for audit; no plugin or action names are hardcoded in the core.
 // UserOnly, when true, hides the action from the LLM system prompt and blocks it from being called via LLM-generated tool calls; it can only be invoked directly by the user (e.g. via RunAction).
+// AlwaysInclude is the RFC #249 Phase 4 pin-to-Tier-0 flag: when true the
+// orchestrator's tier decision keeps this action in the LLM's `tools`
+// array with its full schema regardless of RAG score, so a plugin can
+// guarantee critical capabilities (e.g. emergency-stop) are never demoted
+// to a name-only system-prompt entry.
 type Action struct {
 	Name              string      `yaml:"name"`
 	Description       string      `yaml:"description"`
 	Parameters        []Parameter `yaml:"parameters,omitempty"`
 	InjectContextArgs []string    `yaml:"inject_context_args,omitempty"`
-	AuditLog          bool        `yaml:"audit_log,omitempty"` // if true, log invocation for audit
-	UserOnly          bool        `yaml:"user_only,omitempty"` // if true, hidden from LLM and blocked from LLM-sourced calls
+	AuditLog          bool        `yaml:"audit_log,omitempty"`      // if true, log invocation for audit
+	UserOnly          bool        `yaml:"user_only,omitempty"`      // if true, hidden from LLM and blocked from LLM-sourced calls
+	AlwaysInclude     bool        `yaml:"always_include,omitempty"` // RFC #249 Phase 4: pin to Tier 0 regardless of RAG score
 }
 
 type PluginCapability struct {

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -153,6 +153,7 @@ func toPluginCapability(pb *pluginpb.PluginCapabilities) orchestrator.PluginCapa
 			UserOnly:          a.UserOnly,
 			InjectContextArgs: a.InjectContextArgs,
 			AlwaysInclude:     a.AlwaysInclude,
+			ReadOnly:          a.ReadOnly,
 		}
 	}
 	glossary := make([]orchestrator.GlossaryEntry, len(pb.Glossary))

--- a/internal/plugin/client.go
+++ b/internal/plugin/client.go
@@ -152,6 +152,7 @@ func toPluginCapability(pb *pluginpb.PluginCapabilities) orchestrator.PluginCapa
 			Parameters:        params,
 			UserOnly:          a.UserOnly,
 			InjectContextArgs: a.InjectContextArgs,
+			AlwaysInclude:     a.AlwaysInclude,
 		}
 	}
 	glossary := make([]orchestrator.GlossaryEntry, len(pb.Glossary))

--- a/internal/plugin/client_test.go
+++ b/internal/plugin/client_test.go
@@ -270,6 +270,31 @@ func TestUserOnlyMappedFromProto(t *testing.T) {
 	}
 }
 
+func TestAlwaysIncludeMappedFromProto(t *testing.T) {
+	// RFC #249 Phase 4: a plugin marks a capability as Tier-0-pinned by
+	// setting always_include=true on its Action manifest. The wire bit
+	// must reach orchestrator.Action.AlwaysInclude so the tier
+	// decision can honour it.
+	pb := &pluginpb.PluginCapabilities{
+		Name:        "myplugin",
+		Description: "Test plugin",
+		Actions: []*pluginpb.Action{
+			{Name: "regular_action", Description: "Regular", AlwaysInclude: false},
+			{Name: "pinned_action", Description: "Pinned", AlwaysInclude: true},
+		},
+	}
+	cap := toPluginCapability(pb)
+	if len(cap.Actions) != 2 {
+		t.Fatalf("expected 2 actions, got %d", len(cap.Actions))
+	}
+	if cap.Actions[0].AlwaysInclude {
+		t.Error("regular_action should have AlwaysInclude=false")
+	}
+	if !cap.Actions[1].AlwaysInclude {
+		t.Error("pinned_action should have AlwaysInclude=true")
+	}
+}
+
 // credHeaderCapturingPluginService records the credential headers from each Execute call.
 type credHeaderCapturingPluginService struct {
 	pluginpb.UnimplementedPluginServiceServer

--- a/internal/state/injection_state.go
+++ b/internal/state/injection_state.go
@@ -1,0 +1,37 @@
+package state
+
+// InjectionState is the per-session knowledge / tool dedup bookkeeping
+// persisted by the orchestrator's preparer phase (RFC #249). Phase 3
+// populates KnownKnowledge; KnownTools is reserved for Phase 4 and
+// stays empty on the Phase-3 write path.
+//
+// Lives in the `state` package alongside Session so the orchestrator
+// can wire its optional InjectionStateStore dependency without
+// importing the DB-backed store package — same separation Session
+// already follows.
+type InjectionState struct {
+	KnownKnowledge []KnownKnowledgeEntry `json:"known_knowledge,omitempty"`
+	KnownTools     []KnownToolEntry      `json:"known_tools,omitempty"`
+}
+
+// KnownKnowledgeEntry is one knowledge-article chunk the orchestrator
+// has already seen this session. ContentSHA256 is the dedup key —
+// different chunks of the same article have different SHAs, so chunk-
+// level disjoint information correctly triggers re-injection.
+// ArticleID is auxiliary: O(1) lookup for truncation/summarization
+// release-paths and human-meaningful event-log strings.
+type KnownKnowledgeEntry struct {
+	ArticleID         string `json:"article_id"`
+	ContentSHA256     string `json:"content_sha256"`
+	FirstInjectedTurn int    `json:"first_injected_turn,omitempty"`
+}
+
+// KnownToolEntry is the Phase-4 tool-tier bookkeeping shape. Phase 3
+// readers unmarshal existing entries to preserve forward-compatible
+// rows, but the Phase-3 writer never produces a non-empty slice.
+type KnownToolEntry struct {
+	ToolName string `json:"tool_name"`
+	Tier     string `json:"tier"`
+	LRURank  int    `json:"lru_rank"`
+	Demoted  bool   `json:"demoted"`
+}

--- a/internal/state/injection_state.go
+++ b/internal/state/injection_state.go
@@ -30,8 +30,23 @@ type KnownKnowledgeEntry struct {
 // readers unmarshal existing entries to preserve forward-compatible
 // rows, but the Phase-3 writer never produces a non-empty slice.
 type KnownToolEntry struct {
-	ToolName string `json:"tool_name"`
-	Tier     string `json:"tier"`
-	LRURank  int    `json:"lru_rank"`
-	Demoted  bool   `json:"demoted"`
+	ToolName string        `json:"tool_name"`
+	Tier     KnownToolTier `json:"tier"`
+	LRURank  int           `json:"lru_rank"`
+	Demoted  bool          `json:"demoted"`
 }
+
+// KnownToolTier is the Phase-4 visibility bucket for a tool. Typed
+// string keeps the wire format identical to the previous raw-string
+// shape (encoding/json marshals named-string types as their underlying
+// value) while making the four valid bucket names visible at compile
+// time. A typo like `"teir1"` was previously a silent demotion to
+// Tier 3; with the constants it is a build error.
+type KnownToolTier string
+
+const (
+	KnownToolTier0 KnownToolTier = "tier0"
+	KnownToolTier1 KnownToolTier = "tier1"
+	KnownToolTier2 KnownToolTier = "tier2"
+	KnownToolTier3 KnownToolTier = "tier3"
+)

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -126,6 +126,58 @@ func TestEmitTurnStart_PayloadShape(t *testing.T) {
 	}
 }
 
+func TestEmitTurnStart_PreparerRefsRoundTrip(t *testing.T) {
+	// RFC #249 Pillar C: turn_start carries back-references to the
+	// preparer phase (InjectedKnowledge, PreparerDecisionID, Tier1/Tier3
+	// counts). When populated they round-trip through the payload
+	// JSON; when zero they're omitted under `omitempty` so pre-Phase-3
+	// payloads stay byte-identical.
+	sink := &fakeSink{}
+	ctx := actor.WithSessionID(context.Background(), "s1")
+	EmitTurnStart(ctx, sink, TurnStartArgs{
+		ModelID:            "gpt-x",
+		PreparerDecisionID: "evt_pd_42",
+		InjectedKnowledge: []events.KnowledgeRef{
+			{ArticleID: "kb_a", ContentSHA256: "sha_a"},
+			{ArticleID: "kb_b", ContentSHA256: "sha_b"},
+		},
+		ToolTier1Count: 8,
+		ToolTier3Count: 47,
+	})
+
+	got := sink.snapshot()
+	if len(got) != 1 || got[0].EventType != events.TypeTurnStart {
+		t.Fatalf("unexpected events: %+v", got)
+	}
+	var p events.TurnStartPayload
+	if err := json.Unmarshal(got[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.PreparerDecisionID != "evt_pd_42" {
+		t.Errorf("PreparerDecisionID = %q, want evt_pd_42", p.PreparerDecisionID)
+	}
+	if len(p.InjectedKnowledge) != 2 ||
+		p.InjectedKnowledge[0].ArticleID != "kb_a" || p.InjectedKnowledge[0].ContentSHA256 != "sha_a" ||
+		p.InjectedKnowledge[1].ArticleID != "kb_b" || p.InjectedKnowledge[1].ContentSHA256 != "sha_b" {
+		t.Errorf("InjectedKnowledge mismatch: %+v", p.InjectedKnowledge)
+	}
+	if p.ToolTier1Count != 8 || p.ToolTier3Count != 47 {
+		t.Errorf("tier counts = (%d, %d), want (8, 47)", p.ToolTier1Count, p.ToolTier3Count)
+	}
+
+	// Zero-value case: same helper with none of the Pillar-C fields set
+	// must omit them from the payload JSON (string match on the wire is
+	// the simplest regression guard).
+	sink2 := &fakeSink{}
+	EmitTurnStart(ctx, sink2, TurnStartArgs{ModelID: "gpt-x"})
+	wire := string(sink2.snapshot()[0].Payload)
+	for _, field := range []string{"preparer_decision_id", "injected_knowledge", "tool_tier1_count", "tool_tier3_count"} {
+		if strings.Contains(wire, field) {
+			t.Errorf("zero-value emit leaked %q in payload: %s", field, wire)
+		}
+	}
+}
+
 func TestEmitUserMessage_ContentLengthMatchesStoredContent(t *testing.T) {
 	// The contract: ContentLength matches the BYTES of the stored Content
 	// field (post-sanitization), not the input. ASCII inputs are

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -364,6 +364,98 @@ func TestEmitToolCallNotFound_Minimal(t *testing.T) {
 	}
 }
 
+// ----- preparer cluster (composite payload shape) -----
+
+// TestEmitPreparerDecision_NestedBlocksRoundTrip verifies the Knowledge
+// and Tools sub-blocks of PreparerDecisionPayload serialize with their
+// nested-struct shape intact. The cohort tests above cover the Header.V
+// stamp and the Mode discriminator; this one pins the wire shape of the
+// inner blocks so consumers (api-plugin aggregations, review UI) can
+// rely on a stable JSON layout.
+func TestEmitPreparerDecision_NestedBlocksRoundTrip(t *testing.T) {
+	sink := &fakeSink{}
+	EmitPreparerDecision(context.Background(), sink, PreparerDecisionArgs{
+		Mode: events.PreparerDecisionModeFull,
+		Knowledge: events.PreparerDecisionKnowledgeBlock{
+			CandidateIDs: []string{"kb_a", "kb_b", "kb_c"},
+			Injected: []events.PreparerDecisionInjectedItem{
+				{ArticleID: "kb_a", ContentSHA256: "sha-a", Reason: "new"},
+			},
+			SkippedKnown: []events.PreparerDecisionSkippedItem{
+				{ArticleID: "kb_b", Reason: "content_sha_already_known"},
+			},
+			ScoreOverridesApplied: []events.PreparerDecisionScoreOverride{
+				{ArticleID: "kb_c", CurrentScore: 0.92, Threshold: 0.85},
+			},
+			InjectedBytes: 1024,
+		},
+		Tools: events.PreparerDecisionToolsBlock{
+			Tier0Count:                2,
+			Tier1New:                  []string{"timly__list-items"},
+			Tier1Carried:              []string{"timly__show-item"},
+			Tier1SizeAfter:            8,
+			Tier1Cap:                  10,
+			Tier3TotalVisible:         47,
+			PromotedViaGetToolDetails: []string{"timly__schedule-item"},
+		},
+	})
+
+	var p events.PreparerDecisionPayload
+	if err := json.Unmarshal(sink.snapshot()[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Mode != events.PreparerDecisionModeFull {
+		t.Errorf("Mode = %q, want %q", p.Mode, events.PreparerDecisionModeFull)
+	}
+	if len(p.Knowledge.CandidateIDs) != 3 || p.Knowledge.CandidateIDs[0] != "kb_a" {
+		t.Errorf("Knowledge.CandidateIDs = %v", p.Knowledge.CandidateIDs)
+	}
+	if len(p.Knowledge.Injected) != 1 || p.Knowledge.Injected[0].Reason != "new" {
+		t.Errorf("Knowledge.Injected = %+v", p.Knowledge.Injected)
+	}
+	if len(p.Knowledge.SkippedKnown) != 1 || p.Knowledge.SkippedKnown[0].Reason != "content_sha_already_known" {
+		t.Errorf("Knowledge.SkippedKnown = %+v", p.Knowledge.SkippedKnown)
+	}
+	if len(p.Knowledge.ScoreOverridesApplied) != 1 || p.Knowledge.ScoreOverridesApplied[0].CurrentScore != 0.92 {
+		t.Errorf("Knowledge.ScoreOverridesApplied = %+v", p.Knowledge.ScoreOverridesApplied)
+	}
+	if p.Knowledge.InjectedBytes != 1024 {
+		t.Errorf("Knowledge.InjectedBytes = %d", p.Knowledge.InjectedBytes)
+	}
+	if p.Tools.Tier1Cap != 10 || p.Tools.Tier1SizeAfter != 8 || p.Tools.Tier3TotalVisible != 47 {
+		t.Errorf("Tools tier counts = %+v", p.Tools)
+	}
+	if len(p.Tools.PromotedViaGetToolDetails) != 1 || p.Tools.PromotedViaGetToolDetails[0] != "timly__schedule-item" {
+		t.Errorf("Tools.PromotedViaGetToolDetails = %v", p.Tools.PromotedViaGetToolDetails)
+	}
+}
+
+// TestEmitPreparerDecision_ModeAlwaysSerializes verifies the Mode field
+// is never omitted (no omitempty) even when set to the zero value — Mode
+// is a discriminator and consumers must always see it.
+func TestEmitPreparerDecision_ModeAlwaysSerializes(t *testing.T) {
+	sink := &fakeSink{}
+	EmitPreparerDecision(context.Background(), sink, PreparerDecisionArgs{}) // empty Mode
+	raw := string(sink.snapshot()[0].Payload)
+	if !strings.Contains(raw, `"mode":""`) {
+		t.Errorf("zero-value Mode must serialize as empty string, got: %s", raw)
+	}
+}
+
+// TestEmitMessagesTruncated_NoOpRange verifies that a zero-DroppedCount
+// emission produces no dropped_seq_range field (avoiding noise in event
+// payloads when the cutter ran but dropped nothing). The helper still
+// emits the event so callers can rely on emission unconditional on
+// outcome — that's a producer-side decision, not enforced here.
+func TestEmitMessagesTruncated_NoOpRange(t *testing.T) {
+	sink := &fakeSink{}
+	EmitMessagesTruncated(context.Background(), sink, MessagesTruncatedArgs{DroppedCount: 0})
+	raw := string(sink.snapshot()[0].Payload)
+	if strings.Contains(raw, "dropped_seq_range") {
+		t.Errorf("dropped_seq_range must be absent when DroppedCount=0, got: %s", raw)
+	}
+}
+
 // ----- header.V coverage for every helper -----
 
 // Asserts the Header.V stamp for every Emit<Type> is the matching
@@ -389,6 +481,13 @@ func TestAllEmitHelpers_StampMatchingVersion(t *testing.T) {
 		{"PlannerResponse", func(c context.Context, s Sink) { EmitPlannerResponse(c, s, PlannerResponseArgs{}) }, events.TypePlannerResponse, events.PlannerResponseVersion},
 		{"PlannerStep", func(c context.Context, s Sink) { EmitPlannerStep(c, s, PlannerStepArgs{}) }, events.TypePlannerStep, events.PlannerStepVersion},
 		{"ToolRetrieval", func(c context.Context, s Sink) { EmitToolRetrieval(c, s, ToolRetrievalArgs{}) }, events.TypeToolRetrieval, events.ToolRetrievalVersion},
+		{"KnowledgeRetrieval", func(c context.Context, s Sink) { EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{}) }, events.TypeKnowledgeRetrieval, events.KnowledgeRetrievalVersion},
+		{"GlossaryRetrieval", func(c context.Context, s Sink) { EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{}) }, events.TypeGlossaryRetrieval, events.GlossaryRetrievalVersion},
+		{"PreparerDecision", func(c context.Context, s Sink) {
+			EmitPreparerDecision(c, s, PreparerDecisionArgs{Mode: events.PreparerDecisionModeInstrumentationOnly})
+		}, events.TypePreparerDecision, events.PreparerDecisionVersion},
+		{"DriftDetected", func(c context.Context, s Sink) { EmitDriftDetected(c, s, DriftDetectedArgs{}) }, events.TypeDriftDetected, events.DriftDetectedVersion},
+		{"MessagesTruncated", func(c context.Context, s Sink) { EmitMessagesTruncated(c, s, MessagesTruncatedArgs{}) }, events.TypeMessagesTruncated, events.MessagesTruncatedVersion},
 		{"SummarizationTriggered", func(c context.Context, s Sink) { EmitSummarizationTriggered(c, s, SummarizationTriggeredArgs{}) }, events.TypeSummarizationTriggered, events.SummarizationTriggeredVersion},
 		{"SummarizationCompleted", func(c context.Context, s Sink) { EmitSummarizationCompleted(c, s, SummarizationCompletedArgs{}) }, events.TypeSummarizationCompleted, events.SummarizationCompletedVersion},
 		{"ModelSwitch", func(c context.Context, s Sink) { EmitModelSwitch(c, s, ModelSwitchArgs{}) }, events.TypeModelSwitch, events.ModelSwitchVersion},
@@ -406,10 +505,10 @@ func TestAllEmitHelpers_StampMatchingVersion(t *testing.T) {
 		{"Error", func(c context.Context, s Sink) { EmitError(c, s, "where", "msg") }, events.TypeError, events.ErrorVersion},
 	}
 
-	// All 24 event types must be exercised — keep this in lockstep with
+	// All 29 event types must be exercised — keep this in lockstep with
 	// the constants in event_types.go. If you add a new event type and
 	// this count drops below it, add a row above.
-	const wantCases = 24
+	const wantCases = 29
 	if len(cases) != wantCases {
 		t.Fatalf("len(cases) = %d, want %d — keep TestAllEmitHelpers in sync with event_types.go", len(cases), wantCases)
 	}
@@ -631,6 +730,85 @@ func TestEmit_SanitizesAllFreeTextFields(t *testing.T) {
 					t.Fatalf("unmarshal: %v", err)
 				}
 				return v.Query
+			},
+		},
+		{
+			"KnowledgeRetrieval.Query",
+			func(c context.Context, s Sink) {
+				EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{Query: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.KnowledgeRetrievalPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Query
+			},
+		},
+		{
+			"GlossaryRetrieval.Query",
+			func(c context.Context, s Sink) {
+				EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{Query: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.GlossaryRetrievalPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.Query
+			},
+		},
+		{
+			"DriftDetected.ReconciliationAction",
+			func(c context.Context, s Sink) {
+				EmitDriftDetected(c, s, DriftDetectedArgs{ReconciliationAction: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.DriftDetectedPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.ReconciliationAction
+			},
+		},
+		{
+			"KnowledgeRetrieval.Hits[].Title",
+			func(c context.Context, s Sink) {
+				EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{
+					Query: "q",
+					Hits: []events.KnowledgeRetrievalHit{
+						{ArticleID: "kb_a", Title: invalidUTF8Raw},
+					},
+				})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.KnowledgeRetrievalPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(v.Hits) == 0 {
+					t.Fatalf("Hits is empty after emit; want 1 hit")
+				}
+				return v.Hits[0].Title
+			},
+		},
+		{
+			"GlossaryRetrieval.Hits[].Term",
+			func(c context.Context, s Sink) {
+				EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{
+					Query: "q",
+					Hits:  []events.GlossaryRetrievalHit{{Term: invalidUTF8Raw}},
+				})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.GlossaryRetrievalPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				if len(v.Hits) == 0 {
+					t.Fatalf("Hits is empty after emit; want 1 hit")
+				}
+				return v.Hits[0].Term
 			},
 		},
 		{
@@ -869,6 +1047,42 @@ func TestEmit_RowDurationMirrorsPayloadLatency(t *testing.T) {
 				return v.LatencyMS
 			},
 		},
+		{
+			"ToolRetrieval",
+			func(c context.Context, s Sink) {
+				EmitToolRetrieval(c, s, ToolRetrievalArgs{Query: "q", LatencyMS: 98})
+			},
+			98,
+			func(p []byte) int64 {
+				var v events.ToolRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				return v.LatencyMS
+			},
+		},
+		{
+			"KnowledgeRetrieval",
+			func(c context.Context, s Sink) {
+				EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{Query: "q", LatencyMS: 142})
+			},
+			142,
+			func(p []byte) int64 {
+				var v events.KnowledgeRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				return v.LatencyMS
+			},
+		},
+		{
+			"GlossaryRetrieval",
+			func(c context.Context, s Sink) {
+				EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{Query: "q", LatencyMS: 53})
+			},
+			53,
+			func(p []byte) int64 {
+				var v events.GlossaryRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				return v.LatencyMS
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -978,6 +1192,86 @@ func TestAllEmitHelpers_PopulateDistinctiveField(t *testing.T) {
 				_ = json.Unmarshal(p, &v)
 				if v.TopK != 9 {
 					t.Errorf("TopK = %d", v.TopK)
+				}
+			},
+		},
+		{
+			"KnowledgeRetrieval.Hits_ArticleID",
+			func(c context.Context, s Sink) {
+				EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{
+					Query: "q",
+					Hits: []events.KnowledgeRetrievalHit{
+						{ArticleID: "kb_recurring", Score: 0.91},
+					},
+				})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.KnowledgeRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				if len(v.Hits) != 1 || v.Hits[0].ArticleID != "kb_recurring" {
+					t.Errorf("Hits[0].ArticleID mismatch: %+v", v.Hits)
+				}
+			},
+		},
+		{
+			"GlossaryRetrieval.Hits_Term",
+			func(c context.Context, s Sink) {
+				EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{
+					Query: "q",
+					Hits:  []events.GlossaryRetrievalHit{{Term: "ticket", Score: 0.71}},
+				})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.GlossaryRetrievalPayload
+				_ = json.Unmarshal(p, &v)
+				if len(v.Hits) != 1 || v.Hits[0].Term != "ticket" {
+					t.Errorf("Hits[0].Term mismatch: %+v", v.Hits)
+				}
+			},
+		},
+		{
+			"PreparerDecision.Mode",
+			func(c context.Context, s Sink) {
+				EmitPreparerDecision(c, s, PreparerDecisionArgs{
+					Mode: events.PreparerDecisionModeInstrumentationOnly,
+				})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.PreparerDecisionPayload
+				_ = json.Unmarshal(p, &v)
+				if v.Mode != events.PreparerDecisionModeInstrumentationOnly {
+					t.Errorf("Mode = %q, want %q", v.Mode, events.PreparerDecisionModeInstrumentationOnly)
+				}
+			},
+		},
+		{
+			"DriftDetected.ReconciliationAction",
+			func(c context.Context, s Sink) {
+				EmitDriftDetected(c, s, DriftDetectedArgs{ReconciliationAction: "removed_x_from_state"})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.DriftDetectedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.ReconciliationAction != "removed_x_from_state" {
+					t.Errorf("ReconciliationAction = %q", v.ReconciliationAction)
+				}
+			},
+		},
+		{
+			"MessagesTruncated.DroppedCount",
+			func(c context.Context, s Sink) {
+				EmitMessagesTruncated(c, s, MessagesTruncatedArgs{
+					DroppedSeqFrom: 12, DroppedSeqTo: 18, DroppedCount: 7,
+				})
+			},
+			func(t *testing.T, p []byte) {
+				var v events.MessagesTruncatedPayload
+				_ = json.Unmarshal(p, &v)
+				if v.DroppedCount != 7 {
+					t.Errorf("DroppedCount = %d", v.DroppedCount)
+				}
+				if len(v.DroppedSeqRange) != 2 || v.DroppedSeqRange[0] != 12 || v.DroppedSeqRange[1] != 18 {
+					t.Errorf("DroppedSeqRange = %v, want [12, 18]", v.DroppedSeqRange)
 				}
 			},
 		},

--- a/internal/state/store/events/emit/lifecycle.go
+++ b/internal/state/store/events/emit/lifecycle.go
@@ -25,11 +25,16 @@ func EmitSummarizationTriggered(ctx context.Context, sink Sink, args Summarizati
 
 // SummarizationCompletedArgs is the post-summarization snapshot. Summary
 // is sanitized + excerpted; KeptMessages is the count of original
-// messages that survived past the summary boundary.
+// messages that survived past the summary boundary. ReleasedKnowledgeIDs
+// (RFC #249 Pillar C) lists the article_ids whose [knowledge_context]
+// blocks were inside the summarized-away range — the caller computes
+// them by scanning the soon-to-be-replaced message slice; empty when
+// summarization touched no KC-bearing messages.
 type SummarizationCompletedArgs struct {
-	Summary      string
-	KeptMessages int
-	LatencyMS    int64
+	Summary              string
+	KeptMessages         int
+	LatencyMS            int64
+	ReleasedKnowledgeIDs []string
 }
 
 // EmitSummarizationCompleted writes one summarization_completed event.
@@ -37,11 +42,12 @@ func EmitSummarizationCompleted(ctx context.Context, sink Sink, args Summarizati
 	sanitized := events.SanitizeUTF8(args.Summary)
 	excerpt, truncated := events.Excerpt(sanitized)
 	return send(ctx, sink, events.TypeSummarizationCompleted, events.SummarizationCompletedPayload{
-		Header:           events.Header{V: events.SummarizationCompletedVersion},
-		SummaryExcerpt:   excerpt,
-		SummaryTruncated: truncated,
-		KeptMessages:     args.KeptMessages,
-		LatencyMS:        args.LatencyMS,
+		Header:               events.Header{V: events.SummarizationCompletedVersion},
+		SummaryExcerpt:       excerpt,
+		SummaryTruncated:     truncated,
+		KeptMessages:         args.KeptMessages,
+		LatencyMS:            args.LatencyMS,
+		ReleasedKnowledgeIDs: args.ReleasedKnowledgeIDs,
 	}, args.LatencyMS)
 }
 

--- a/internal/state/store/events/emit/planner.go
+++ b/internal/state/store/events/emit/planner.go
@@ -74,4 +74,3 @@ func EmitPlannerStep(ctx context.Context, sink Sink, args PlannerStepArgs) strin
 		Note:      args.Note,
 	}, 0)
 }
-

--- a/internal/state/store/events/emit/planner.go
+++ b/internal/state/store/events/emit/planner.go
@@ -75,21 +75,3 @@ func EmitPlannerStep(ctx context.Context, sink Sink, args PlannerStepArgs) strin
 	}, 0)
 }
 
-// ToolRetrievalArgs carries one Weaviate (or other RAG backend) tool-
-// retrieval result set. Hits are stored in returned-rank order so a
-// consumer can compute position-based metrics without re-sorting.
-type ToolRetrievalArgs struct {
-	Query string
-	TopK  int
-	Hits  []events.ToolRetrievalHit
-}
-
-// EmitToolRetrieval writes one tool_retrieval event.
-func EmitToolRetrieval(ctx context.Context, sink Sink, args ToolRetrievalArgs) string {
-	return send(ctx, sink, events.TypeToolRetrieval, events.ToolRetrievalPayload{
-		Header: events.Header{V: events.ToolRetrievalVersion},
-		Query:  events.SanitizeUTF8(args.Query),
-		TopK:   args.TopK,
-		Hits:   args.Hits,
-	}, 0)
-}

--- a/internal/state/store/events/emit/preparer.go
+++ b/internal/state/store/events/emit/preparer.go
@@ -1,0 +1,222 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// Preparer-phase emit helpers (RFC #249). One file groups the six events
+// that fire from (or describe) the orchestrator's preparer pass:
+//
+//   - knowledge_retrieval / glossary_retrieval / tool_retrieval — one
+//     per RAG corpus searched on the current user turn, parented to the
+//     user_message event so a session timeline reads as a clean tree.
+//   - preparer_decision — the composite outcome (which candidates
+//     injected, which tools tier-promoted, etc.). Always emitted exactly
+//     once per turn; the Mode field discriminates Phase-2 instrumentation
+//     from Phase-3+ dedup behaviour.
+//   - drift_detected — emitted at the start of a preparer pass when the
+//     session's known-knowledge state and the actual visible message
+//     stream disagree (Phase 3+ only; helper exists now so the wiring
+//     site can land alongside the dedup logic without a schema bump).
+//   - messages_truncated — emitted when the sliding-window cutter drops
+//     messages from the LLM-bound message slice.
+//
+// EmitToolRetrieval used to live in planner.go but moves here because
+// tool retrieval is preparer-phase scope, not planner scope. Callers
+// keep the same function signature on this side of the move; the helper
+// gains search_text_source / min_score / latency_ms args to match the
+// dimensions the new knowledge / glossary retrievals carry.
+
+// KnowledgeRetrievalArgs carries the result of a knowledge-base RAG
+// search. Hits stay in returned-rank order so consumers can compute
+// position-based metrics without re-sorting.
+type KnowledgeRetrievalArgs struct {
+	Query            string
+	SearchTextSource string // events.SearchTextSource* — empty when unspecified
+	TopK             int
+	MinScore         float64
+	LatencyMS        int64
+	Hits             []events.KnowledgeRetrievalHit
+}
+
+// EmitKnowledgeRetrieval writes one knowledge_retrieval event. Hits are
+// sanitized per-element on the free-text fields (Title, Source) since
+// RAG-plugin output is upstream of Postgres' UTF-8 constraint and we
+// can't trust the corpus byte-for-byte.
+func EmitKnowledgeRetrieval(ctx context.Context, sink Sink, args KnowledgeRetrievalArgs) string {
+	return send(ctx, sink, events.TypeKnowledgeRetrieval, events.KnowledgeRetrievalPayload{
+		Header:           events.Header{V: events.KnowledgeRetrievalVersion},
+		Query:            events.SanitizeUTF8(args.Query),
+		SearchTextSource: args.SearchTextSource,
+		TopK:             args.TopK,
+		MinScore:         args.MinScore,
+		LatencyMS:        args.LatencyMS,
+		Hits:             sanitizeKnowledgeHits(args.Hits),
+	}, args.LatencyMS)
+}
+
+// sanitizeKnowledgeHits returns a copy of hits with free-text fields
+// scrubbed of invalid UTF-8. The input slice is not mutated.
+func sanitizeKnowledgeHits(hits []events.KnowledgeRetrievalHit) []events.KnowledgeRetrievalHit {
+	if len(hits) == 0 {
+		return hits
+	}
+	out := make([]events.KnowledgeRetrievalHit, len(hits))
+	for i, h := range hits {
+		h.Title = events.SanitizeUTF8(h.Title)
+		h.Source = events.SanitizeUTF8(h.Source)
+		out[i] = h
+	}
+	return out
+}
+
+// GlossaryRetrievalArgs mirrors KnowledgeRetrievalArgs; the only
+// difference is the per-hit "term" instead of "title".
+type GlossaryRetrievalArgs struct {
+	Query            string
+	SearchTextSource string
+	TopK             int
+	MinScore         float64
+	LatencyMS        int64
+	Hits             []events.GlossaryRetrievalHit
+}
+
+// EmitGlossaryRetrieval writes one glossary_retrieval event. Hits are
+// sanitized per-element analogous to EmitKnowledgeRetrieval.
+func EmitGlossaryRetrieval(ctx context.Context, sink Sink, args GlossaryRetrievalArgs) string {
+	return send(ctx, sink, events.TypeGlossaryRetrieval, events.GlossaryRetrievalPayload{
+		Header:           events.Header{V: events.GlossaryRetrievalVersion},
+		Query:            events.SanitizeUTF8(args.Query),
+		SearchTextSource: args.SearchTextSource,
+		TopK:             args.TopK,
+		MinScore:         args.MinScore,
+		LatencyMS:        args.LatencyMS,
+		Hits:             sanitizeGlossaryHits(args.Hits),
+	}, args.LatencyMS)
+}
+
+func sanitizeGlossaryHits(hits []events.GlossaryRetrievalHit) []events.GlossaryRetrievalHit {
+	if len(hits) == 0 {
+		return hits
+	}
+	out := make([]events.GlossaryRetrievalHit, len(hits))
+	for i, h := range hits {
+		h.Term = events.SanitizeUTF8(h.Term)
+		h.Source = events.SanitizeUTF8(h.Source)
+		out[i] = h
+	}
+	return out
+}
+
+// ToolRetrievalArgs carries the result of a tool RAG search.
+type ToolRetrievalArgs struct {
+	Query            string
+	SearchTextSource string
+	TopK             int
+	MinScore         float64
+	LatencyMS        int64
+	Hits             []events.ToolRetrievalHit
+}
+
+// EmitToolRetrieval writes one tool_retrieval event.
+//
+// The type exists since migration 009 but was never emitted before; per
+// the RFC #249 Phase 2 rollout the helper formally lives here from now
+// on (the trivial reachable-only-via-planner.go version is gone).
+func EmitToolRetrieval(ctx context.Context, sink Sink, args ToolRetrievalArgs) string {
+	return send(ctx, sink, events.TypeToolRetrieval, events.ToolRetrievalPayload{
+		Header:           events.Header{V: events.ToolRetrievalVersion},
+		Query:            events.SanitizeUTF8(args.Query),
+		SearchTextSource: args.SearchTextSource,
+		TopK:             args.TopK,
+		MinScore:         args.MinScore,
+		LatencyMS:        args.LatencyMS,
+		Hits:             args.Hits,
+	}, args.LatencyMS)
+}
+
+// PreparerDecisionArgs is the composite outcome the orchestrator landed
+// on for one preparer pass. Mode is one of the
+// events.PreparerDecisionMode* constants; callers in Phase 2 always pass
+// PreparerDecisionModeInstrumentationOnly, with Knowledge.Injected
+// listing all candidates and the dedup-state-related buckets empty.
+//
+// Phase 3+ callers flip Mode to "full" and start populating
+// Knowledge.SkippedKnown / ScoreOverridesApplied etc.; Phase 4 wires up
+// the Tools block. The helper has no opinion about the mode — it just
+// forwards what the caller assembles.
+type PreparerDecisionArgs struct {
+	Mode      string
+	Knowledge events.PreparerDecisionKnowledgeBlock
+	Tools     events.PreparerDecisionToolsBlock
+}
+
+// EmitPreparerDecision writes one preparer_decision event.
+func EmitPreparerDecision(ctx context.Context, sink Sink, args PreparerDecisionArgs) string {
+	return send(ctx, sink, events.TypePreparerDecision, events.PreparerDecisionPayload{
+		Header:    events.Header{V: events.PreparerDecisionVersion},
+		Mode:      args.Mode,
+		Knowledge: args.Knowledge,
+		Tools:     args.Tools,
+	}, 0)
+}
+
+// DriftDetectedArgs describes one drift between the in-state known-
+// knowledge set and the actual visible-message scan. ReconciliationAction
+// is free-form so future paths can record what they did without a schema
+// bump — see RFC #249 §Pillar A for the vocabulary today.
+//
+// Helper is defined now so Phase 3's reconciliation code can land
+// without a follow-up schema change; Phase 2 has no caller.
+type DriftDetectedArgs struct {
+	StateBelievedKnown   []string
+	ActuallyVisible      []string
+	MissingFromVisible   []string
+	ExtrasInVisible      []string
+	ReconciliationAction string
+}
+
+// EmitDriftDetected writes one drift_detected event.
+func EmitDriftDetected(ctx context.Context, sink Sink, args DriftDetectedArgs) string {
+	return send(ctx, sink, events.TypeDriftDetected, events.DriftDetectedPayload{
+		Header:               events.Header{V: events.DriftDetectedVersion},
+		StateBelievedKnown:   args.StateBelievedKnown,
+		ActuallyVisible:      args.ActuallyVisible,
+		MissingFromVisible:   args.MissingFromVisible,
+		ExtrasInVisible:      args.ExtrasInVisible,
+		ReconciliationAction: events.SanitizeUTF8(args.ReconciliationAction),
+	}, 0)
+}
+
+// MessagesTruncatedArgs describes one sliding-window cutter pass.
+// DroppedSeqRange is [from, to] inclusive indexed into sess.Messages
+// (position-based, since the in-memory message slice does not carry a
+// seq column). ReleasedKnowledgeIDs / RemainingKnownKnowledgeCount stay
+// empty/zero in Phase 2 — the dedup state that would populate them
+// arrives with Phase 3.
+type MessagesTruncatedArgs struct {
+	DroppedSeqFrom               int
+	DroppedSeqTo                 int
+	DroppedCount                 int
+	ReleasedKnowledgeIDs         []string
+	RemainingKnownKnowledgeCount int
+}
+
+// EmitMessagesTruncated writes one messages_truncated event. Callers
+// should only emit when DroppedCount > 0; the helper does not guard
+// against a no-op emit so the orchestrator's logic stays explicit.
+func EmitMessagesTruncated(ctx context.Context, sink Sink, args MessagesTruncatedArgs) string {
+	var seqRange []int
+	if args.DroppedCount > 0 {
+		seqRange = []int{args.DroppedSeqFrom, args.DroppedSeqTo}
+	}
+	return send(ctx, sink, events.TypeMessagesTruncated, events.MessagesTruncatedPayload{
+		Header:                       events.Header{V: events.MessagesTruncatedVersion},
+		DroppedSeqRange:              seqRange,
+		DroppedCount:                 args.DroppedCount,
+		ReleasedKnowledgeIDs:         args.ReleasedKnowledgeIDs,
+		RemainingKnownKnowledgeCount: args.RemainingKnownKnowledgeCount,
+	}, 0)
+}

--- a/internal/state/store/events/emit/turn.go
+++ b/internal/state/store/events/emit/turn.go
@@ -10,10 +10,20 @@ import (
 // are referenced by SHA256 — callers are responsible for upserting the
 // underlying content into prompt_snapshots before (or alongside) the
 // turn_start emission so a consumer can resolve the digest.
+//
+// RFC #249 Pillar C: InjectedKnowledge / PreparerDecisionID /
+// ToolTier1Count / ToolTier3Count cross-reference the preparer phase
+// emitted just before turn_start. Callers populate them from the
+// preparer aggregate stashed on ctx; pre-preparer-phase code paths
+// leave them zero/nil and the JSON payload omits them.
 type TurnStartArgs struct {
 	SystemPromptSHA256 string
 	ServerInstructions []events.ServerInstructionRef
 	AvailableTools     []events.ToolRef
+	InjectedKnowledge  []events.KnowledgeRef
+	PreparerDecisionID string
+	ToolTier1Count     int
+	ToolTier3Count     int
 	ModelID            string
 	Temperature        *float64
 	ReasoningEffort    string
@@ -28,6 +38,10 @@ func EmitTurnStart(ctx context.Context, sink Sink, args TurnStartArgs) string {
 		SystemPromptSHA256: args.SystemPromptSHA256,
 		ServerInstructions: args.ServerInstructions,
 		AvailableTools:     args.AvailableTools,
+		InjectedKnowledge:  args.InjectedKnowledge,
+		PreparerDecisionID: args.PreparerDecisionID,
+		ToolTier1Count:     args.ToolTier1Count,
+		ToolTier3Count:     args.ToolTier3Count,
 		ModelID:            args.ModelID,
 		Temperature:        args.Temperature,
 		ReasoningEffort:    args.ReasoningEffort,

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -462,6 +462,13 @@ type PreparerDecisionToolsBlock struct {
 	Tier1DemotedSticky        []string `json:"tier1_demoted_sticky,omitempty"`
 	Tier1SizeAfter            int      `json:"tier1_size_after,omitempty"`
 	Tier1Cap                  int      `json:"tier1_cap,omitempty"`
+	// Tier 2 is reseeded from RAG candidates every turn (no LRU
+	// carry / new distinction), so a single slice + size + cap is the
+	// full payload. Names emitted so consumers can verify the
+	// system-prompt render against what the orchestrator decided.
+	Tier2Tools                []string `json:"tier2_tools,omitempty"`
+	Tier2SizeAfter            int      `json:"tier2_size_after,omitempty"`
+	Tier2Cap                  int      `json:"tier2_cap,omitempty"`
 	Tier3TotalVisible         int      `json:"tier3_total_visible,omitempty"`
 	PromotedViaGetToolDetails []string `json:"promoted_via_get_tool_details,omitempty"`
 }

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -36,11 +36,23 @@ const (
 	TypeLLMResponse = "llm_response"
 
 	// Planner / orchestrator internals (debug-view or fold-default in UI).
-	TypePlannerInvoked         = "planner_invoked"
-	TypePlannerRequest         = "planner_request"
-	TypePlannerResponse        = "planner_response"
-	TypePlannerStep            = "planner_step"
-	TypeToolRetrieval          = "tool_retrieval"
+	TypePlannerInvoked  = "planner_invoked"
+	TypePlannerRequest  = "planner_request"
+	TypePlannerResponse = "planner_response"
+	TypePlannerStep     = "planner_step"
+
+	// Preparer-phase retrieval + decision events (RFC #249).
+	// Emitted children of user_message: each RAG retrieval becomes one
+	// *_retrieval event, then preparer_decision is the composite outcome
+	// the orchestrator landed on. drift_detected and messages_truncated
+	// are sibling-to-turn_start events on the rare paths where they fire.
+	TypeKnowledgeRetrieval = "knowledge_retrieval"
+	TypeGlossaryRetrieval  = "glossary_retrieval"
+	TypeToolRetrieval      = "tool_retrieval"
+	TypePreparerDecision   = "preparer_decision"
+	TypeDriftDetected      = "drift_detected"
+	TypeMessagesTruncated  = "messages_truncated"
+
 	TypeSummarizationTriggered = "summarization_triggered"
 	TypeSummarizationCompleted = "summarization_completed"
 	TypeModelSwitch            = "model_switch"
@@ -64,11 +76,53 @@ const (
 	TypeScoreComputed = "score_computed"
 )
 
-// PromptSnapshotKind values for prompt_snapshots.kind.
+// PromptSnapshotKind values for prompt_snapshots.kind. knowledge_article
+// is added by RFC #249: per-turn-injected knowledge bodies are stored
+// content-addressed alongside the existing system_prompt / tool_description
+// entries, so consumers resolve them through the same /prompt-snapshots
+// endpoint.
 const (
 	PromptKindSystemPrompt       = "system_prompt"
 	PromptKindServerInstructions = "server_instructions"
 	PromptKindToolDescription    = "tool_description"
+	PromptKindKnowledgeArticle   = "knowledge_article"
+)
+
+// PreparerDecisionMode values for PreparerDecisionPayload.Mode.
+//
+// instrumentation_only — Phase 2: events emit but dedup/tier logic is
+//
+//	disabled. All candidates pass through to the LLM unchanged; the event
+//	payload records what *would* be the decision had the dedup logic been
+//	active, with empty skipped_known / score_overrides_applied buckets.
+//
+// full — Phase 3+: dedup + tier logic active, payload reflects the
+//
+//	actual orchestrator decision for this turn.
+//
+// legacy_fallback — plugin returned only the legacy `message` field
+//
+//	(no structured candidates). The orchestrator forwards the plugin's
+//	injection verbatim; preparer_decision records the fall-through path
+//	for analytics. One deprecation warning per plugin per session is
+//	logged alongside.
+const (
+	PreparerDecisionModeInstrumentationOnly = "instrumentation_only"
+	PreparerDecisionModeFull                = "full"
+	PreparerDecisionModeLegacyFallback      = "legacy_fallback"
+)
+
+// KnowledgeRetrievalSearchTextSource values for the search_text_source
+// dimension on KnowledgeRetrievalPayload / GlossaryRetrievalPayload.
+//
+// user_input — raw user message bytes sent as the search query.
+// enriched — user message + recent conversation context concatenated
+//
+//	(see orchestrator's enriched-search-query path) so follow-ups like
+//	"both" or "yes" resolve to the right RAG hits.
+const (
+	SearchTextSourceUserInput = "user_input"
+	SearchTextSourceEnriched  = "enriched"
 )
 
 // ExcerptCap is the maximum byte length stored for raw LLM/tool-emitted
@@ -248,9 +302,12 @@ const PlannerStepVersion = 1
 // regression analysis can spot retrieval quality drift over time.
 type ToolRetrievalPayload struct {
 	Header
-	Query string             `json:"query"`
-	TopK  int                `json:"top_k"`
-	Hits  []ToolRetrievalHit `json:"hits"`
+	Query            string             `json:"query"`
+	SearchTextSource string             `json:"search_text_source,omitempty"`
+	TopK             int                `json:"top_k,omitempty"`
+	MinScore         float64            `json:"min_score,omitempty"`
+	LatencyMS        int64              `json:"latency_ms,omitempty"`
+	Hits             []ToolRetrievalHit `json:"hits"`
 }
 
 type ToolRetrievalHit struct {
@@ -258,7 +315,156 @@ type ToolRetrievalHit struct {
 	Score    float64 `json:"score"`
 }
 
-const ToolRetrievalVersion = 1
+// ToolRetrievalVersion bumped to 2 when the payload gained
+// search_text_source / min_score / latency_ms (RFC #249, Phase 2). No
+// v=1 rows exist in the wild — the type was declared in 009 but never
+// emitted before — so the bump is documentation hygiene rather than a
+// compatibility step.
+const ToolRetrievalVersion = 2
+
+// KnowledgeRetrievalPayload — Weaviate-backed knowledge-base RAG. Each
+// hit carries a content_sha256 so consumers can resolve the body via the
+// prompt_snapshots store (kind=knowledge_article). RFC #249.
+type KnowledgeRetrievalPayload struct {
+	Header
+	Query            string                  `json:"query"`
+	SearchTextSource string                  `json:"search_text_source,omitempty"`
+	TopK             int                     `json:"top_k,omitempty"`
+	MinScore         float64                 `json:"min_score,omitempty"`
+	LatencyMS        int64                   `json:"latency_ms,omitempty"`
+	Hits             []KnowledgeRetrievalHit `json:"hits"`
+}
+
+type KnowledgeRetrievalHit struct {
+	ArticleID     string  `json:"article_id"`
+	Title         string  `json:"title,omitempty"`
+	Score         float64 `json:"score"`
+	ContentSHA256 string  `json:"content_sha256,omitempty"`
+	Source        string  `json:"source,omitempty"` // "knowledge_base" | future per-tenant sources
+}
+
+const KnowledgeRetrievalVersion = 1
+
+// GlossaryRetrievalPayload — Weaviate-backed glossary RAG. Shape mirrors
+// KnowledgeRetrievalPayload; the only difference is per-hit "term"
+// instead of "title". RFC #249.
+type GlossaryRetrievalPayload struct {
+	Header
+	Query            string                 `json:"query"`
+	SearchTextSource string                 `json:"search_text_source,omitempty"`
+	TopK             int                    `json:"top_k,omitempty"`
+	MinScore         float64                `json:"min_score,omitempty"`
+	LatencyMS        int64                  `json:"latency_ms,omitempty"`
+	Hits             []GlossaryRetrievalHit `json:"hits"`
+}
+
+type GlossaryRetrievalHit struct {
+	Term          string  `json:"term"`
+	Score         float64 `json:"score"`
+	ContentSHA256 string  `json:"content_sha256,omitempty"`
+	Source        string  `json:"source,omitempty"`
+}
+
+const GlossaryRetrievalVersion = 1
+
+// PreparerDecisionPayload — composite outcome of the preparer phase. One
+// event per user turn, parented to the user_message. RFC #249.
+//
+// Mode is one of the PreparerDecisionMode* constants and discriminates
+// the meaning of the sub-blocks. In "instrumentation_only" mode all
+// candidates appear under Knowledge.Injected and Tools.Tier1New; the
+// skipped/evicted buckets are empty. In "full" mode the blocks reflect
+// the real dedup+tier decision.
+type PreparerDecisionPayload struct {
+	Header
+	Mode      string                         `json:"mode"`
+	Knowledge PreparerDecisionKnowledgeBlock `json:"knowledge"`
+	Tools     PreparerDecisionToolsBlock     `json:"tools"`
+}
+
+type PreparerDecisionKnowledgeBlock struct {
+	CandidateIDs          []string                        `json:"candidate_ids,omitempty"`
+	Injected              []PreparerDecisionInjectedItem  `json:"injected,omitempty"`
+	SkippedKnown          []PreparerDecisionSkippedItem   `json:"skipped_known,omitempty"`
+	SkippedBelowThreshold []string                        `json:"skipped_below_threshold,omitempty"`
+	ScoreOverridesApplied []PreparerDecisionScoreOverride `json:"score_overrides_applied,omitempty"`
+	InjectedBytes         int                             `json:"injected_bytes,omitempty"`
+}
+
+// PreparerDecisionInjectedItem records one injected knowledge article and
+// the reason it was selected. Reason values:
+//   - "new" — content_sha not yet known to the session
+//   - "score_override" — known but current score above reinject threshold
+//   - "top_k_force" — within the forced top-K of current-turn results
+//   - "instrumentation_only" — Phase 2: all candidates pass through
+type PreparerDecisionInjectedItem struct {
+	ArticleID     string `json:"article_id"`
+	ContentSHA256 string `json:"content_sha256,omitempty"`
+	Reason        string `json:"reason,omitempty"`
+}
+
+// PreparerDecisionSkippedItem records one candidate skipped by dedup.
+// Reason today is just "content_sha_already_known"; extend the vocabulary
+// here when new skip paths are added (e.g. "demoted").
+type PreparerDecisionSkippedItem struct {
+	ArticleID string `json:"article_id"`
+	Reason    string `json:"reason"`
+}
+
+type PreparerDecisionScoreOverride struct {
+	ArticleID    string  `json:"article_id"`
+	CurrentScore float64 `json:"current_score"`
+	Threshold    float64 `json:"threshold"`
+}
+
+type PreparerDecisionToolsBlock struct {
+	Tier0Count                int      `json:"tier0_count,omitempty"`
+	Tier1New                  []string `json:"tier1_new,omitempty"`
+	Tier1Carried              []string `json:"tier1_carried,omitempty"`
+	Tier1EvictedToTier3       []string `json:"tier1_evicted_to_tier3,omitempty"`
+	Tier1DemotedSticky        []string `json:"tier1_demoted_sticky,omitempty"`
+	Tier1SizeAfter            int      `json:"tier1_size_after,omitempty"`
+	Tier1Cap                  int      `json:"tier1_cap,omitempty"`
+	Tier3TotalVisible         int      `json:"tier3_total_visible,omitempty"`
+	PromotedViaGetToolDetails []string `json:"promoted_via_get_tool_details,omitempty"`
+}
+
+const PreparerDecisionVersion = 1
+
+// DriftDetectedPayload — emitted at the start of a preparer pass when
+// the in-state known-knowledge set and the actual visible-message scan
+// disagree. State is then rewritten to match the scan, and
+// ReconciliationAction describes what changed. RFC #249.
+//
+// Not emitted in Phase 2 (the dedup state doesn't exist yet); the
+// payload struct is defined now so Phase 3 can wire it without a schema
+// change.
+type DriftDetectedPayload struct {
+	Header
+	StateBelievedKnown   []string `json:"state_believed_known,omitempty"`
+	ActuallyVisible      []string `json:"actually_visible,omitempty"`
+	MissingFromVisible   []string `json:"missing_from_visible,omitempty"`
+	ExtrasInVisible      []string `json:"extras_in_visible,omitempty"`
+	ReconciliationAction string   `json:"reconciliation_action,omitempty"`
+}
+
+const DriftDetectedVersion = 1
+
+// MessagesTruncatedPayload — emitted when the sliding-window cutter
+// drops messages from the assembled LLM input. DroppedSeqRange is
+// [from, to] inclusive, indexed into sess.Messages (position-based,
+// since the in-memory provider.Message slice does not carry a seq
+// column). Phase 3 will populate ReleasedKnowledgeIDs / Remaining* once
+// the dedup state exists; in Phase 2 they stay empty/zero.
+type MessagesTruncatedPayload struct {
+	Header
+	DroppedSeqRange              []int    `json:"dropped_seq_range,omitempty"` // [from, to] inclusive
+	DroppedCount                 int      `json:"dropped_count"`
+	ReleasedKnowledgeIDs         []string `json:"released_knowledge_ids,omitempty"`
+	RemainingKnownKnowledgeCount int      `json:"remaining_known_knowledge_count,omitempty"`
+}
+
+const MessagesTruncatedVersion = 1
 
 type SummarizationTriggeredPayload struct {
 	Header

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -44,8 +44,12 @@ const (
 	// Preparer-phase retrieval + decision events (RFC #249).
 	// Emitted children of user_message: each RAG retrieval becomes one
 	// *_retrieval event, then preparer_decision is the composite outcome
-	// the orchestrator landed on. drift_detected and messages_truncated
-	// are sibling-to-turn_start events on the rare paths where they fire.
+	// the orchestrator landed on. drift_detected (Phase 3+) fires
+	// alongside the preparer pass; messages_truncated fires from
+	// buildMessages inside the agent loop and parents to turn_start
+	// (it can fire more than once per turn when the cutter applies on
+	// successive iterations as the conversation grows during tool
+	// rounds).
 	TypeKnowledgeRetrieval = "knowledge_retrieval"
 	TypeGlossaryRetrieval  = "glossary_retrieval"
 	TypeToolRetrieval      = "tool_retrieval"

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -89,7 +89,20 @@ const (
 	PromptKindSystemPrompt       = "system_prompt"
 	PromptKindServerInstructions = "server_instructions"
 	PromptKindToolDescription    = "tool_description"
-	PromptKindKnowledgeArticle   = "knowledge_article"
+	// PromptKindKnowledgeArticle is reserved for the content-addressed
+	// body of one [knowledge_context] block. The constant + payload
+	// kind value ship now so consumers can resolve the SHA carried in
+	// TurnStartPayload.InjectedKnowledge[].ContentSHA256 via the
+	// /prompt-snapshots endpoint once a producer exists. No orchestrator-
+	// side producer ships in RFC #249's initial scope — the bodies
+	// still live inline in the user message's [knowledge_context]
+	// envelope (parseable via internal/orchestrator's KC helpers), and
+	// reviewer-side rendering today resolves bodies that way. A
+	// snapshot-writer (orchestrator-side at dedup-injection time OR
+	// plugin-side at retrieval time) is tracked as a follow-up so
+	// existing call-sites don't pay a write per turn before consumers
+	// actually need it.
+	PromptKindKnowledgeArticle = "knowledge_article"
 )
 
 // PreparerDecisionMode values for PreparerDecisionPayload.Mode.
@@ -182,11 +195,22 @@ type Header struct {
 // TurnStartPayload — emitted once per orchestrator turn. References to
 // prompt content are by SHA256; bodies are persisted out-of-band in
 // prompt_snapshots so the same prompt costs one row across all sessions.
+//
+// RFC #249 Pillar C adds four references back into the preparer phase:
+// InjectedKnowledge / PreparerDecisionID / ToolTier1Count / ToolTier3Count.
+// These let consumers (review UIs, api-plugin aggregations) render the
+// turn's preparer outcome in-place without walking sibling events by
+// parent_id. All four are omitempty so pre-Phase-3 deployments and
+// no-preparer turns emit a payload byte-identical to the original shape.
 type TurnStartPayload struct {
 	Header
 	SystemPromptSHA256 string                 `json:"system_prompt_sha256,omitempty"`
 	ServerInstructions []ServerInstructionRef `json:"server_instructions,omitempty"`
 	AvailableTools     []ToolRef              `json:"available_tools,omitempty"`
+	InjectedKnowledge  []KnowledgeRef         `json:"injected_knowledge,omitempty"`
+	PreparerDecisionID string                 `json:"preparer_decision_id,omitempty"`
+	ToolTier1Count     int                    `json:"tool_tier1_count,omitempty"`
+	ToolTier3Count     int                    `json:"tool_tier3_count,omitempty"`
 	ModelID            string                 `json:"model_id"`
 	Temperature        *float64               `json:"temperature,omitempty"`
 	ReasoningEffort    string                 `json:"reasoning_effort,omitempty"`
@@ -200,6 +224,21 @@ type ServerInstructionRef struct {
 type ToolRef struct {
 	Name       string `json:"name"`
 	DescSHA256 string `json:"desc_sha256"`
+}
+
+// KnowledgeRef is the turn_start reference back to one knowledge article
+// injected into this turn's [knowledge_context] envelope. ContentSHA256
+// participates in the same content-addressed prompt_snapshots store as
+// SystemPromptSHA256 / DescSHA256 — once a producer writes a
+// PromptKindKnowledgeArticle snapshot, consumers can resolve the body
+// via /prompt-snapshots?sha=… without re-running RAG retrieval. Today
+// the snapshot writer for that kind is deferred (see the comment on
+// PromptKindKnowledgeArticle); the reference itself is durable
+// regardless, and the bodies remain readable inline in the user
+// message's [knowledge_context] block.
+type KnowledgeRef struct {
+	ArticleID     string `json:"article_id"`
+	ContentSHA256 string `json:"content_sha256"`
 }
 
 const TurnStartVersion = 1
@@ -524,6 +563,15 @@ type SummarizationCompletedPayload struct {
 	SummaryTruncated bool   `json:"summary_truncated,omitempty"`
 	KeptMessages     int    `json:"kept_messages"`
 	LatencyMS        int64  `json:"latency_ms,omitempty"`
+	// ReleasedKnowledgeIDs — article_ids whose [knowledge_context]
+	// blocks were inside the summarized-and-replaced range. The next
+	// preparer pass's reconciliation will drop them from
+	// known_knowledge anyway (visible-message scan is authoritative);
+	// the field exists so consumers correlating with InjectionState
+	// can render the release in-place without diffing two
+	// reconciliation snapshots. Empty when summarization replaced no
+	// messages carrying KC blocks.
+	ReleasedKnowledgeIDs []string `json:"released_knowledge_ids,omitempty"`
 }
 
 const SummarizationCompletedVersion = 1

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -395,12 +395,44 @@ type PreparerDecisionKnowledgeBlock struct {
 	InjectedBytes         int                             `json:"injected_bytes,omitempty"`
 }
 
+// PreparerDecisionReason values for PreparerDecisionInjectedItem.Reason
+// and PreparerDecisionSkippedItem.Reason. The "injected" group lists
+// the reasons a candidate ended up in the LLM-visible KC block; the
+// "skipped" group lists why a candidate didn't make it. Define one
+// constant per wire-format string so producers / consumers / docs all
+// agree, mirroring the PreparerDecisionMode* constants above.
+const (
+	// PreparerDecisionReasonInstrumentationOnly is the catch-all reason
+	// used during Phase 2 (and any later turn where dedup decision logic
+	// is disabled): every candidate is reported as if newly injected.
+	PreparerDecisionReasonInstrumentationOnly = "instrumentation_only"
+
+	// PreparerDecisionReasonNew — content_sha not yet known to the session.
+	PreparerDecisionReasonNew = "new"
+
+	// PreparerDecisionReasonScoreOverride — known SHA, but the
+	// current-turn score exceeded reinject_score_threshold.
+	PreparerDecisionReasonScoreOverride = "score_override"
+
+	// PreparerDecisionReasonTopKForce — known SHA, but the candidate's
+	// rank in the current retrieval is within reinject_top_k_force.
+	PreparerDecisionReasonTopKForce = "top_k_force"
+
+	// PreparerDecisionReasonAlreadyKnown — content_sha already in
+	// known_knowledge and none of the override paths fired. The LLM
+	// already saw this body in an earlier turn.
+	PreparerDecisionReasonAlreadyKnown = "content_sha_already_known"
+
+	// PreparerDecisionReasonCapExceeded — candidate WOULD have injected
+	// but cap_per_turn was already hit. Signal of per-turn budget
+	// pressure rather than dedup state.
+	PreparerDecisionReasonCapExceeded = "cap_exceeded"
+)
+
 // PreparerDecisionInjectedItem records one injected knowledge article and
-// the reason it was selected. Reason values:
-//   - "new" — content_sha not yet known to the session
-//   - "score_override" — known but current score above reinject threshold
-//   - "top_k_force" — within the forced top-K of current-turn results
-//   - "instrumentation_only" — Phase 2: all candidates pass through
+// the reason it was selected. Reason is one of the
+// PreparerDecisionReason* constants above (the "injected" group plus
+// PreparerDecisionReasonInstrumentationOnly).
 type PreparerDecisionInjectedItem struct {
 	ArticleID     string `json:"article_id"`
 	ContentSHA256 string `json:"content_sha256,omitempty"`
@@ -408,8 +440,9 @@ type PreparerDecisionInjectedItem struct {
 }
 
 // PreparerDecisionSkippedItem records one candidate skipped by dedup.
-// Reason today is just "content_sha_already_known"; extend the vocabulary
-// here when new skip paths are added (e.g. "demoted").
+// Reason is one of the PreparerDecisionReason* constants in the
+// "skipped" group (AlreadyKnown / CapExceeded). Future skip paths
+// (e.g. "demoted") extend that group above.
 type PreparerDecisionSkippedItem struct {
 	ArticleID string `json:"article_id"`
 	Reason    string `json:"reason"`

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -455,13 +455,13 @@ type PreparerDecisionScoreOverride struct {
 }
 
 type PreparerDecisionToolsBlock struct {
-	Tier0Count                int      `json:"tier0_count,omitempty"`
-	Tier1New                  []string `json:"tier1_new,omitempty"`
-	Tier1Carried              []string `json:"tier1_carried,omitempty"`
-	Tier1EvictedToTier3       []string `json:"tier1_evicted_to_tier3,omitempty"`
-	Tier1DemotedSticky        []string `json:"tier1_demoted_sticky,omitempty"`
-	Tier1SizeAfter            int      `json:"tier1_size_after,omitempty"`
-	Tier1Cap                  int      `json:"tier1_cap,omitempty"`
+	Tier0Count          int      `json:"tier0_count,omitempty"`
+	Tier1New            []string `json:"tier1_new,omitempty"`
+	Tier1Carried        []string `json:"tier1_carried,omitempty"`
+	Tier1EvictedToTier3 []string `json:"tier1_evicted_to_tier3,omitempty"`
+	Tier1DemotedSticky  []string `json:"tier1_demoted_sticky,omitempty"`
+	Tier1SizeAfter      int      `json:"tier1_size_after,omitempty"`
+	Tier1Cap            int      `json:"tier1_cap,omitempty"`
 	// Tier 2 is reseeded from RAG candidates every turn (no LRU
 	// carry / new distinction), so a single slice + size + cap is the
 	// full payload. Names emitted so consumers can verify the

--- a/internal/state/store/injection_state.go
+++ b/internal/state/store/injection_state.go
@@ -5,43 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+
+	"github.com/opentalon/opentalon/internal/state"
 )
-
-// InjectionState is the per-session knowledge / tool dedup bookkeeping
-// persisted in sessions.injection_state (migration 010). Phase 3
-// populates KnownKnowledge; KnownTools is reserved for Phase 4 and
-// stays empty on the Phase-3 write path.
-//
-// The on-disk format mirrors the RFC #249 shape — JSON-encoded TEXT,
-// not JSONB, so SQLite and PostgreSQL share one code path. New rows
-// (created before this column existed) default to '{}' so the zero-
-// valued struct represents "first turn, nothing known yet".
-type InjectionState struct {
-	KnownKnowledge []KnownKnowledgeEntry `json:"known_knowledge,omitempty"`
-	KnownTools     []KnownToolEntry      `json:"known_tools,omitempty"`
-}
-
-// KnownKnowledgeEntry is one knowledge-article chunk the orchestrator
-// has already seen this session. ContentSHA256 is the dedup key —
-// different chunks of the same article have different SHAs, so chunk-
-// level disjoint information correctly triggers re-injection.
-// ArticleID is auxiliary: O(1) lookup for truncation/summarization
-// release-paths and human-meaningful event-log strings.
-type KnownKnowledgeEntry struct {
-	ArticleID         string `json:"article_id"`
-	ContentSHA256     string `json:"content_sha256"`
-	FirstInjectedTurn int    `json:"first_injected_turn,omitempty"`
-}
-
-// KnownToolEntry is the Phase-4 tool-tier bookkeeping shape. Phase 3
-// readers unmarshal existing entries to preserve forward-compatible
-// rows, but the Phase-3 writer never produces a non-empty slice.
-type KnownToolEntry struct {
-	ToolName string `json:"tool_name"`
-	Tier     string `json:"tier"`
-	LRURank  int    `json:"lru_rank"`
-	Demoted  bool   `json:"demoted"`
-}
 
 // GetInjectionState returns the deserialized dedup state for sessionID.
 // An empty / NULL / "{}" column yields a zero-valued state without
@@ -56,9 +22,9 @@ type KnownToolEntry struct {
 // Missing sessions return a `session %q not found` error, matching the
 // shape SessionStore.Get returns. The underlying sql.ErrNoRows is not
 // chained — consistent with the existing package-level convention.
-func (s *SessionStore) GetInjectionState(ctx context.Context, sessionID string) (InjectionState, error) {
+func (s *SessionStore) GetInjectionState(ctx context.Context, sessionID string) (state.InjectionState, error) {
 	if sessionID == "" {
-		return InjectionState{}, fmt.Errorf("get injection state: session_id required")
+		return state.InjectionState{}, fmt.Errorf("get injection state: session_id required")
 	}
 	d := s.db.Dialect()
 	var raw string
@@ -67,19 +33,19 @@ func (s *SessionStore) GetInjectionState(ctx context.Context, sessionID string) 
 		sessionID,
 	).Scan(&raw)
 	if err == sql.ErrNoRows {
-		return InjectionState{}, fmt.Errorf("session %q not found", sessionID)
+		return state.InjectionState{}, fmt.Errorf("session %q not found", sessionID)
 	}
 	if err != nil {
-		return InjectionState{}, fmt.Errorf("get injection state: %w", err)
+		return state.InjectionState{}, fmt.Errorf("get injection state: %w", err)
 	}
 	if raw == "" || raw == "{}" {
-		return InjectionState{}, nil
+		return state.InjectionState{}, nil
 	}
-	var state InjectionState
-	if err := json.Unmarshal([]byte(raw), &state); err != nil {
-		return InjectionState{}, fmt.Errorf("get injection state: parse: %w", err)
+	var out state.InjectionState
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return state.InjectionState{}, fmt.Errorf("get injection state: parse: %w", err)
 	}
-	return state, nil
+	return out, nil
 }
 
 // UpdateInjectionState overwrites the persisted state for sessionID.
@@ -91,11 +57,11 @@ func (s *SessionStore) GetInjectionState(ctx context.Context, sessionID string) 
 // updated_at is intentionally NOT bumped here: injection_state churns
 // on every preparer pass and bumping the session-level timestamp would
 // fight with the legitimate per-message touches in AddMessage.
-func (s *SessionStore) UpdateInjectionState(ctx context.Context, sessionID string, state InjectionState) error {
+func (s *SessionStore) UpdateInjectionState(ctx context.Context, sessionID string, st state.InjectionState) error {
 	if sessionID == "" {
 		return fmt.Errorf("update injection state: session_id required")
 	}
-	payload, err := json.Marshal(state)
+	payload, err := json.Marshal(st)
 	if err != nil {
 		return fmt.Errorf("update injection state: marshal: %w", err)
 	}

--- a/internal/state/store/injection_state.go
+++ b/internal/state/store/injection_state.go
@@ -1,0 +1,115 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+)
+
+// InjectionState is the per-session knowledge / tool dedup bookkeeping
+// persisted in sessions.injection_state (migration 010). Phase 3
+// populates KnownKnowledge; KnownTools is reserved for Phase 4 and
+// stays empty on the Phase-3 write path.
+//
+// The on-disk format mirrors the RFC #249 shape — JSON-encoded TEXT,
+// not JSONB, so SQLite and PostgreSQL share one code path. New rows
+// (created before this column existed) default to '{}' so the zero-
+// valued struct represents "first turn, nothing known yet".
+type InjectionState struct {
+	KnownKnowledge []KnownKnowledgeEntry `json:"known_knowledge,omitempty"`
+	KnownTools     []KnownToolEntry      `json:"known_tools,omitempty"`
+}
+
+// KnownKnowledgeEntry is one knowledge-article chunk the orchestrator
+// has already seen this session. ContentSHA256 is the dedup key —
+// different chunks of the same article have different SHAs, so chunk-
+// level disjoint information correctly triggers re-injection.
+// ArticleID is auxiliary: O(1) lookup for truncation/summarization
+// release-paths and human-meaningful event-log strings.
+type KnownKnowledgeEntry struct {
+	ArticleID         string `json:"article_id"`
+	ContentSHA256     string `json:"content_sha256"`
+	FirstInjectedTurn int    `json:"first_injected_turn,omitempty"`
+}
+
+// KnownToolEntry is the Phase-4 tool-tier bookkeeping shape. Phase 3
+// readers unmarshal existing entries to preserve forward-compatible
+// rows, but the Phase-3 writer never produces a non-empty slice.
+type KnownToolEntry struct {
+	ToolName string `json:"tool_name"`
+	Tier     string `json:"tier"`
+	LRURank  int    `json:"lru_rank"`
+	Demoted  bool   `json:"demoted"`
+}
+
+// GetInjectionState returns the deserialized dedup state for sessionID.
+// An empty / NULL / "{}" column yields a zero-valued state without
+// error — the caller treats that as "first turn, nothing known yet".
+//
+// A row that exists but contains invalid JSON returns the parse error
+// so callers can decide between aborting the turn and dropping state
+// to start fresh. Phase 3 always picks "start fresh" to keep service
+// availability ahead of dedup correctness (see Orchestrator.applyKnowledgeDedup
+// once that lands).
+//
+// Missing sessions return a `session %q not found` error, matching the
+// shape SessionStore.Get returns. The underlying sql.ErrNoRows is not
+// chained — consistent with the existing package-level convention.
+func (s *SessionStore) GetInjectionState(ctx context.Context, sessionID string) (InjectionState, error) {
+	if sessionID == "" {
+		return InjectionState{}, fmt.Errorf("get injection state: session_id required")
+	}
+	d := s.db.Dialect()
+	var raw string
+	err := s.db.SQLDB().QueryRowContext(ctx,
+		d.Rebind(`SELECT COALESCE(injection_state, '{}') FROM sessions WHERE id = ?`),
+		sessionID,
+	).Scan(&raw)
+	if err == sql.ErrNoRows {
+		return InjectionState{}, fmt.Errorf("session %q not found", sessionID)
+	}
+	if err != nil {
+		return InjectionState{}, fmt.Errorf("get injection state: %w", err)
+	}
+	if raw == "" || raw == "{}" {
+		return InjectionState{}, nil
+	}
+	var state InjectionState
+	if err := json.Unmarshal([]byte(raw), &state); err != nil {
+		return InjectionState{}, fmt.Errorf("get injection state: parse: %w", err)
+	}
+	return state, nil
+}
+
+// UpdateInjectionState overwrites the persisted state for sessionID.
+// The whole struct is rewritten — callers are expected to merge before
+// calling, mirroring the read-modify-write pattern SetMetadata uses
+// for the metadata column.
+//
+// The serialized bytes go into the TEXT column added by migration 010.
+// updated_at is intentionally NOT bumped here: injection_state churns
+// on every preparer pass and bumping the session-level timestamp would
+// fight with the legitimate per-message touches in AddMessage.
+func (s *SessionStore) UpdateInjectionState(ctx context.Context, sessionID string, state InjectionState) error {
+	if sessionID == "" {
+		return fmt.Errorf("update injection state: session_id required")
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("update injection state: marshal: %w", err)
+	}
+	d := s.db.Dialect()
+	res, err := s.db.SQLDB().ExecContext(ctx,
+		d.Rebind(`UPDATE sessions SET injection_state = ? WHERE id = ?`),
+		string(payload), sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("update injection state: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("session %q not found", sessionID)
+	}
+	return nil
+}

--- a/internal/state/store/injection_state_test.go
+++ b/internal/state/store/injection_state_test.go
@@ -1,0 +1,235 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/config"
+)
+
+// freshSessionStore opens a temp-dir DB, creates a session, and returns
+// both the SessionStore and the session id. Used by every injection-
+// state test so the table-and-row plumbing stays out of the case
+// bodies.
+func freshSessionStore(t *testing.T) (*SessionStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	db, err := Open(config.DBConfig{}, dir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s := NewSessionStore(db, 0, 0)
+	sess := s.Create("sess-injection-test", "ent-1", "grp-1")
+	if sess == nil {
+		t.Fatal("Create returned nil session")
+	}
+	return s, sess.ID
+}
+
+func TestInjectionState_DefaultsToZeroValue(t *testing.T) {
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	state, err := s.GetInjectionState(ctx, id)
+	if err != nil {
+		t.Fatalf("GetInjectionState: %v", err)
+	}
+	if len(state.KnownKnowledge) != 0 || len(state.KnownTools) != 0 {
+		t.Errorf("fresh session must yield zero-valued state, got %+v", state)
+	}
+}
+
+func TestInjectionState_RoundTrip(t *testing.T) {
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	want := InjectionState{
+		KnownKnowledge: []KnownKnowledgeEntry{
+			{ArticleID: "kb_recurring-tickets", ContentSHA256: "9f3a", FirstInjectedTurn: 3},
+			{ArticleID: "kb_ticket-basics", ContentSHA256: "ab12", FirstInjectedTurn: 1},
+		},
+	}
+	if err := s.UpdateInjectionState(ctx, id, want); err != nil {
+		t.Fatalf("UpdateInjectionState: %v", err)
+	}
+	got, err := s.GetInjectionState(ctx, id)
+	if err != nil {
+		t.Fatalf("GetInjectionState: %v", err)
+	}
+	if len(got.KnownKnowledge) != 2 {
+		t.Fatalf("got %d known_knowledge entries, want 2", len(got.KnownKnowledge))
+	}
+	if got.KnownKnowledge[0].ContentSHA256 != "9f3a" || got.KnownKnowledge[1].FirstInjectedTurn != 1 {
+		t.Errorf("round-trip mismatch: %+v", got.KnownKnowledge)
+	}
+}
+
+func TestInjectionState_OverwritesPreviousState(t *testing.T) {
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	first := InjectionState{KnownKnowledge: []KnownKnowledgeEntry{{ArticleID: "kb_a", ContentSHA256: "aaa"}}}
+	if err := s.UpdateInjectionState(ctx, id, first); err != nil {
+		t.Fatalf("UpdateInjectionState first: %v", err)
+	}
+	second := InjectionState{KnownKnowledge: []KnownKnowledgeEntry{{ArticleID: "kb_b", ContentSHA256: "bbb"}}}
+	if err := s.UpdateInjectionState(ctx, id, second); err != nil {
+		t.Fatalf("UpdateInjectionState second: %v", err)
+	}
+	got, err := s.GetInjectionState(ctx, id)
+	if err != nil {
+		t.Fatalf("GetInjectionState: %v", err)
+	}
+	if len(got.KnownKnowledge) != 1 || got.KnownKnowledge[0].ArticleID != "kb_b" {
+		t.Errorf("overwrite expected only kb_b, got %+v", got.KnownKnowledge)
+	}
+}
+
+func TestInjectionState_PreservesPhase4Fields(t *testing.T) {
+	// Forward-compat guarantee: a row written with KnownTools entries
+	// (Phase 4 land) round-trips through GetInjectionState even though
+	// the Phase-3 writer never produces such entries. Lets Phase 4 land
+	// without a migration / data backfill.
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	want := InjectionState{
+		KnownTools: []KnownToolEntry{
+			{ToolName: "timly__list-items", Tier: "tier1", LRURank: 5, Demoted: false},
+			{ToolName: "timly__broken-action", Tier: "tier3", LRURank: 2, Demoted: true},
+		},
+	}
+	if err := s.UpdateInjectionState(ctx, id, want); err != nil {
+		t.Fatalf("UpdateInjectionState: %v", err)
+	}
+	got, err := s.GetInjectionState(ctx, id)
+	if err != nil {
+		t.Fatalf("GetInjectionState: %v", err)
+	}
+	if len(got.KnownTools) != 2 || got.KnownTools[1].Demoted != true {
+		t.Errorf("Phase-4 KnownTools round-trip mismatch: %+v", got.KnownTools)
+	}
+}
+
+func TestInjectionState_InvalidJSONIsReportedNotSwallowed(t *testing.T) {
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	d := s.db.Dialect()
+	if _, err := s.db.SQLDB().ExecContext(ctx,
+		d.Rebind(`UPDATE sessions SET injection_state = ? WHERE id = ?`),
+		"{not valid json", id,
+	); err != nil {
+		t.Fatalf("seed invalid json: %v", err)
+	}
+	_, err := s.GetInjectionState(ctx, id)
+	if err == nil {
+		t.Fatal("expected parse error for malformed injection_state, got nil")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("error must surface parse failure, got %v", err)
+	}
+}
+
+func TestInjectionState_MissingSessionReturnsError(t *testing.T) {
+	s, _ := freshSessionStore(t)
+	ctx := context.Background()
+	_, err := s.GetInjectionState(ctx, "does-not-exist")
+	if err == nil {
+		t.Fatal("expected not-found error, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error must signal not-found, got %v", err)
+	}
+	err = s.UpdateInjectionState(ctx, "does-not-exist", InjectionState{})
+	if err == nil {
+		t.Fatal("update on missing session must error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("update error must signal not-found, got %v", err)
+	}
+}
+
+func TestInjectionState_EmptyAndNilSlicesAreOmittedOnMarshal(t *testing.T) {
+	// Defensive guard against an `omitempty` tag-drift regression: both
+	// nil and non-nil-empty slices must serialize to "{}" so on-disk
+	// rows stay compact for sessions that have never run dedup.
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	cases := []struct {
+		name  string
+		state InjectionState
+	}{
+		{"nil-slices", InjectionState{}},
+		{"empty-non-nil-slices", InjectionState{
+			KnownKnowledge: []KnownKnowledgeEntry{},
+			KnownTools:     []KnownToolEntry{},
+		}},
+	}
+	d := s.db.Dialect()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.UpdateInjectionState(ctx, id, tc.state); err != nil {
+				t.Fatalf("UpdateInjectionState: %v", err)
+			}
+			var raw string
+			if err := s.db.SQLDB().QueryRowContext(ctx,
+				d.Rebind(`SELECT injection_state FROM sessions WHERE id = ?`), id,
+			).Scan(&raw); err != nil {
+				t.Fatalf("read raw: %v", err)
+			}
+			if raw != "{}" {
+				t.Errorf("on-disk row must collapse to %q, got %q", "{}", raw)
+			}
+		})
+	}
+}
+
+func TestInjectionState_DefaultObjectUnmarshalsToNilSlices(t *testing.T) {
+	// On a fresh session, the "{}" default produced by migration 010
+	// must yield nil (not zero-length) slices so producers can rely on
+	// `len(state.KnownKnowledge) == 0` as the "first turn" sentinel
+	// without worrying about nil-vs-empty semantics.
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	state, err := s.GetInjectionState(ctx, id)
+	if err != nil {
+		t.Fatalf("GetInjectionState: %v", err)
+	}
+	if state.KnownKnowledge != nil {
+		t.Errorf("KnownKnowledge must be nil for a fresh row, got %#v", state.KnownKnowledge)
+	}
+	if state.KnownTools != nil {
+		t.Errorf("KnownTools must be nil for a fresh row, got %#v", state.KnownTools)
+	}
+}
+
+func TestInjectionState_RejectsEmptySessionID(t *testing.T) {
+	s, _ := freshSessionStore(t)
+	ctx := context.Background()
+	if _, err := s.GetInjectionState(ctx, ""); err == nil || !strings.Contains(err.Error(), "session_id required") {
+		t.Errorf("Get with empty session_id must error explicitly, got %v", err)
+	}
+	if err := s.UpdateInjectionState(ctx, "", InjectionState{}); err == nil || !strings.Contains(err.Error(), "session_id required") {
+		t.Errorf("Update with empty session_id must error explicitly, got %v", err)
+	}
+}
+
+func TestInjectionState_EmptyStateMarshalsAsObject(t *testing.T) {
+	// Confirms json.Marshal of zero-value InjectionState produces "{}"
+	// — the omitempty tags keep the on-disk row compact, which
+	// matters because every session gets one of these rows from
+	// migration 010 onward.
+	s, id := freshSessionStore(t)
+	ctx := context.Background()
+	if err := s.UpdateInjectionState(ctx, id, InjectionState{}); err != nil {
+		t.Fatalf("UpdateInjectionState: %v", err)
+	}
+	d := s.db.Dialect()
+	var raw string
+	if err := s.db.SQLDB().QueryRowContext(ctx,
+		d.Rebind(`SELECT injection_state FROM sessions WHERE id = ?`), id,
+	).Scan(&raw); err != nil {
+		t.Fatalf("read raw: %v", err)
+	}
+	if raw != "{}" {
+		t.Errorf("zero-value must serialize to %q, got %q", "{}", raw)
+	}
+}

--- a/internal/state/store/injection_state_test.go
+++ b/internal/state/store/injection_state_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/config"
+	"github.com/opentalon/opentalon/internal/state"
 )
 
 // freshSessionStore opens a temp-dir DB, creates a session, and returns
@@ -31,20 +32,20 @@ func freshSessionStore(t *testing.T) (*SessionStore, string) {
 func TestInjectionState_DefaultsToZeroValue(t *testing.T) {
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	state, err := s.GetInjectionState(ctx, id)
+	got, err := s.GetInjectionState(ctx, id)
 	if err != nil {
 		t.Fatalf("GetInjectionState: %v", err)
 	}
-	if len(state.KnownKnowledge) != 0 || len(state.KnownTools) != 0 {
-		t.Errorf("fresh session must yield zero-valued state, got %+v", state)
+	if len(got.KnownKnowledge) != 0 || len(got.KnownTools) != 0 {
+		t.Errorf("fresh session must yield zero-valued state, got %+v", got)
 	}
 }
 
 func TestInjectionState_RoundTrip(t *testing.T) {
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	want := InjectionState{
-		KnownKnowledge: []KnownKnowledgeEntry{
+	want := state.InjectionState{
+		KnownKnowledge: []state.KnownKnowledgeEntry{
 			{ArticleID: "kb_recurring-tickets", ContentSHA256: "9f3a", FirstInjectedTurn: 3},
 			{ArticleID: "kb_ticket-basics", ContentSHA256: "ab12", FirstInjectedTurn: 1},
 		},
@@ -67,11 +68,11 @@ func TestInjectionState_RoundTrip(t *testing.T) {
 func TestInjectionState_OverwritesPreviousState(t *testing.T) {
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	first := InjectionState{KnownKnowledge: []KnownKnowledgeEntry{{ArticleID: "kb_a", ContentSHA256: "aaa"}}}
+	first := state.InjectionState{KnownKnowledge: []state.KnownKnowledgeEntry{{ArticleID: "kb_a", ContentSHA256: "aaa"}}}
 	if err := s.UpdateInjectionState(ctx, id, first); err != nil {
 		t.Fatalf("UpdateInjectionState first: %v", err)
 	}
-	second := InjectionState{KnownKnowledge: []KnownKnowledgeEntry{{ArticleID: "kb_b", ContentSHA256: "bbb"}}}
+	second := state.InjectionState{KnownKnowledge: []state.KnownKnowledgeEntry{{ArticleID: "kb_b", ContentSHA256: "bbb"}}}
 	if err := s.UpdateInjectionState(ctx, id, second); err != nil {
 		t.Fatalf("UpdateInjectionState second: %v", err)
 	}
@@ -91,8 +92,8 @@ func TestInjectionState_PreservesPhase4Fields(t *testing.T) {
 	// without a migration / data backfill.
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	want := InjectionState{
-		KnownTools: []KnownToolEntry{
+	want := state.InjectionState{
+		KnownTools: []state.KnownToolEntry{
 			{ToolName: "timly__list-items", Tier: "tier1", LRURank: 5, Demoted: false},
 			{ToolName: "timly__broken-action", Tier: "tier3", LRURank: 2, Demoted: true},
 		},
@@ -138,7 +139,7 @@ func TestInjectionState_MissingSessionReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error must signal not-found, got %v", err)
 	}
-	err = s.UpdateInjectionState(ctx, "does-not-exist", InjectionState{})
+	err = s.UpdateInjectionState(ctx, "does-not-exist", state.InjectionState{})
 	if err == nil {
 		t.Fatal("update on missing session must error")
 	}
@@ -155,12 +156,12 @@ func TestInjectionState_EmptyAndNilSlicesAreOmittedOnMarshal(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
 		name  string
-		state InjectionState
+		state state.InjectionState
 	}{
-		{"nil-slices", InjectionState{}},
-		{"empty-non-nil-slices", InjectionState{
-			KnownKnowledge: []KnownKnowledgeEntry{},
-			KnownTools:     []KnownToolEntry{},
+		{"nil-slices", state.InjectionState{}},
+		{"empty-non-nil-slices", state.InjectionState{
+			KnownKnowledge: []state.KnownKnowledgeEntry{},
+			KnownTools:     []state.KnownToolEntry{},
 		}},
 	}
 	d := s.db.Dialect()
@@ -189,15 +190,15 @@ func TestInjectionState_DefaultObjectUnmarshalsToNilSlices(t *testing.T) {
 	// without worrying about nil-vs-empty semantics.
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	state, err := s.GetInjectionState(ctx, id)
+	got, err := s.GetInjectionState(ctx, id)
 	if err != nil {
 		t.Fatalf("GetInjectionState: %v", err)
 	}
-	if state.KnownKnowledge != nil {
-		t.Errorf("KnownKnowledge must be nil for a fresh row, got %#v", state.KnownKnowledge)
+	if got.KnownKnowledge != nil {
+		t.Errorf("KnownKnowledge must be nil for a fresh row, got %#v", got.KnownKnowledge)
 	}
-	if state.KnownTools != nil {
-		t.Errorf("KnownTools must be nil for a fresh row, got %#v", state.KnownTools)
+	if got.KnownTools != nil {
+		t.Errorf("KnownTools must be nil for a fresh row, got %#v", got.KnownTools)
 	}
 }
 
@@ -207,7 +208,7 @@ func TestInjectionState_RejectsEmptySessionID(t *testing.T) {
 	if _, err := s.GetInjectionState(ctx, ""); err == nil || !strings.Contains(err.Error(), "session_id required") {
 		t.Errorf("Get with empty session_id must error explicitly, got %v", err)
 	}
-	if err := s.UpdateInjectionState(ctx, "", InjectionState{}); err == nil || !strings.Contains(err.Error(), "session_id required") {
+	if err := s.UpdateInjectionState(ctx, "", state.InjectionState{}); err == nil || !strings.Contains(err.Error(), "session_id required") {
 		t.Errorf("Update with empty session_id must error explicitly, got %v", err)
 	}
 }
@@ -219,7 +220,7 @@ func TestInjectionState_EmptyStateMarshalsAsObject(t *testing.T) {
 	// migration 010 onward.
 	s, id := freshSessionStore(t)
 	ctx := context.Background()
-	if err := s.UpdateInjectionState(ctx, id, InjectionState{}); err != nil {
+	if err := s.UpdateInjectionState(ctx, id, state.InjectionState{}); err != nil {
 		t.Fatalf("UpdateInjectionState: %v", err)
 	}
 	d := s.db.Dialect()

--- a/internal/state/store/injection_state_test.go
+++ b/internal/state/store/injection_state_test.go
@@ -94,8 +94,8 @@ func TestInjectionState_PreservesPhase4Fields(t *testing.T) {
 	ctx := context.Background()
 	want := state.InjectionState{
 		KnownTools: []state.KnownToolEntry{
-			{ToolName: "timly__list-items", Tier: "tier1", LRURank: 5, Demoted: false},
-			{ToolName: "timly__broken-action", Tier: "tier3", LRURank: 2, Demoted: true},
+			{ToolName: "timly__list-items", Tier: state.KnownToolTier1, LRURank: 5, Demoted: false},
+			{ToolName: "timly__broken-action", Tier: state.KnownToolTier3, LRURank: 2, Demoted: true},
 		},
 	}
 	if err := s.UpdateInjectionState(ctx, id, want); err != nil {

--- a/internal/state/store/migrations/010_sessions_injection_state.sql
+++ b/internal/state/store/migrations/010_sessions_injection_state.sql
@@ -1,0 +1,11 @@
+-- Per-session injection state for the preparer-phase refactor (RFC #249).
+-- Holds the set of knowledge articles already injected and the tool-tier
+-- bookkeeping (Phase 3/4). Phase 2 ships the column so the schema is in
+-- place before any reader/writer is wired; the body stays at '{}' until
+-- Phase 3 enables the dedup logic that populates it.
+--
+-- TEXT (not JSONB) for SQLite/PostgreSQL portability — matches the
+-- convention established by 007/008/009. The column is JSON-shaped at
+-- the application layer; consumers parse it with the InjectionState Go
+-- struct in package state/store.
+ALTER TABLE sessions ADD COLUMN injection_state TEXT NOT NULL DEFAULT '{}';

--- a/internal/state/store/store_test.go
+++ b/internal/state/store/store_test.go
@@ -26,8 +26,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != 9 {
-		t.Errorf("schema_version = %d, want 9", v)
+	if v != 10 {
+		t.Errorf("schema_version = %d, want 10", v)
 	}
 
 	// Re-open: idempotent, no error
@@ -40,8 +40,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version (second open): %v", err)
 	}
-	if v != 9 {
-		t.Errorf("schema_version after re-open = %d, want 9", v)
+	if v != 10 {
+		t.Errorf("schema_version after re-open = %d, want 10", v)
 	}
 }
 

--- a/pkg/plugin/convert.go
+++ b/pkg/plugin/convert.go
@@ -24,6 +24,8 @@ func capsToProto(c CapabilitiesMsg) *pluginpb.PluginCapabilities {
 			Parameters:        params,
 			UserOnly:          a.UserOnly,
 			InjectContextArgs: a.InjectContextArgs,
+			AlwaysInclude:     a.AlwaysInclude,
+			ReadOnly:          a.ReadOnly,
 		}
 	}
 	glossary := make([]*pluginpb.GlossaryEntry, len(c.Glossary))

--- a/pkg/plugin/convert_test.go
+++ b/pkg/plugin/convert_test.go
@@ -112,6 +112,54 @@ func TestCapsToProto_UserOnly(t *testing.T) {
 	}
 }
 
+func TestCapsToProto_AlwaysInclude(t *testing.T) {
+	// Locks in the AlwaysInclude flow plugin SDK -> proto. Previously the
+	// flag existed in the proto + the host-side `orchestrator.Action`
+	// type, but `pkg/plugin.ActionMsg` and `capsToProto` did not surface
+	// it — so an external plugin built on this SDK had no way to declare
+	// AlwaysInclude=true. The host therefore could never pin a plugin-
+	// supplied action to Tier 0, regardless of what the plugin intended.
+	msg := CapabilitiesMsg{
+		Name:        "myplugin",
+		Description: "Test",
+		Actions: []ActionMsg{
+			{Name: "critical_action", Description: "Pinned", AlwaysInclude: true},
+			{Name: "regular_action", Description: "Normal"},
+		},
+	}
+	pb := capsToProto(msg)
+
+	if !pb.Actions[0].AlwaysInclude {
+		t.Error("critical_action should propagate AlwaysInclude=true to proto")
+	}
+	if pb.Actions[1].AlwaysInclude {
+		t.Error("regular_action should default to AlwaysInclude=false")
+	}
+}
+
+func TestCapsToProto_ReadOnly(t *testing.T) {
+	// Locks in the ReadOnly flow plugin SDK -> proto. The host short-
+	// circuits the confirmation gate when this is set: read_only actions
+	// execute without an "I'm about to execute X" prompt. Default is
+	// false so any action that doesn't opt in stays gated.
+	msg := CapabilitiesMsg{
+		Name:        "myplugin",
+		Description: "Test",
+		Actions: []ActionMsg{
+			{Name: "list_things", Description: "Pure query", ReadOnly: true},
+			{Name: "delete_thing", Description: "Mutation"},
+		},
+	}
+	pb := capsToProto(msg)
+
+	if !pb.Actions[0].ReadOnly {
+		t.Error("list_things should propagate ReadOnly=true to proto")
+	}
+	if pb.Actions[1].ReadOnly {
+		t.Error("delete_thing should default to ReadOnly=false")
+	}
+}
+
 func TestCapsToProto_Parameters(t *testing.T) {
 	msg := CapabilitiesMsg{
 		Name:        "myplugin",

--- a/pkg/plugin/protocol.go
+++ b/pkg/plugin/protocol.go
@@ -82,6 +82,21 @@ type ActionMsg struct {
 	Parameters        []ParameterMsg `json:"parameters,omitempty"`
 	InjectContextArgs []string       `json:"inject_context_args,omitempty"` // context arg names (e.g. "actor_id") the host injects before calling Execute
 	UserOnly          bool           `json:"user_only,omitempty"`           // if true, hidden from LLM and only invocable directly by the user
+	// AlwaysInclude is the RFC #249 Phase 4 pin-to-Tier-0 flag — when true
+	// the host's tier decision keeps this action in the LLM's `tools`
+	// array (full schema) regardless of RAG score. The pkg/plugin SDK
+	// surfaces it here so external plugins built on this SDK can declare
+	// it; internal/orchestrator/system_tools registers in-process actions
+	// against orchestrator.Action directly and bypasses this struct.
+	AlwaysInclude bool `json:"always_include,omitempty"`
+	// ReadOnly is true for actions that do not mutate any user-visible
+	// state (queries, lookups). The host's confirmation gate skips the
+	// "I'm about to execute X" prompt for these actions, eliminating the
+	// per-call user friction and the planner-narration LLM call that
+	// would otherwise fire on every list/show invocation. Default false
+	// — every action is treated as a potential write until the plugin
+	// declares otherwise.
+	ReadOnly bool `json:"read_only,omitempty"`
 }
 
 // ParameterMsg describes one parameter of an action.

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -98,6 +98,13 @@ message Action {
   repeated Parameter parameters = 3;
   bool user_only = 4; // if true, hidden from LLM and blocked from LLM-sourced calls; only invocable directly by the user
   repeated string inject_context_args = 5; // context arg names (e.g. "actor_id") the host injects from request context before calling Execute
+  // RFC #249 Phase 4 tool-tier flag: if true, the orchestrator pins this
+  // action into Tier 0 (always present in the LLM's `tools` array, full
+  // schema). RAG-derived scores still feed into the per-turn ranking for
+  // event diagnostics, but never demote an always_include action below
+  // Tier 0. Use for capabilities a plugin considers non-negotiable for
+  // its domain (e.g. an emergency-stop or session-reset action).
+  bool always_include = 6;
 }
 
 message Parameter {

--- a/proto/plugin.proto
+++ b/proto/plugin.proto
@@ -105,6 +105,17 @@ message Action {
   // Tier 0. Use for capabilities a plugin considers non-negotiable for
   // its domain (e.g. an emergency-stop or session-reset action).
   bool always_include = 6;
+  // If true, the action is a pure query — it does not mutate any state
+  // the user cares about. The orchestrator's per-tool-call confirmation
+  // gate short-circuits when this is set: read_only=true actions execute
+  // without prompting the user "I'm about to execute X, proceed?",
+  // which would otherwise be noise and burn an LLM round-trip for a
+  // narration that the user never needed to see. Default false — every
+  // action is treated as a potential write until the plugin declares
+  // otherwise. Plugins that aggregate upstream tools (e.g. the
+  // mcp-plugin) typically propagate this from the upstream protocol's
+  // own read-only hint (MCP: `annotations.readOnlyHint`).
+  bool read_only = 7;
 }
 
 message Parameter {

--- a/proto/pluginpb/plugin.pb.go
+++ b/proto/pluginpb/plugin.pb.go
@@ -534,6 +534,17 @@ type Action struct {
 	// Tier 0. Use for capabilities a plugin considers non-negotiable for
 	// its domain (e.g. an emergency-stop or session-reset action).
 	AlwaysInclude bool `protobuf:"varint,6,opt,name=always_include,json=alwaysInclude,proto3" json:"always_include,omitempty"`
+	// If true, the action is a pure query — it does not mutate any state
+	// the user cares about. The orchestrator's per-tool-call confirmation
+	// gate short-circuits when this is set: read_only=true actions execute
+	// without prompting the user "I'm about to execute X, proceed?",
+	// which would otherwise be noise and burn an LLM round-trip for a
+	// narration that the user never needed to see. Default false — every
+	// action is treated as a potential write until the plugin declares
+	// otherwise. Plugins that aggregate upstream tools (e.g. the
+	// mcp-plugin) typically propagate this from the upstream protocol's
+	// own read-only hint (MCP: `annotations.readOnlyHint`).
+	ReadOnly      bool `protobuf:"varint,7,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -606,6 +617,13 @@ func (x *Action) GetInjectContextArgs() []string {
 func (x *Action) GetAlwaysInclude() bool {
 	if x != nil {
 		return x.AlwaysInclude
+	}
+	return false
+}
+
+func (x *Action) GetReadOnly() bool {
+	if x != nil {
+		return x.ReadOnly
 	}
 	return false
 }
@@ -725,7 +743,7 @@ const file_plugin_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x18\n" +
 	"\acontent\x18\x03 \x01(\tR\acontent\x12\x12\n" +
-	"\x04tags\x18\x04 \x03(\tR\x04tags\"\xf2\x01\n" +
+	"\x04tags\x18\x04 \x03(\tR\x04tags\"\x8f\x02\n" +
 	"\x06Action\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12>\n" +
@@ -734,7 +752,8 @@ const file_plugin_proto_rawDesc = "" +
 	"parameters\x12\x1b\n" +
 	"\tuser_only\x18\x04 \x01(\bR\buserOnly\x12.\n" +
 	"\x13inject_context_args\x18\x05 \x03(\tR\x11injectContextArgs\x12%\n" +
-	"\x0ealways_include\x18\x06 \x01(\bR\ralwaysInclude\"q\n" +
+	"\x0ealways_include\x18\x06 \x01(\bR\ralwaysInclude\x12\x1b\n" +
+	"\tread_only\x18\a \x01(\bR\breadOnly\"q\n" +
 	"\tParameter\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x12\n" +

--- a/proto/pluginpb/plugin.pb.go
+++ b/proto/pluginpb/plugin.pb.go
@@ -527,8 +527,15 @@ type Action struct {
 	Parameters        []*Parameter           `protobuf:"bytes,3,rep,name=parameters,proto3" json:"parameters,omitempty"`
 	UserOnly          bool                   `protobuf:"varint,4,opt,name=user_only,json=userOnly,proto3" json:"user_only,omitempty"`                             // if true, hidden from LLM and blocked from LLM-sourced calls; only invocable directly by the user
 	InjectContextArgs []string               `protobuf:"bytes,5,rep,name=inject_context_args,json=injectContextArgs,proto3" json:"inject_context_args,omitempty"` // context arg names (e.g. "actor_id") the host injects from request context before calling Execute
-	unknownFields     protoimpl.UnknownFields
-	sizeCache         protoimpl.SizeCache
+	// RFC #249 Phase 4 tool-tier flag: if true, the orchestrator pins this
+	// action into Tier 0 (always present in the LLM's `tools` array, full
+	// schema). RAG-derived scores still feed into the per-turn ranking for
+	// event diagnostics, but never demote an always_include action below
+	// Tier 0. Use for capabilities a plugin considers non-negotiable for
+	// its domain (e.g. an emergency-stop or session-reset action).
+	AlwaysInclude bool `protobuf:"varint,6,opt,name=always_include,json=alwaysInclude,proto3" json:"always_include,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Action) Reset() {
@@ -594,6 +601,13 @@ func (x *Action) GetInjectContextArgs() []string {
 		return x.InjectContextArgs
 	}
 	return nil
+}
+
+func (x *Action) GetAlwaysInclude() bool {
+	if x != nil {
+		return x.AlwaysInclude
+	}
+	return false
 }
 
 type Parameter struct {
@@ -711,7 +725,7 @@ const file_plugin_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x18\n" +
 	"\acontent\x18\x03 \x01(\tR\acontent\x12\x12\n" +
-	"\x04tags\x18\x04 \x03(\tR\x04tags\"\xcb\x01\n" +
+	"\x04tags\x18\x04 \x03(\tR\x04tags\"\xf2\x01\n" +
 	"\x06Action\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12>\n" +
@@ -719,7 +733,8 @@ const file_plugin_proto_rawDesc = "" +
 	"parameters\x18\x03 \x03(\v2\x1e.opentalon.plugin.v1.ParameterR\n" +
 	"parameters\x12\x1b\n" +
 	"\tuser_only\x18\x04 \x01(\bR\buserOnly\x12.\n" +
-	"\x13inject_context_args\x18\x05 \x03(\tR\x11injectContextArgs\"q\n" +
+	"\x13inject_context_args\x18\x05 \x03(\tR\x11injectContextArgs\x12%\n" +
+	"\x0ealways_include\x18\x06 \x01(\bR\ralwaysInclude\"q\n" +
 	"\tParameter\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x02 \x01(\tR\vdescription\x12\x12\n" +


### PR DESCRIPTION
## Summary

RFC #249 end-to-end implementation in three layered phases on a single branch:

- **Phase 2** — comprehensive event instrumentation of the preparer layer (knowledge / glossary / tool retrieval + composite decision + drift events under the `user_message` parent).
- **Phase 3** — session-aware knowledge deduplication with `content_sha256`-keyed `KnownKnowledge` state, ID-tagged `[knowledge_context]` blocks, and a lazy visible-message reconciliation that emits `drift_detected` when persisted state and the LLM's actual context disagree.
- **Phase 4** — 3-tier tool visibility (Tier 0 pinned via `AlwaysInclude`, Tier 1 capped + LRU, Tier 2 names+summary, Tier 3 names-only), `_meta.get_tool_details` meta-tool that expands a Tier 2/3 tool back to Tier 1 (including a same-turn `cachedTools` refresh for native-tools-mode LLMs), and tool error tracking (`loop_cap_per_turn` warning injection + `sticky_demotion` self-heal).

Each phase is gated by a feature flag (`knowledge_dedup.enabled`, `tool_tiers.enabled`) so legacy deployments retain pre-RFC behaviour when flags are off.

Originally opened as Phase-2-only — Phases 3 and 4 landed as additional commits on the same branch, then a real-stack E2E sweep against Postgres + a live LLM endpoint + an MCP plugin server + Weaviate surfaced 10+ defects across the integrated chain, also folded in as atomic root-cause fixes with regression coverage.

## Scope

### Phase 2 — preparer-phase event instrumentation
| SHA | Scope |
|---|---|
| `50a8cc6` | event types + payload structs + migration 010 (`sessions.injection_state TEXT NOT NULL DEFAULT '{}'`) |
| `b4899bf` | `emit/preparer.go` with six helpers (`EmitKnowledgeRetrieval` / `EmitGlossaryRetrieval` / `EmitToolRetrieval` / `EmitPreparerDecision` / `EmitDriftDetected` / `EmitMessagesTruncated`) + cohort tests |
| `4d84149` | `preparerResponse` JSON shape extension (`KnowledgeCandidates` / `GlossaryCandidates` / `ToolCandidates` / `RetrievalMetrics`) — receive-side schema, backwards-compat for legacy plugins |
| `7fbed0f` | `runSinglePreparer` → `preparerOutcome` struct (pure refactor unlocks emit wiring) |
| `d6dce15` | wire emission into the preparer loop + parent-chain via `WithParent(user_message)` |
| `cab47e0` | consolidate two duplicate sliding-window blocks into one `applySlidingWindow` + emit `messages_truncated` |

### Phase 3 — session-aware knowledge dedup + lazy reconciliation
| SHA | Scope |
|---|---|
| `b75b733` | `internal/state.InjectionState` (`KnownKnowledge` / `KnownTools`) domain type + Postgres-backed `InjectionStateStore` |
| `3545e78` | `knowledge_dedup.enabled` config flag + `InjectionStateStore` interface wired to Orchestrator |
| `d9fa617` | `[knowledge_context id="..." sha="..."]…[/knowledge_context]` block format helpers + tests |
| `f93158d` | dedup decision logic (`applyKnowledgeDedup` / `prepareDedupDecision`) — `mode=full` |
| `9964402` | lazy visible-message reconciliation + `drift_detected` emission when persisted state disagrees with the actual `[knowledge_context]` SHAs in the message stream |
| `077968a` | `mode=legacy_fallback` when any preparer returns un-migrated shape — turn-atomicity preserved |
| `6300c69` | switch-over style for `applyKnowledgeDedup` (pure refactor) |

Dedup reason codes implemented end-to-end: `new`, `score_override`, `top_k_force`, `content_sha_already_known`, `cap_exceeded` as values on the `PreparerDecisionReason` axis (skipped vs injected buckets per the decision logic). Memory-stream drift surfaces as the separate top-level event type `drift_detected`, not as a candidate-skip reason — drift can fire on a turn with zero candidates so it deliberately doesn't share the per-candidate reason axis.

### Phase 4 — 3-tier tool visibility + meta-tool + error tracking
| SHA | Scope |
|---|---|
| `eb44ecf` | `tool_tiers` + `tool_error_handling` config flags + `Action.AlwaysInclude` manifest field |
| `f3b4cb7` | `applyToolTierDecision` / `prepareToolTierDecision` — Tier 0/1/2/3 split + LRU sort key `(Demoted asc, LRURank desc, Name asc)` |
| `ec6fffb` | system-prompt rendering for Tier 2 (name + one-line summary) and Tier 3 (names only) + `tier3_total_visible` budget |
| `e77a970` | `_meta.get_tool_details(name)` meta-tool — Tier 0 via `AlwaysInclude`, full-description fetch + Tier-1 promotion via `KnownToolEntry.LRURank` |
| `abedb83` | `recordToolOutcome` + `toolErrorTracker` — `loop_cap_per_turn` injects a system message after N same-tool errors in one turn; `sticky_demotion_threshold` flips `KnownToolEntry.Demoted=true` after N session errors and self-heals on first success |

### End-to-end hardening (real-stack integration sweep)

Defects surfaced by running the full chain against a live LLM + an MCP plugin server + Weaviate — patterns that didn't show up in unit tests because they live at trust boundaries or in cross-component plumbing:

| SHA | Defect |
|---|---|
| `219c29b` | Tier 2 was computed by `applyToolTierDecision` but `PreparerDecisionToolsBlock` had no `tier2_*` fields → invisible in the event log |
| `acdced8` | `Action.ReadOnly` plumbed end-to-end (proto + pluginpb + ActionMsg + Action + registry) + confirmation-gate short-circuit on read-only tools |
| `08b114a` | `registry.IsActionReadOnly` now applies the same candidate-list normalization as `executeCall`'s resolve loop, so mcp-plugin's `<server>__<tool>` action names match the gate |
| `b240a66` | `_meta` plugin namespace special-cased in `pluginAllowed` — pre-fix, any non-permissive profile got `plugin "_meta" is not available for this profile`, breaking the meta-tool promotion path entirely. Also marks `get_tool_details` as `ReadOnly: true`. |
| `889e2d1` | wire `promoted_via_get_tool_details` event payload — in-memory per-session recents cache, mutex-guarded, drain-on-read |
| `f7abac2` | same-turn `cachedTools` refresh after a successful `_meta.get_tool_details` call — native-tools-mode LLMs now see the promoted tool in the SAME turn's tools array rather than only the next turn (was the unwired half of the meta-tool contract) |
| `fe4dbf1` / `adfb9bb` | gofmt struct-alignment fixups for new struct fields |
| `0a79a02` | profile-gate the inspected plugin in `_meta.get_tool_details` so a profile-restricted plugin's description doesn't leak via the meta-tool. Surfaced by post-merge security review; mirrors the not-registered branch's `"plugin %q not found"` shape so denial is indistinguishable from non-existence. |
| `648494c` | RFC #249 Pillar C wiring: `turn_start` payload gains `InjectedKnowledge []KnowledgeRef` + `PreparerDecisionID` + `ToolTier1Count` + `ToolTier3Count` so consumers render the preparer outcome in-place. `messages_truncated` + `summarization_completed` now populate `released_knowledge_ids` from the dropped/summarized-away message range. `PromptKindKnowledgeArticle` doc-comment clarifies that an orchestrator-side snapshot writer is deferred follow-up. |

## Plugin protocol changes

- `proto/plugin.proto`: `Action.read_only` (skip confirmation for read-only actions), `Action.always_include` (pin to Tier 0)
- `pkg/plugin/protocol.go`: `ActionMsg.AlwaysInclude` + `ActionMsg.ReadOnly`
- `pkg/plugin/convert.go`: capability ↔ ActionMsg round-trip preserves both new fields

Plugin authors opt in only if they want either behaviour; defaults (`false` / `false`) preserve pre-RFC semantics.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all green
- [x] cohort coverage in `emit_test.go`: stamping, distinctive-field, sanitize, latency-mirror extended for all six new helpers
- [x] orchestrator integration tests added for: Phase-2 emit + parent-chain + multi-preparer aggregation; Phase-3 each of the six dedup reason codes + reconciliation drift + legacy-fallback atomicity; Phase-4 tier assignment + LRU eviction + `AlwaysInclude` pin + `get_tool_details` promotion (state + cache + same-turn refresh) + error tracking (loop_cap warning injection + sticky_demotion / self-heal)

## Local E2E validation (real LLM + MCP plugin + Weaviate)

Validated end-to-end in a local-stack integration sweep:

- All six dedup reason codes (`drift_detected` via synthetic SHA injected into `sessions.injection_state`)
- Tier 0/1/2/3 distribution + LRU `tier1_evicted_to_tier3` transitions across multi-turn sessions
- `_meta.get_tool_details` full chain: profile-gate-bypass, ReadOnly short-circuit, promotion-cache write, same-turn `cachedTools` refresh (verified: tools array `11 → 12` in the next LLM request of the same turn)
- Read-only short-circuit eliminates confirmation roundtrip for all read-only tools

`loop_cap_per_turn` and `sticky_demotion_threshold`: unit-test-covered only. Natural reproduction is blocked because real LLMs don't loop after a single error — a deterministic always-fails test plugin is the clean path (follow-up, not in this PR).

## Notes for reviewers

- Commits are atomic with their own root-cause documentation; no squashing planned because several carry non-trivial design decisions (in particular `b240a66` argues why `_meta` must always pass the profile gate, and `f7abac2` documents the native-tools-mode-vs-text-tool-call asymmetry).
- Intentional deviations from the RFC literal text are inline-documented on the relevant struct/migration: `latency_ms` field names (Go-idiomatic), TEXT-not-JSONB column (SQLite/Postgres portability), `RetrievalMetrics` envelope on `preparerResponse` (cleanest way to publish per-corpus dimensions without duplicating them on every candidate).
- 44 files, +9082 / -152.

Refs: opentalon/opentalon#249

