### PR TITLE
fix(events): capture StructuredContent on tool_call_result

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3441,15 +3441,18 @@ func (o *Orchestrator) executeCall(ctx context.Context, call ToolCall) ToolResul
 	if call.FromLLM {
 		status := "ok"
 		respBody := result.Content
+		structBody := result.StructuredContent
 		if result.Error != "" {
 			status = "error"
 			respBody = result.Error
+			structBody = ""
 		}
 		emit.EmitToolCallResult(ctx, o.eventSink, emit.ToolCallResultArgs{
-			CallID:    call.ID,
-			Status:    status,
-			Response:  respBody,
-			LatencyMS: time.Since(dispatchStart).Milliseconds(),
+			CallID:     call.ID,
+			Status:     status,
+			Response:   respBody,
+			Structured: structBody,
+			LatencyMS:  time.Since(dispatchStart).Milliseconds(),
 		})
 	}
 	return result

--- a/internal/orchestrator/orchestrator_session_events_test.go
+++ b/internal/orchestrator/orchestrator_session_events_test.go
@@ -663,6 +663,26 @@ func (e *errorExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
 	return ToolResult{CallID: call.ID, Error: e.msg}
 }
 
+// structuredExecutor returns a ToolResult with both Content and
+// StructuredContent populated — exercises the audit-log capture of the
+// structured half that nativeToolContent appends to the LLM-bound
+// message. The optional errMsg lets one stub cover the defensive
+// "error result that happens to carry structured data" case.
+type structuredExecutor struct {
+	content    string
+	structured string
+	errMsg     string
+}
+
+func (s *structuredExecutor) Execute(_ context.Context, call ToolCall) ToolResult {
+	return ToolResult{
+		CallID:            call.ID,
+		Content:           s.content,
+		StructuredContent: s.structured,
+		Error:             s.errMsg,
+	}
+}
+
 // findToolCallEvents collects all events of the given type into typed payloads.
 func findToolCallExtractedPayloads(t *testing.T, evs []emit.Event) []events.ToolCallExtractedPayload {
 	t.Helper()
@@ -819,6 +839,98 @@ func TestOrchestrator_ExecuteCall_ResultStatus_ErrorOnDispatchError(t *testing.T
 	}
 	if results[0].ResponseExcerpt != "exec blew up" {
 		t.Errorf("ResponseExcerpt = %q, want %q", results[0].ResponseExcerpt, "exec blew up")
+	}
+}
+
+// TestOrchestrator_ExecuteCall_PassesStructuredContent pins the
+// dispatch-site contract: when a tool returns a ToolResult with both
+// Content and StructuredContent populated, the emitted
+// tool_call_result event captures BOTH halves as independent excerpt
+// fields. A future copy-paste regression that drops Structured from
+// the ToolCallResultArgs payload fails this test.
+func TestOrchestrator_ExecuteCall_PassesStructuredContent(t *testing.T) {
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "structured",
+		Actions: []Action{{Name: "fetch"}},
+	}, &structuredExecutor{
+		content:    "human-readable summary",
+		structured: `{"items":[{"id":42}]}`,
+	})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	call := ToolCall{ID: "c1", Plugin: "structured", Action: "fetch", FromLLM: true}
+	res := orch.executeCall(context.Background(), call)
+	if res.Error != "" {
+		t.Fatalf("unexpected error result: %q", res.Error)
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "ok" {
+		t.Errorf("Status = %q, want ok", results[0].Status)
+	}
+	if results[0].ResponseExcerpt != "human-readable summary" {
+		t.Errorf("ResponseExcerpt = %q, want %q", results[0].ResponseExcerpt, "human-readable summary")
+	}
+	if results[0].StructuredExcerpt != `{"items":[{"id":42}]}` {
+		t.Errorf("StructuredExcerpt = %q, want raw JSON passthrough", results[0].StructuredExcerpt)
+	}
+	if results[0].ResponseTruncated || results[0].StructuredTruncated {
+		t.Errorf("unexpected truncation: resp=%v struct=%v", results[0].ResponseTruncated, results[0].StructuredTruncated)
+	}
+}
+
+// TestOrchestrator_ExecuteCall_ErrorClearsStructured pins the
+// error-path invariant: when a tool returns an error, the
+// tool_call_result event records the error message in
+// ResponseExcerpt and DOES NOT carry over a structured payload —
+// even if the ToolResult happens to have one populated. A
+// status:"error" event with structured_excerpt set would mislead
+// operators reading the audit log.
+func TestOrchestrator_ExecuteCall_ErrorClearsStructured(t *testing.T) {
+	sink := &recordingEventSink{}
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name:    "structured",
+		Actions: []Action{{Name: "fetch"}},
+	}, &structuredExecutor{
+		content:    "should be ignored",
+		structured: `{"partial":true}`,
+		errMsg:     "downstream blew up",
+	})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("sess", "", "")
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }},
+		registry, memory, sessions, OrchestratorOpts{EventSink: sink})
+
+	call := ToolCall{ID: "c1", Plugin: "structured", Action: "fetch", FromLLM: true}
+	if res := orch.executeCall(context.Background(), call); res.Error == "" {
+		t.Fatal("expected error result")
+	}
+
+	results := findToolCallResultPayloads(t, sink.snapshot())
+	if len(results) != 1 {
+		t.Fatalf("tool_call_result count = %d, want 1", len(results))
+	}
+	if results[0].Status != "error" {
+		t.Errorf("Status = %q, want error", results[0].Status)
+	}
+	if results[0].ResponseExcerpt != "downstream blew up" {
+		t.Errorf("ResponseExcerpt = %q, want error message", results[0].ResponseExcerpt)
+	}
+	if results[0].StructuredExcerpt != "" {
+		t.Errorf("StructuredExcerpt = %q on error path, want empty (partial structured data must not leak under status:error)", results[0].StructuredExcerpt)
 	}
 }
 

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -305,6 +305,55 @@ func TestEmitToolCallExtractedThenResult_ParentLinkage(t *testing.T) {
 	}
 }
 
+// TestEmitToolCallResult_DualFieldCapture pins the contract that the
+// human-readable Response and the raw Structured payload are captured
+// as independent excerpt fields, not merged. A merge would couple the
+// audit log to nativeToolContent's wire formatting; this test fails the
+// build if that boundary erodes.
+//
+// Empty-Structured shape is also asserted: omitempty must drop the
+// JSON keys entirely so an event before this fix (or any future
+// non-structured-returning tool) stays byte-identical on the wire.
+func TestEmitToolCallResult_DualFieldCapture(t *testing.T) {
+	t.Run("both fields captured independently", func(t *testing.T) {
+		sink := &fakeSink{}
+		EmitToolCallResult(context.Background(), sink, ToolCallResultArgs{
+			CallID: "c1", Status: "ok",
+			Response:   `OK`,
+			Structured: `{"items":[{"id":42}]}`,
+		})
+
+		raw := sink.snapshot()[0].Payload
+		var p events.ToolCallResultPayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if p.ResponseExcerpt != `OK` {
+			t.Errorf("ResponseExcerpt = %q, want %q", p.ResponseExcerpt, `OK`)
+		}
+		if p.StructuredExcerpt != `{"items":[{"id":42}]}` {
+			t.Errorf("StructuredExcerpt = %q, want raw JSON passthrough", p.StructuredExcerpt)
+		}
+		if p.ResponseTruncated || p.StructuredTruncated {
+			t.Errorf("unexpected truncation flag: resp=%v struct=%v", p.ResponseTruncated, p.StructuredTruncated)
+		}
+	})
+
+	t.Run("omitempty drops structured fields when unset", func(t *testing.T) {
+		sink := &fakeSink{}
+		EmitToolCallResult(context.Background(), sink, ToolCallResultArgs{
+			CallID: "c1", Status: "ok", Response: `plain text`,
+		})
+		body := string(sink.snapshot()[0].Payload)
+		if strings.Contains(body, `"structured_excerpt"`) {
+			t.Errorf("structured_excerpt key present on wire when Structured is empty; payload = %s", body)
+		}
+		if strings.Contains(body, `"structured_truncated"`) {
+			t.Errorf("structured_truncated key present on wire when Structured is empty; payload = %s", body)
+		}
+	})
+}
+
 func TestEmitToolCallNotFound_Minimal(t *testing.T) {
 	sink := &fakeSink{}
 	EmitToolCallNotFound(context.Background(), sink, "nonexistent.action")
@@ -533,6 +582,19 @@ func TestEmit_SanitizesAllFreeTextFields(t *testing.T) {
 			},
 		},
 		{
+			"ToolCallResult.StructuredExcerpt",
+			func(c context.Context, s Sink) {
+				EmitToolCallResult(c, s, ToolCallResultArgs{CallID: "c", Structured: invalidUTF8Raw})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.ToolCallResultPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.StructuredExcerpt
+			},
+		},
+		{
 			"ToolCallParseFailed.RawSnippet",
 			func(c context.Context, s Sink) {
 				EmitToolCallParseFailed(c, s, ToolCallParseFailedArgs{RawSnippet: invalidUTF8Raw})
@@ -674,6 +736,18 @@ func TestEmit_ExcerptAndTruncatedFlag_AllHelpers(t *testing.T) {
 				var v events.ToolCallResultPayload
 				_ = json.Unmarshal(p, &v)
 				return v.ResponseExcerpt, v.ResponseTruncated
+			},
+			true,
+		},
+		{
+			"ToolCallResult.Structured",
+			func(c context.Context, s Sink) {
+				EmitToolCallResult(c, s, ToolCallResultArgs{CallID: "c", Structured: long})
+			},
+			func(p []byte) (string, bool) {
+				var v events.ToolCallResultPayload
+				_ = json.Unmarshal(p, &v)
+				return v.StructuredExcerpt, v.StructuredTruncated
 			},
 			true,
 		},

--- a/internal/state/store/events/emit/tool.go
+++ b/internal/state/store/events/emit/tool.go
@@ -41,27 +41,37 @@ func EmitToolCallExtracted(ctx context.Context, sink Sink, args ToolCallExtracte
 }
 
 // ToolCallResultArgs is the dispatch outcome. Status follows plugin
-// convention ("ok" or "error"). Response is sanitized + excerpted; the
-// parent linkage to tool_call_extracted is carried on ctx via
-// emit.WithParent at the dispatch site.
+// convention ("ok" or "error"). Response is the human-readable half of
+// the tool result; Structured carries the raw structured-content half
+// (typically JSON) that the orchestrator appends to the LLM-bound
+// message via nativeToolContent. Both are sanitized + excerpted
+// independently so the event log captures the full picture without
+// duplicating nativeToolContent's wire formatting. The parent linkage
+// to tool_call_extracted is carried on ctx via emit.WithParent at the
+// dispatch site.
 type ToolCallResultArgs struct {
-	CallID    string
-	Status    string
-	Response  string
-	LatencyMS int64
+	CallID     string
+	Status     string
+	Response   string
+	Structured string
+	LatencyMS  int64
 }
 
 // EmitToolCallResult writes one tool_call_result event.
 func EmitToolCallResult(ctx context.Context, sink Sink, args ToolCallResultArgs) string {
-	sanitized := events.SanitizeUTF8(args.Response)
-	excerpt, truncated := events.Excerpt(sanitized)
+	sanitizedResp := events.SanitizeUTF8(args.Response)
+	respExcerpt, respTruncated := events.Excerpt(sanitizedResp)
+	sanitizedStruct := events.SanitizeUTF8(args.Structured)
+	structExcerpt, structTruncated := events.Excerpt(sanitizedStruct)
 	return send(ctx, sink, events.TypeToolCallResult, events.ToolCallResultPayload{
-		Header:            events.Header{V: events.ToolCallResultVersion},
-		CallID:            args.CallID,
-		Status:            args.Status,
-		ResponseExcerpt:   excerpt,
-		ResponseTruncated: truncated,
-		LatencyMS:         args.LatencyMS,
+		Header:              events.Header{V: events.ToolCallResultVersion},
+		CallID:              args.CallID,
+		Status:              args.Status,
+		ResponseExcerpt:     respExcerpt,
+		ResponseTruncated:   respTruncated,
+		StructuredExcerpt:   structExcerpt,
+		StructuredTruncated: structTruncated,
+		LatencyMS:           args.LatencyMS,
 	}, args.LatencyMS)
 }
 

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -331,13 +331,28 @@ const ToolCallExtractedVersion = 1
 // errors out. Status mirrors plugin convention ("ok" / "error"). Parent
 // event_id of the corresponding tool_call_extracted is linked via the
 // session_events.parent_id column, not duplicated in payload.
+//
+// Content/StructuredContent split mirrors the ToolResult shape: a tool
+// may return a human-readable response (Content) and a structured JSON
+// payload that gets appended to the LLM-bound message via
+// nativeToolContent. Both halves are captured here as independent
+// excerpts so the audit log records the full picture, not just the
+// human-readable half. Each field gets its own truncation flag because
+// a 500-byte response with a 50 KB JSON tail is a realistic shape.
+//
+// StructuredExcerpt is forensic-only — when truncated it is cut at a
+// byte boundary and is therefore NOT guaranteed to be valid JSON.
+// Consumers must check structured_truncated before attempting to
+// parse, and treat the field as an opaque prefix when the flag is set.
 type ToolCallResultPayload struct {
 	Header
-	CallID            string `json:"call_id"`
-	Status            string `json:"status"`
-	ResponseExcerpt   string `json:"response_excerpt"`
-	ResponseTruncated bool   `json:"response_truncated,omitempty"`
-	LatencyMS         int64  `json:"latency_ms,omitempty"`
+	CallID              string `json:"call_id"`
+	Status              string `json:"status"`
+	ResponseExcerpt     string `json:"response_excerpt"`
+	ResponseTruncated   bool   `json:"response_truncated,omitempty"`
+	StructuredExcerpt   string `json:"structured_excerpt,omitempty"`
+	StructuredTruncated bool   `json:"structured_truncated,omitempty"`
+	LatencyMS           int64  `json:"latency_ms,omitempty"`
 }
 
 const ToolCallResultVersion = 1


### PR DESCRIPTION
## Summary

- Add `structured_excerpt` + `structured_truncated` to `ToolCallResultPayload` as additive fields, sanitized and excerpted independently from the existing `response_excerpt` pair.
- Wire the dispatch call site at [internal/orchestrator/orchestrator.go:3448](https://github.com/opentalon/opentalon/blob/fix/tool-call-result-structured/internal/orchestrator/orchestrator.go#L3448) to pass both `result.Content` and `result.StructuredContent`. Refusal call site stays unchanged (refusal results carry only an error message). Error path clears the structured half so a partial result's JSON tail can't leak under `status:"error"`.
- Wire format stays byte-identical for tools that return no structured content (`omitempty` on both new fields). No schema change on `session_events`, no version bump.

Closes #253.

## Why

`tool_call_result.response_excerpt` recorded only the human-readable half of `ToolResult`. The structured half — appended to the LLM-bound message by `nativeToolContent` and stored verbatim into `messages.content` — was silently dropped from the event log. Operators reading session events saw "the LLM got N tokens of text" when the LLM actually got N + a JSON block. The new field closes that gap without coupling the audit-log schema to `nativeToolContent`'s wire formatting (no rendered concatenation, no `[structured]…[/structured]` envelope in the event).

## Design notes

- **Pattern match.** The new fields follow the established `<Name>Excerpt` + `<Name>Truncated` convention used by `LLMResponsePayload.RawContentExcerpt`, `PlannerResponsePayload.RawContentExcerpt`, and others.
- **Independent truncation.** A 500-byte response + 50 KB JSON tail flags `response_truncated:false, structured_truncated:true` — a single merged string would lose that distinction.
- **Forensic-only contract.** `StructuredExcerpt` is cut at a byte boundary on truncation and is therefore NOT guaranteed to be valid JSON — doc-comment makes that explicit. Consumers must check `structured_truncated` before parsing.

## Test plan

- [x] `TestEmitToolCallResult_DualFieldCapture` (emit-package) — happy path + `omitempty` wire-shape contract: empty Structured drops `structured_excerpt` and `structured_truncated` keys entirely.
- [x] Parameterized `TestEmit_SanitizesAllFreeTextFields` gains `ToolCallResult.StructuredExcerpt` — invalid UTF-8 sanitization before excerpting.
- [x] Parameterized `TestEmit_ExcerptAndTruncatedFlag_AllHelpers` gains `ToolCallResult.Structured` — oversize input correctly stamps the truncation flag.
- [x] `TestOrchestrator_ExecuteCall_PassesStructuredContent` (orchestrator) — dispatch-site regression guard, both halves flow through to the emitted event.
- [x] `TestOrchestrator_ExecuteCall_ErrorClearsStructured` — `status:"error"` events never carry a structured payload, even if the underlying `ToolResult` populated one.
- [x] `gofmt`, `go vet`, full `go test ./...` clean on master + this branch.