### PR TITLE
orchestrator: persist synthetic [LLM error] message on provider failure

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1896,6 +1896,19 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 		}
 		llmDuration := time.Since(llmStart)
 		if err != nil {
+			// Persist a synthetic assistant message so the AI-Sessions
+			// diagnostic page (Rails reads via api-plugin) surfaces the
+			// broken turn — without this row the conversation appears
+			// to simply end after the user's question with no
+			// acknowledgement. The live channel reply is handled
+			// separately by channel/handler.go's friendlyError() and
+			// dispatched via channel.Send, so live chat already shows
+			// a user-facing message; this row only patches the gap on
+			// the persisted-history side.
+			_ = sessions.AddMessage(sessionID, provider.Message{
+				Role:    provider.RoleAssistant,
+				Content: "[LLM error] The request could not be completed. Please try again.",
+			})
 			return nil, fmt.Errorf("LLM completion: %w", err)
 		}
 		// Stamp the just-emitted llm_response as parent for the rest of


### PR DESCRIPTION
## Summary

- When the LLM provider call inside `Run()` returns an error (OVH 5xx, connect refused, context deadline exceeded, …) the orchestrator now writes one synthetic `assistant`-role row into the `messages` table before propagating the error up. The `llm_error` event is unchanged.
- Without this row, the AI-Sessions diagnostic page (Rails reads via api-plugin's `messages` query) showed the conversation simply ending after the user question, with no acknowledgement that anything had failed. The live chat widget already surfaces a user-facing message via `channel/handler.go`'s `friendlyError()` → `channel.Send`; this patch only closes the gap on the persisted-history side.

## Why

The current failure mode is invisible. Sequence today on an OVH burst:

1. `o.llm.Complete()` returns `context deadline exceeded` after 120 s
2. `EmitLLMError` writes one `llm_error` event into `session_events` ✓
3. `Run()` returns `nil, fmt.Errorf("LLM completion: %w", err)`
4. handler.go logs `"handler run failed"` + builds an OutboundMessage via `friendlyError()` + returns `(msg, nil)`
5. registry.go's `direct send path` calls `ch.Send(ctx, resp)` — live chat sees text ✓
6. **`messages` table has no new row.** Rails `/ai_sessions/:id` view: conversation ends after the user's question with no follow-up.

Step 6 is what this PR fixes.

## Diff

Single block added at `internal/orchestrator/orchestrator.go:1899` (immediately before the existing `return nil, fmt.Errorf(...)`):

```go
_ = sessions.AddMessage(sessionID, provider.Message{
    Role:    provider.RoleAssistant,
    Content: "[LLM error] The request could not be completed. Please try again.",
})
```

Uses `RoleAssistant` (not a new `RoleError`) to keep the patch minimal — a dedicated role would require filtering it out from the LLM-context build (multiple call sites in `applySlidingWindow` / `messages := make(..., sess.Messages+4)`) plus provider-side encoding decisions. A follow-up adding `RoleError` + red error styling in the Rails view can come later.

## Test plan

Verified locally end-to-end by temporarily pointing `OVH_AI_ENDPOINTS_URL` at `http://127.0.0.1:1/v1` (connection refused) and sending a chat message:

- [x] `session_events` has the `llm_error` event (unchanged behaviour, regression check)
- [x] `messages` table now has the synthetic `assistant` row at the next seq with `[LLM error] The request could not be completed. Please try again.`
- [x] Rails `/ai_sessions/<id>` renders the failed turn with `ASSISTANT [LLM error] ...` visible in the conversation list (before this PR: nothing rendered after the user's question)
- [x] Live chat widget still gets the localised `friendlyError()` text via the unchanged `channel.Send` path
- [x] `go vet ./internal/orchestrator/...` clean
- [x] `go test ./internal/orchestrator/...` green (17.7 s)