### PR TITLE
feat(events): add `translation` event type + preparer-phase emit wiring

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -599,6 +599,34 @@ type preparerResponse struct {
 	// them. All fields are optional; missing values stay zero-valued
 	// in the corresponding *_retrieval events.
 	RetrievalMetrics *PreparerRetrievalMetrics `json:"retrieval_metrics,omitempty"`
+
+	// TranslatorEvents is an optional slice of translator invocations the
+	// plugin made during this preparer call. One entry per actual
+	// translator call (per-corpus, per-callsite); empty / nil when the
+	// plugin's translator is disabled or the input was already in the
+	// target language. The orchestrator emits one `translation` session
+	// event per entry, parented to the surrounding user_message. See
+	// opentalon/opentalon#256.
+	TranslatorEvents []PreparerTranslatorEvent `json:"translator_events,omitempty"`
+}
+
+// PreparerTranslatorEvent is one translator invocation captured by the
+// plugin and bubbled up to the orchestrator for emit. Field names mirror
+// emit.TranslationArgs so the orchestrator wiring is a 1:1 copy. Callsite
+// and Outcome are the wire-stable vocabularies declared in
+// events/event_types.go (TranslationCallsite* / TranslationOutcome*); the
+// orchestrator does not validate them — anything the plugin sends lands
+// in the audit row as-is so analytics can spot a misconfigured plugin
+// rather than have the row silently dropped.
+type PreparerTranslatorEvent struct {
+	Callsite             string  `json:"callsite"`
+	Outcome              string  `json:"outcome"`
+	SourceLangDetected   string  `json:"source_lang_detected,omitempty"`
+	SourceLangConfidence float64 `json:"source_lang_confidence,omitempty"`
+	TargetLang           string  `json:"target_lang"`
+	InputText            string  `json:"input_text,omitempty"`
+	OutputText           string  `json:"output_text,omitempty"`
+	DurationMS           int64   `json:"duration_ms,omitempty"`
 }
 
 // KnowledgeCandidate is one knowledge-base article returned by the
@@ -1313,6 +1341,14 @@ func (o *Orchestrator) Run(ctx context.Context, sessionID, userMessage string, f
 			// retrieval events for this preparer, then accumulate the
 			// candidate slices for the composite preparer_decision
 			// emitted after the loop.
+			//
+			// #256: emit translation events BEFORE the retrieval events
+			// so the per-session timeline reads in causal order (translate
+			// query → retrieve from each corpus). Plugin sends a slice
+			// because one preparer call can produce 1..N translator
+			// invocations (one per callsite — prepare_knowledge /
+			// prepare_actions / prepare_glossary / search).
+			o.emitPreparerTranslations(ctx, outcome.Response)
 			o.emitPreparerRetrievals(ctx, userMessage, searchSource, outcome.Response)
 			prepAgg.append(prep.Plugin, outcome.Response)
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -602,10 +602,12 @@ type preparerResponse struct {
 
 	// TranslatorEvents is an optional slice of translator invocations the
 	// plugin made during this preparer call. One entry per actual
-	// translator call (per-corpus, per-callsite); empty / nil when the
-	// plugin's translator is disabled or the input was already in the
-	// target language. The orchestrator emits one `translation` session
-	// event per entry, parented to the surrounding user_message. See
+	// translator call (per-corpus, per-callsite). Empty / nil when the
+	// plugin's translator is disabled (or absent) or the input was empty
+	// — `skipped_target_lang` IS emitted, since the row's presence
+	// records that the translator ran and decided to short-circuit. The
+	// orchestrator emits one `translation` session event per entry,
+	// parented to the surrounding user_message. See
 	// opentalon/opentalon#256.
 	TranslatorEvents []PreparerTranslatorEvent `json:"translator_events,omitempty"`
 }

--- a/internal/orchestrator/preparer_events.go
+++ b/internal/orchestrator/preparer_events.go
@@ -145,6 +145,29 @@ func (o *Orchestrator) emitPreparerRetrievals(ctx context.Context, query string,
 	}
 }
 
+// emitPreparerTranslations fires one `translation` event per entry in
+// pr.TranslatorEvents. The plugin's translator is the source of truth for
+// what counted as a call worth recording (typically: translator enabled
+// AND input text non-empty AND not skipped_disabled); the orchestrator's
+// only job here is the audit-row write. opentalon/opentalon#256.
+func (o *Orchestrator) emitPreparerTranslations(ctx context.Context, pr preparerResponse) {
+	if o.eventSink == nil || len(pr.TranslatorEvents) == 0 {
+		return
+	}
+	for _, te := range pr.TranslatorEvents {
+		emit.EmitTranslation(ctx, o.eventSink, emit.TranslationArgs{
+			Callsite:             te.Callsite,
+			Outcome:              te.Outcome,
+			SourceLangDetected:   te.SourceLangDetected,
+			SourceLangConfidence: te.SourceLangConfidence,
+			TargetLang:           te.TargetLang,
+			InputText:            te.InputText,
+			OutputText:           te.OutputText,
+			DurationMS:           te.DurationMS,
+		})
+	}
+}
+
 // emitPreparerDecision publishes the composite preparer-pass outcome
 // once per user turn. The shape of the Knowledge block depends on
 // whether agg.KnowledgeDedup is set:

--- a/internal/orchestrator/preparer_events_test.go
+++ b/internal/orchestrator/preparer_events_test.go
@@ -1,6 +1,8 @@
 package orchestrator
 
 import (
+	"context"
+	"encoding/json"
 	"reflect"
 	"testing"
 
@@ -92,4 +94,94 @@ func TestTurnStartRefsFromAggregate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestEmitPreparerTranslations covers the three contract clauses of the
+// translation-event fan-out (opentalon/opentalon#256):
+//   - one event per slice entry, in slice order
+//   - no event when the slice is empty/nil
+//   - field-for-field pass-through of every PreparerTranslatorEvent into
+//     the emitted TranslationPayload
+func TestEmitPreparerTranslations(t *testing.T) {
+	t.Run("no events when slice is empty", func(t *testing.T) {
+		sink := &recordingEventSink{}
+		o := &Orchestrator{eventSink: sink}
+		o.emitPreparerTranslations(context.Background(), preparerResponse{})
+		if got := len(sink.snapshot()); got != 0 {
+			t.Fatalf("emitted %d events for empty slice, want 0", got)
+		}
+	})
+
+	t.Run("one event per slice entry, field pass-through", func(t *testing.T) {
+		sink := &recordingEventSink{}
+		o := &Orchestrator{eventSink: sink}
+		o.emitPreparerTranslations(context.Background(), preparerResponse{
+			TranslatorEvents: []PreparerTranslatorEvent{
+				{
+					Callsite:             events.TranslationCallsitePrepare,
+					Outcome:              events.TranslationOutcomeTranslated,
+					SourceLangDetected:   "de",
+					SourceLangConfidence: 0.93,
+					TargetLang:           "en",
+					InputText:            "wieviele Items habe ich",
+					OutputText:           "how many items do I have",
+					DurationMS:           42,
+				},
+				{
+					Callsite:   events.TranslationCallsiteSearch,
+					Outcome:    events.TranslationOutcomeSkippedTargetLang,
+					TargetLang: "en",
+					InputText:  "list available tools",
+					OutputText: "list available tools",
+					DurationMS: 5,
+				},
+			},
+		})
+
+		evts := sink.snapshot()
+		if len(evts) != 2 {
+			t.Fatalf("got %d events, want 2", len(evts))
+		}
+		for _, e := range evts {
+			if e.EventType != events.TypeTranslation {
+				t.Errorf("EventType = %q, want %q", e.EventType, events.TypeTranslation)
+			}
+		}
+
+		var first events.TranslationPayload
+		if err := json.Unmarshal(evts[0].Payload, &first); err != nil {
+			t.Fatalf("unmarshal first: %v", err)
+		}
+		if first.Callsite != events.TranslationCallsitePrepare ||
+			first.Outcome != events.TranslationOutcomeTranslated ||
+			first.SourceLangDetected != "de" ||
+			first.SourceLangConfidence != 0.93 ||
+			first.TargetLang != "en" ||
+			first.DurationMS != 42 {
+			t.Errorf("first payload mismatch: %+v", first)
+		}
+		if first.InputExcerpt != "wieviele Items habe ich" || first.OutputExcerpt != "how many items do I have" {
+			t.Errorf("first excerpts mismatch: in=%q out=%q", first.InputExcerpt, first.OutputExcerpt)
+		}
+
+		var second events.TranslationPayload
+		if err := json.Unmarshal(evts[1].Payload, &second); err != nil {
+			t.Fatalf("unmarshal second: %v", err)
+		}
+		if second.Outcome != events.TranslationOutcomeSkippedTargetLang {
+			t.Errorf("second.Outcome = %q", second.Outcome)
+		}
+		if second.InputExcerpt != second.OutputExcerpt {
+			t.Errorf("skipped_target_lang: in/out should be equal; in=%q out=%q",
+				second.InputExcerpt, second.OutputExcerpt)
+		}
+	})
+
+	t.Run("nil eventSink is a no-op", func(t *testing.T) {
+		o := &Orchestrator{eventSink: nil}
+		// Should not panic.
+		o.emitPreparerTranslations(context.Background(), preparerResponse{
+			TranslatorEvents: []PreparerTranslatorEvent{{Callsite: "x"}},
+		})
+	})
 }

--- a/internal/state/store/events/emit/emit_test.go
+++ b/internal/state/store/events/emit/emit_test.go
@@ -535,6 +535,13 @@ func TestAllEmitHelpers_StampMatchingVersion(t *testing.T) {
 		{"ToolRetrieval", func(c context.Context, s Sink) { EmitToolRetrieval(c, s, ToolRetrievalArgs{}) }, events.TypeToolRetrieval, events.ToolRetrievalVersion},
 		{"KnowledgeRetrieval", func(c context.Context, s Sink) { EmitKnowledgeRetrieval(c, s, KnowledgeRetrievalArgs{}) }, events.TypeKnowledgeRetrieval, events.KnowledgeRetrievalVersion},
 		{"GlossaryRetrieval", func(c context.Context, s Sink) { EmitGlossaryRetrieval(c, s, GlossaryRetrievalArgs{}) }, events.TypeGlossaryRetrieval, events.GlossaryRetrievalVersion},
+		{"Translation", func(c context.Context, s Sink) {
+			EmitTranslation(c, s, TranslationArgs{
+				Callsite:   events.TranslationCallsiteSearch,
+				Outcome:    events.TranslationOutcomeTranslated,
+				TargetLang: "en",
+			})
+		}, events.TypeTranslation, events.TranslationVersion},
 		{"PreparerDecision", func(c context.Context, s Sink) {
 			EmitPreparerDecision(c, s, PreparerDecisionArgs{Mode: events.PreparerDecisionModeInstrumentationOnly})
 		}, events.TypePreparerDecision, events.PreparerDecisionVersion},
@@ -557,10 +564,10 @@ func TestAllEmitHelpers_StampMatchingVersion(t *testing.T) {
 		{"Error", func(c context.Context, s Sink) { EmitError(c, s, "where", "msg") }, events.TypeError, events.ErrorVersion},
 	}
 
-	// All 29 event types must be exercised — keep this in lockstep with
+	// All 30 event types must be exercised — keep this in lockstep with
 	// the constants in event_types.go. If you add a new event type and
 	// this count drops below it, add a row above.
-	const wantCases = 29
+	const wantCases = 30
 	if len(cases) != wantCases {
 		t.Fatalf("len(cases) = %d, want %d — keep TestAllEmitHelpers in sync with event_types.go", len(cases), wantCases)
 	}
@@ -808,6 +815,44 @@ func TestEmit_SanitizesAllFreeTextFields(t *testing.T) {
 					t.Fatalf("unmarshal: %v", err)
 				}
 				return v.Query
+			},
+		},
+		{
+			"Translation.InputText",
+			func(c context.Context, s Sink) {
+				EmitTranslation(c, s, TranslationArgs{
+					Callsite:   events.TranslationCallsiteSearch,
+					Outcome:    events.TranslationOutcomeTranslated,
+					TargetLang: "en",
+					InputText:  invalidUTF8Raw,
+					OutputText: "valid output",
+				})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.TranslationPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.InputExcerpt
+			},
+		},
+		{
+			"Translation.OutputText",
+			func(c context.Context, s Sink) {
+				EmitTranslation(c, s, TranslationArgs{
+					Callsite:   events.TranslationCallsiteSearch,
+					Outcome:    events.TranslationOutcomeTranslated,
+					TargetLang: "en",
+					InputText:  "valid input",
+					OutputText: invalidUTF8Raw,
+				})
+			},
+			func(t *testing.T, p []byte) string {
+				var v events.TranslationPayload
+				if err := json.Unmarshal(p, &v); err != nil {
+					t.Fatalf("unmarshal: %v", err)
+				}
+				return v.OutputExcerpt
 			},
 		},
 		{

--- a/internal/state/store/events/emit/translator.go
+++ b/internal/state/store/events/emit/translator.go
@@ -17,10 +17,11 @@ import (
 // TranslationOutcome* / TranslationCallsite* constants in that file.
 
 // TranslationArgs is the shape the orchestrator passes after unpacking
-// one TranslatorMetadata entry from a plugin's prepare/search response.
-// Field names mirror events.TranslationPayload exactly so the orchestrator
-// wiring stays a 1:1 struct copy with no rename layer; the helper handles
-// Excerpt + SanitizeUTF8 so callers can pass raw plugin bytes through.
+// one entry from a plugin's prepare-response `translator_events` slice
+// (orchestrator.PreparerTranslatorEvent). Field names mirror
+// events.TranslationPayload except for the InputText / OutputText pair,
+// which the helper itself runs through Excerpt + SanitizeUTF8 to produce
+// the InputExcerpt / OutputExcerpt fields that land in the payload.
 type TranslationArgs struct {
 	Callsite             string
 	Outcome              string

--- a/internal/state/store/events/emit/translator.go
+++ b/internal/state/store/events/emit/translator.go
@@ -1,0 +1,55 @@
+package emit
+
+import (
+	"context"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// Preparer-phase pre-processing emit helper. Translator runs inside a
+// plugin (today: weaviate-plugin's translateQuery), the plugin returns
+// per-call metadata in its RPC response, and the orchestrator emits one
+// translation event per entry — same pattern as the retrieval-event
+// helpers in preparer.go.
+//
+// Schema lives in event_types.go (TranslationPayload + TranslationVersion);
+// the wire-stable Outcome / Callsite vocabularies are the
+// TranslationOutcome* / TranslationCallsite* constants in that file.
+
+// TranslationArgs is the shape the orchestrator passes after unpacking
+// one TranslatorMetadata entry from a plugin's prepare/search response.
+// Field names mirror events.TranslationPayload exactly so the orchestrator
+// wiring stays a 1:1 struct copy with no rename layer; the helper handles
+// Excerpt + SanitizeUTF8 so callers can pass raw plugin bytes through.
+type TranslationArgs struct {
+	Callsite             string
+	Outcome              string
+	SourceLangDetected   string
+	SourceLangConfidence float64
+	TargetLang           string
+	InputText            string
+	OutputText           string
+	DurationMS           int64
+}
+
+// EmitTranslation writes one translation event. Free-text fields are
+// sanitised + capped; Truncated is set when either excerpt was clipped.
+// The returned event id is the parent for any downstream events the
+// caller chains via WithParent (none today, but consistent with the
+// other Emit* helpers' contract).
+func EmitTranslation(ctx context.Context, sink Sink, args TranslationArgs) string {
+	inputExcerpt, inputTruncated := events.Excerpt(events.SanitizeUTF8(args.InputText))
+	outputExcerpt, outputTruncated := events.Excerpt(events.SanitizeUTF8(args.OutputText))
+	return send(ctx, sink, events.TypeTranslation, events.TranslationPayload{
+		Header:               events.Header{V: events.TranslationVersion},
+		Callsite:             args.Callsite,
+		Outcome:              args.Outcome,
+		SourceLangDetected:   args.SourceLangDetected,
+		SourceLangConfidence: args.SourceLangConfidence,
+		TargetLang:           args.TargetLang,
+		InputExcerpt:         inputExcerpt,
+		OutputExcerpt:        outputExcerpt,
+		DurationMS:           args.DurationMS,
+		Truncated:            inputTruncated || outputTruncated,
+	}, args.DurationMS)
+}

--- a/internal/state/store/events/emit/translator_test.go
+++ b/internal/state/store/events/emit/translator_test.go
@@ -126,6 +126,44 @@ func TestEmitTranslation_FailedOutcomeZeroConfidence(t *testing.T) {
 	}
 }
 
+// TestEmitTranslation_FailedAfterSuccessfulDetect covers the failure mode
+// the weaviate-plugin actually emits in production: /detect succeeded
+// (lang + confidence populated), then /translate failed (network /5xx /
+// parse-err). The audit row must preserve the detect output so operators
+// can see what the detector saw even when the downstream call failed —
+// "translator detected German, then died" is materially different from
+// "translator died before knowing the language".
+func TestEmitTranslation_FailedAfterSuccessfulDetect(t *testing.T) {
+	sink := &fakeSink{}
+	EmitTranslation(context.Background(), sink, TranslationArgs{
+		Callsite:             events.TranslationCallsitePrepare,
+		Outcome:              events.TranslationOutcomeFailed,
+		SourceLangDetected:   "de",
+		SourceLangConfidence: 0.91,
+		TargetLang:           "en",
+		InputText:            "Wieviele Items habe ich",
+		OutputText:           "",
+		DurationMS:           2500,
+	})
+
+	var p events.TranslationPayload
+	if err := json.Unmarshal(sink.events[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Outcome != events.TranslationOutcomeFailed {
+		t.Errorf("Outcome = %q, want failed", p.Outcome)
+	}
+	if p.SourceLangDetected != "de" {
+		t.Errorf("SourceLangDetected = %q, want detect output preserved through failed translate", p.SourceLangDetected)
+	}
+	if p.SourceLangConfidence != 0.91 {
+		t.Errorf("SourceLangConfidence = %v, want detect confidence preserved", p.SourceLangConfidence)
+	}
+	if p.OutputExcerpt != "" {
+		t.Errorf("OutputExcerpt = %q, want empty for failed outcome", p.OutputExcerpt)
+	}
+}
+
 // TestEmitTranslation_ExcerptCap exercises the 4 KB clip: an 8 KB input
 // must be clipped, and Truncated must be set. The helper also clips the
 // output side, so we exercise both in one assertion.

--- a/internal/state/store/events/emit/translator_test.go
+++ b/internal/state/store/events/emit/translator_test.go
@@ -1,0 +1,157 @@
+package emit
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/opentalon/opentalon/internal/state/store/events"
+)
+
+// TestEmitTranslation_RoundTripTranslatedOutcome exercises the happy
+// path: a DE→EN translation produces a payload with both excerpts, a
+// non-zero confidence, and a non-zero duration.
+func TestEmitTranslation_RoundTripTranslatedOutcome(t *testing.T) {
+	sink := &fakeSink{}
+	EmitTranslation(context.Background(), sink, TranslationArgs{
+		Callsite:             events.TranslationCallsiteSearch,
+		Outcome:              events.TranslationOutcomeTranslated,
+		SourceLangDetected:   "de",
+		SourceLangConfidence: 0.93,
+		TargetLang:           "en",
+		InputText:            "wie viele Items habe ich",
+		OutputText:           "how many items do I have",
+		DurationMS:           42,
+	})
+
+	if len(sink.events) != 1 {
+		t.Fatalf("got %d events, want 1", len(sink.events))
+	}
+	evt := sink.events[0]
+	if evt.EventType != events.TypeTranslation {
+		t.Errorf("EventType = %q, want %q", evt.EventType, events.TypeTranslation)
+	}
+
+	var p events.TranslationPayload
+	if err := json.Unmarshal(evt.Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.V != events.TranslationVersion {
+		t.Errorf("V = %d, want %d", p.V, events.TranslationVersion)
+	}
+	if p.Callsite != events.TranslationCallsiteSearch {
+		t.Errorf("Callsite = %q", p.Callsite)
+	}
+	if p.Outcome != events.TranslationOutcomeTranslated {
+		t.Errorf("Outcome = %q", p.Outcome)
+	}
+	if p.SourceLangDetected != "de" || p.SourceLangConfidence != 0.93 {
+		t.Errorf("source lang/confidence = %q/%v", p.SourceLangDetected, p.SourceLangConfidence)
+	}
+	if p.TargetLang != "en" {
+		t.Errorf("TargetLang = %q", p.TargetLang)
+	}
+	if p.InputExcerpt != "wie viele Items habe ich" {
+		t.Errorf("InputExcerpt = %q", p.InputExcerpt)
+	}
+	if p.OutputExcerpt != "how many items do I have" {
+		t.Errorf("OutputExcerpt = %q", p.OutputExcerpt)
+	}
+	if p.DurationMS != 42 {
+		t.Errorf("DurationMS = %d", p.DurationMS)
+	}
+	if p.Truncated {
+		t.Errorf("Truncated = true, want false (inputs were short)")
+	}
+}
+
+// TestEmitTranslation_SkippedTargetLangOmitsOutput covers the "input is
+// already in target language" path: outcome is skipped_target_lang, the
+// OutputText typically equals InputText so the JSON carries equal
+// excerpts. Confidence reflects the detector's reading of the input.
+func TestEmitTranslation_SkippedTargetLangOmitsOutput(t *testing.T) {
+	sink := &fakeSink{}
+	EmitTranslation(context.Background(), sink, TranslationArgs{
+		Callsite:             events.TranslationCallsiteSearch,
+		Outcome:              events.TranslationOutcomeSkippedTargetLang,
+		SourceLangDetected:   "en",
+		SourceLangConfidence: 0.98,
+		TargetLang:           "en",
+		InputText:            "how many items",
+		OutputText:           "how many items",
+		DurationMS:           5,
+	})
+
+	var p events.TranslationPayload
+	if err := json.Unmarshal(sink.events[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Outcome != events.TranslationOutcomeSkippedTargetLang {
+		t.Errorf("Outcome = %q", p.Outcome)
+	}
+	if p.InputExcerpt != p.OutputExcerpt {
+		t.Errorf("input/output excerpts differ for skipped_target_lang: %q vs %q", p.InputExcerpt, p.OutputExcerpt)
+	}
+}
+
+// TestEmitTranslation_FailedOutcomeZeroConfidence covers the
+// translator-failed path: detect may have run (and recorded a confidence)
+// or may have failed outright (confidence stays 0). OutputText is empty.
+func TestEmitTranslation_FailedOutcomeZeroConfidence(t *testing.T) {
+	sink := &fakeSink{}
+	EmitTranslation(context.Background(), sink, TranslationArgs{
+		Callsite:             events.TranslationCallsitePrepare,
+		Outcome:              events.TranslationOutcomeFailed,
+		SourceLangDetected:   "",
+		SourceLangConfidence: 0,
+		TargetLang:           "en",
+		InputText:            "some text the translator could not process",
+		OutputText:           "",
+		DurationMS:           3000,
+	})
+
+	var p events.TranslationPayload
+	if err := json.Unmarshal(sink.events[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Outcome != events.TranslationOutcomeFailed {
+		t.Errorf("Outcome = %q", p.Outcome)
+	}
+	if p.OutputExcerpt != "" {
+		t.Errorf("OutputExcerpt = %q, want empty for failed outcome", p.OutputExcerpt)
+	}
+	if p.SourceLangConfidence != 0 {
+		t.Errorf("SourceLangConfidence = %v, want 0 for failed-detect", p.SourceLangConfidence)
+	}
+}
+
+// TestEmitTranslation_ExcerptCap exercises the 4 KB clip: an 8 KB input
+// must be clipped, and Truncated must be set. The helper also clips the
+// output side, so we exercise both in one assertion.
+func TestEmitTranslation_ExcerptCap(t *testing.T) {
+	big := strings.Repeat("a", 8*1024) // 8 KB ASCII
+
+	sink := &fakeSink{}
+	EmitTranslation(context.Background(), sink, TranslationArgs{
+		Callsite:   events.TranslationCallsiteSearch,
+		Outcome:    events.TranslationOutcomeTranslated,
+		TargetLang: "en",
+		InputText:  big,
+		OutputText: big,
+	})
+
+	var p events.TranslationPayload
+	if err := json.Unmarshal(sink.events[0].Payload, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(p.InputExcerpt) != events.ExcerptCap {
+		t.Errorf("InputExcerpt len = %d, want %d (capped)", len(p.InputExcerpt), events.ExcerptCap)
+	}
+	if len(p.OutputExcerpt) != events.ExcerptCap {
+		t.Errorf("OutputExcerpt len = %d, want %d (capped)", len(p.OutputExcerpt), events.ExcerptCap)
+	}
+	if !p.Truncated {
+		t.Errorf("Truncated = false, want true (both fields were clipped)")
+	}
+}

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -56,6 +56,13 @@ const (
 	TypePreparerDecision   = "preparer_decision"
 	TypeDriftDetected      = "drift_detected"
 	TypeMessagesTruncated  = "messages_truncated"
+	// Pre-retrieval translation step. One event per actual translator
+	// invocation inside a plugin's prepare/search path; multiple
+	// callsites in one turn (prepare_knowledge / prepare_actions /
+	// prepare_glossary) emit multiple events parented to the user_message.
+	// Disabled / target-language input produces no event — the row's
+	// presence already means "translator ran".
+	TypeTranslation = "translation"
 
 	TypeSummarizationTriggered = "summarization_triggered"
 	TypeSummarizationCompleted = "summarization_completed"
@@ -409,6 +416,60 @@ type GlossaryRetrievalHit struct {
 }
 
 const GlossaryRetrievalVersion = 1
+
+// TranslationPayload — preparer-phase pre-processing event. Records one
+// translator invocation in enough detail that the per-session diagnostic
+// page can render the cross-lingual normalisation step alongside the
+// retrieval events it precedes. See opentalon/opentalon#256.
+//
+// Callsite mirrors the Prometheus counter's label vocabulary so per-event
+// analytics joins cleanly against the aggregate dashboard. Outcome is one
+// of "translated" | "skipped_target_lang" | "failed"; the row's presence
+// already means "the translator ran", so "skipped_disabled" is not
+// emitted.
+//
+// Input/OutputExcerpt are produced via Excerpt() — 4 KB cap, Truncated
+// flag set when either was clipped. Same raw-capture rule as
+// LLMRequestPayload.RawPromptExcerpt: bytes are stored as captured,
+// SanitizeUTF8 only on UTF-8-invalid input.
+type TranslationPayload struct {
+	Header
+	Callsite             string  `json:"callsite"`
+	Outcome              string  `json:"outcome"`
+	SourceLangDetected   string  `json:"source_lang_detected,omitempty"`
+	SourceLangConfidence float64 `json:"source_lang_confidence,omitempty"`
+	TargetLang           string  `json:"target_lang"`
+	InputExcerpt         string  `json:"input_excerpt,omitempty"`
+	OutputExcerpt        string  `json:"output_excerpt,omitempty"`
+	DurationMS           int64   `json:"duration_ms,omitempty"`
+	Truncated            bool    `json:"truncated,omitempty"`
+}
+
+// TranslationOutcome values for TranslationPayload.Outcome. The set is
+// closed; new outcomes bump TranslationVersion. Mirror the Prom counter's
+// `result` label vocabulary minus `skipped_disabled` (no call → no event).
+const (
+	TranslationOutcomeTranslated       = "translated"
+	TranslationOutcomeSkippedTargetLang = "skipped_target_lang"
+	TranslationOutcomeFailed           = "failed"
+)
+
+// TranslationCallsite values for TranslationPayload.Callsite. Mirror the
+// Prom counter's `callsite` label so the per-event audit and the
+// aggregate dashboard share one disambiguator. The set documents what
+// today's weaviate-plugin emits; the orchestrator does not validate, so
+// new callsites or out-of-tree plugins can pass any string and the audit
+// row carries it verbatim.
+const (
+	TranslationCallsiteSearch             = "search"
+	TranslationCallsiteHybridSearch       = "hybrid_search"
+	TranslationCallsitePrepare            = "prepare"
+	TranslationCallsiteAskKnowledge       = "ask_knowledge"
+	TranslationCallsiteSearchInstructions = "search_instructions"
+	TranslationCallsiteDebugPrepare       = "debug_prepare"
+)
+
+const TranslationVersion = 1
 
 // PreparerDecisionPayload — composite outcome of the preparer phase. One
 // event per user turn, parented to the user_message. RFC #249.

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -57,11 +57,13 @@ const (
 	TypeDriftDetected      = "drift_detected"
 	TypeMessagesTruncated  = "messages_truncated"
 	// Pre-retrieval translation step. One event per actual translator
-	// invocation inside a plugin's prepare/search path; multiple
-	// callsites in one turn (prepare_knowledge / prepare_actions /
-	// prepare_glossary) emit multiple events parented to the user_message.
-	// Disabled / target-language input produces no event — the row's
-	// presence already means "translator ran".
+	// invocation inside a plugin's prepare/search path; the
+	// TranslationCallsite* constants enumerate the per-call disambiguator
+	// used in practice. A plugin that translates once per preparer call
+	// (today's weaviate-plugin) emits one event; a plugin that translates
+	// per-corpus emits multiple, all parented to the user_message.
+	// Translator-disabled and empty-input paths produce no event — the
+	// row's presence already means "the translator ran".
 	TypeTranslation = "translation"
 
 	TypeSummarizationTriggered = "summarization_triggered"

--- a/internal/state/store/events/event_types.go
+++ b/internal/state/store/events/event_types.go
@@ -451,9 +451,9 @@ type TranslationPayload struct {
 // closed; new outcomes bump TranslationVersion. Mirror the Prom counter's
 // `result` label vocabulary minus `skipped_disabled` (no call → no event).
 const (
-	TranslationOutcomeTranslated       = "translated"
+	TranslationOutcomeTranslated        = "translated"
 	TranslationOutcomeSkippedTargetLang = "skipped_target_lang"
-	TranslationOutcomeFailed           = "failed"
+	TranslationOutcomeFailed            = "failed"
 )
 
 // TranslationCallsite values for TranslationPayload.Callsite. Mirror the


### PR DESCRIPTION
Closes #256.

## Summary

Adds the `translation` event_type to `session_events` so the cross-lingual query translation step (today: weaviate-plugin's `translateQuery` against LibreTranslate) becomes visible on the per-session diagnostic page alongside the other preparer-phase events (`knowledge_retrieval`, `tool_retrieval`, `preparer_decision`, `drift_detected`).

Before: translator activity surfaces only in Prometheus counters (`translator_calls_total`, `translator_duration_seconds`). Debugging a DE-user-cannot-find-tool bug means hunting through Grafana aggregates.

After: every actual translator invocation produces one `session_events` row parented to `user_message`, with the detected language, confidence, callsite, outcome, in/out excerpts, and duration. Renderer in Timly Rails is a separate Timly-side follow-up; until then the UI gracefully falls back to its "unknown event_type" branch.

## Scope (this PR, opentalon-core)

**Phase 1 — event type + emit helper:**
- `internal/state/store/events/event_types.go`: `TypeTranslation`, `TranslationPayload`, `TranslationVersion=1`, plus the wire-stable `TranslationOutcome*` / `TranslationCallsite*` constants
- `internal/state/store/events/emit/translator.go`: `EmitTranslation` helper with `Excerpt` + `SanitizeUTF8` hygiene
- `emit_test.go` version matrix bumped to 30; two new UTF-8 sanitisation rows
- New `translator_test.go` covers all 3 outcomes + 4 KB cap

**Phase 3 — orchestrator wiring:**
- `preparerResponse` gains `TranslatorEvents []PreparerTranslatorEvent` (additive, omitempty, back-compat)
- `emitPreparerTranslations` fans the slice out, wired BEFORE `emitPreparerRetrievals` so the timeline reads in causal order (translate → retrieve)
- Three-subtest unit test in `preparer_events_test.go` pins: empty/nil slice = no emit, populated slice = field-for-field pass-through, nil sink = silent no-op

## Out of scope (separate)

- **Plugin-side population** of the new `translator_events` JSON field — filed in parallel on opentalon/weaviate-plugin (PR forthcoming). Pre-this-PR plugins stay back-compat: their unknown field gets ignored on the orchestrator side; post-this-PR plugins populating the field cause the event to fire.
- **Timly Rails renderer** for the new event_type — separate MR on the Timly side.
- **Translator caching across the 3-corpus prepare** — today the plugin calls LT once per preparer call (not three times as my original spec assumed); no perf work needed in this iteration.

## DB / api-plugin impact

Zero. `event_type` is `TEXT NOT NULL` (free-form), `payload` is `TEXT NOT NULL` (schema-less JSON). No DB migration. api-plugin's `/events`, `/sessions/{id}`, `/sessions/{id}/events` read surfaces pass the new rows through transparently.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — full suite green (32 packages, 4 new translation-specific tests)
- [x] Emit-matrix `TestAllEmitHelpers_StampMatchingVersion` bumped from 29 → 30, runs green
- [x] UTF-8 sanitisation paths exercised for both `input_excerpt` and `output_excerpt`
- [ ] End-to-end smoke against local-dev stack once the plugin PR ships