### PR TITLE
Replace EnsureSession with strict Load/Create split

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -776,8 +776,11 @@ func main() {
 
 	// Strict resume: surface "not found" up to the handler so it can emit
 	// session_expired to the client rather than silently auto-creating
-	// (the pre-refactor footgun that let UI and server drift apart).
-	loadSession := func(sessionKey string) error {
+	// (the pre-refactor footgun that let UI and server drift apart). The
+	// underlying SessionStore.Get already wraps state.ErrSessionNotFound on
+	// genuine misses and a distinct infra error otherwise; the handler
+	// discriminates via errors.Is.
+	resumeSession := func(sessionKey string) error {
 		_, err := sessions.Get(sessionKey)
 		return err
 	}
@@ -789,7 +792,7 @@ func main() {
 	}
 	runner := &channelRunner{orch: orch}
 	handler := channel.NewMessageHandler(channel.HandlerConfig{
-		LoadSession:   loadSession,
+		ResumeSession: resumeSession,
 		CreateSession: createSession,
 		Runner:        runner,
 		RunAction:     orch.RunAction,

--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -774,14 +774,23 @@ func main() {
 		slog.Warn("register reminder tool failed", "error", err)
 	}
 
-	ensureSession := func(sessionKey, entityID, groupID string) {
-		if _, err := sessions.Get(sessionKey); err != nil {
-			sessions.Create(sessionKey, entityID, groupID)
-		}
+	// Strict resume: surface "not found" up to the handler so it can emit
+	// session_expired to the client rather than silently auto-creating
+	// (the pre-refactor footgun that let UI and server drift apart).
+	loadSession := func(sessionKey string) error {
+		_, err := sessions.Get(sessionKey)
+		return err
+	}
+	// Fresh mint: delegates to the underlying store, which is idempotent
+	// in both the DB-backed (INSERT-on-conflict returns existing row) and
+	// the in-memory variant (Create returns existing pointer when present).
+	createSession := func(sessionKey, entityID, groupID string) {
+		sessions.Create(sessionKey, entityID, groupID)
 	}
 	runner := &channelRunner{orch: orch}
 	handler := channel.NewMessageHandler(channel.HandlerConfig{
-		EnsureSession: ensureSession,
+		LoadSession:   loadSession,
+		CreateSession: createSession,
 		Runner:        runner,
 		RunAction:     orch.RunAction,
 		HasAction:     toolRegistry.HasAction,

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -24,7 +24,17 @@ type LimitChecker interface {
 
 // HandlerConfig holds the dependencies for NewMessageHandler.
 type HandlerConfig struct {
-	EnsureSession pkg.EnsureSessionFunc
+	// LoadSession is the strict-resume path: error if the session is not in
+	// the store. Called when the inbound message carries
+	// pkg.ResumeIntentMetadataKey="true" (i.e. the channel got a
+	// conversation_id from the client). nil disables resume validation,
+	// which is the right default for channels that cannot distinguish
+	// resume vs fresh (e.g. console).
+	LoadSession pkg.LoadSessionFunc
+	// CreateSession is the fresh-mint path: idempotent registration of a
+	// new session for the given key/entity/group. Called when the inbound
+	// message does NOT carry resume_intent=true (channel-minted id).
+	CreateSession pkg.CreateSessionFunc
 	Runner        pkg.Runner
 	RunAction     pkg.RunActionFunc
 	HasAction     pkg.HasActionFunc
@@ -92,7 +102,24 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 			ctx = actor.WithConfirmationDecision(ctx, cd)
 		}
 
-		cfg.EnsureSession(sessionKey, entityID, groupID)
+		// Route by resume intent: client-supplied conv-id → strict Load
+		// (error frame if the session is gone); channel-minted conv-id →
+		// idempotent Create. This replaces the legacy EnsureSession
+		// closure that silently auto-created on any cache miss and let
+		// the UI drift against a brand-new server-side session.
+		if msg.Metadata[pkg.ResumeIntentMetadataKey] == "true" {
+			if cfg.LoadSession != nil {
+				if err := cfg.LoadSession(sessionKey); err != nil {
+					slog.Info("session resume rejected — not found",
+						"session_key", sessionKey, "channel", msg.ChannelID, "error", err)
+					return errorResponse(msg, "This conversation is no longer available. Please start a new chat.", map[string]string{
+						"type": "error", "error_code": "session_expired",
+					}), nil
+				}
+			}
+		} else if cfg.CreateSession != nil {
+			cfg.CreateSession(sessionKey, entityID, groupID)
+		}
 		content := msg.Content
 		if prep := pkg.GetContentPreparer(msg.ChannelID); prep != nil {
 			content = prep(ctx, content, cfg.RunAction, cfg.HasAction)

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/opentalon/opentalon/internal/actor"
 	"github.com/opentalon/opentalon/internal/logger"
 	"github.com/opentalon/opentalon/internal/profile"
+	"github.com/opentalon/opentalon/internal/state"
 	pkg "github.com/opentalon/opentalon/pkg/channel"
 )
 
@@ -24,16 +26,15 @@ type LimitChecker interface {
 
 // HandlerConfig holds the dependencies for NewMessageHandler.
 type HandlerConfig struct {
-	// LoadSession is the strict-resume path: error if the session is not in
-	// the store. Called when the inbound message carries
+	// ResumeSession is the strict-resume path: error if the session is not
+	// in the store. Called when the inbound message carries
 	// pkg.ResumeIntentMetadataKey="true" (i.e. the channel got a
-	// conversation_id from the client). nil disables resume validation,
-	// which is the right default for channels that cannot distinguish
-	// resume vs fresh (e.g. console).
-	LoadSession pkg.LoadSessionFunc
+	// conversation_id from the client). Required — see NewMessageHandler.
+	ResumeSession pkg.ResumeSessionFunc
 	// CreateSession is the fresh-mint path: idempotent registration of a
 	// new session for the given key/entity/group. Called when the inbound
 	// message does NOT carry resume_intent=true (channel-minted id).
+	// Required — see NewMessageHandler.
 	CreateSession pkg.CreateSessionFunc
 	Runner        pkg.Runner
 	RunAction     pkg.RunActionFunc
@@ -45,7 +46,21 @@ type HandlerConfig struct {
 // NewMessageHandler returns a MessageHandler that: ensures session, verifies profile token (if
 // Verifier is non-nil), runs channel-specific content preparer (if registered), then runs the
 // message through the Runner and returns the response.
+//
+// Panics at construction if ResumeSession, CreateSession, or Runner is nil:
+// these are required for the strict-session contract and a missing one is a
+// boot-time misconfiguration that must surface immediately rather than as a
+// nil-deref under load. Verifier and LimitChecker remain optional.
 func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
+	if cfg.ResumeSession == nil {
+		panic("channel.NewMessageHandler: ResumeSession is required")
+	}
+	if cfg.CreateSession == nil {
+		panic("channel.NewMessageHandler: CreateSession is required")
+	}
+	if cfg.Runner == nil {
+		panic("channel.NewMessageHandler: Runner is required")
+	}
 	return func(ctx context.Context, sessionKey string, msg pkg.InboundMessage) (pkg.OutboundMessage, error) {
 		var entityID, groupID string
 
@@ -53,16 +68,12 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 		if cfg.Verifier != nil {
 			token := msg.Metadata["profile_token"]
 			if token == "" {
-				return errorResponse(msg, "profile token required", map[string]string{
-					"type": "error", "error_code": "token_required",
-				}), nil
+				return errorFrame(msg, "profile token required", "token_required"), nil
 			}
 			p, err := cfg.Verifier.Verify(ctx, token, msg.ChannelID)
 			if err != nil {
 				slog.Warn("profile verification failed", "error", err, "channel", msg.ChannelID)
-				return errorResponse(msg, "authentication failed", map[string]string{
-					"type": "error", "error_code": "auth_failed",
-				}), nil
+				return errorFrame(msg, "authentication failed", "auth_failed"), nil
 			}
 			p.ChannelID = msg.ChannelID
 			ctx = profile.WithProfile(ctx, p)
@@ -75,9 +86,7 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 					slog.Warn("limit check failed", "error", lerr, "entity", p.EntityID)
 				} else if used >= p.Limit {
 					slog.Info("token limit exceeded", "entity", p.EntityID, "used", used, "limit", p.Limit, "window", p.LimitWindow)
-					return errorResponse(msg, "token limit reached, please try again later", map[string]string{
-						"type": "error", "error_code": "token_limit_exceeded",
-					}), nil
+					return errorFrame(msg, "token limit reached, please try again later", "token_limit_exceeded"), nil
 				}
 			}
 
@@ -102,22 +111,30 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 			ctx = actor.WithConfirmationDecision(ctx, cd)
 		}
 
-		// Route by resume intent: client-supplied conv-id → strict Load
+		// Route by resume intent: client-supplied conv-id → strict Resume
 		// (error frame if the session is gone); channel-minted conv-id →
 		// idempotent Create. This replaces the legacy EnsureSession
 		// closure that silently auto-created on any cache miss and let
 		// the UI drift against a brand-new server-side session.
 		if msg.Metadata[pkg.ResumeIntentMetadataKey] == "true" {
-			if cfg.LoadSession != nil {
-				if err := cfg.LoadSession(sessionKey); err != nil {
+			if err := cfg.ResumeSession(sessionKey); err != nil {
+				// Only "row genuinely absent" maps to session_expired —
+				// the client-side recovery contract assumes the session
+				// is gone and clears its stored conversation_id. A DB
+				// hiccup must not look the same: surface as a retryable
+				// internal_error so a valid conversation_id is preserved.
+				if errors.Is(err, state.ErrSessionNotFound) {
 					slog.Info("session resume rejected — not found",
-						"session_key", sessionKey, "channel", msg.ChannelID, "error", err)
-					return errorResponse(msg, "This conversation is no longer available. Please start a new chat.", map[string]string{
-						"type": "error", "error_code": "session_expired",
-					}), nil
+						"session", sessionKey, "channel", msg.ChannelID,
+						"entity_id", entityID, "group_id", groupID)
+					return errorFrame(msg, "This conversation is no longer available. Please start a new chat.", "session_expired"), nil
 				}
+				slog.Warn("session resume failed — infrastructure error",
+					"session", sessionKey, "channel", msg.ChannelID,
+					"entity_id", entityID, "group_id", groupID, "error", err)
+				return errorFrame(msg, "Something went wrong loading your conversation. Please try again.", "internal_error"), nil
 			}
-		} else if cfg.CreateSession != nil {
+		} else {
 			cfg.CreateSession(sessionKey, entityID, groupID)
 		}
 		content := msg.Content
@@ -128,9 +145,7 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 		if err != nil {
 			logger.FromContext(ctx).Error("handler run failed", "error", err)
 			errText, errCode := friendlyError(err)
-			return errorResponse(msg, errText, map[string]string{
-				"type": "error", "error_code": errCode,
-			}), nil
+			return errorFrame(msg, errText, errCode), nil
 		}
 		outContent := response
 		if outContent == "" {
@@ -153,6 +168,17 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 			Metadata:       outMeta,
 		}, nil
 	}
+}
+
+// errorFrame builds a typed error response with the {type:error, error_code:<code>}
+// metadata contract the channel-side recovery code (UI handleMessage, console
+// printer, etc.) keys off. Every error_code is stable and may be referenced
+// by frontends for translated copy — adding one is an API change, not just
+// a log message tweak.
+func errorFrame(msg pkg.InboundMessage, text, errorCode string) pkg.OutboundMessage {
+	return errorResponse(msg, text, map[string]string{
+		"type": "error", "error_code": errorCode,
+	})
 }
 
 func errorResponse(msg pkg.InboundMessage, text string, meta ...map[string]string) pkg.OutboundMessage {

--- a/internal/channel/handler_test.go
+++ b/internal/channel/handler_test.go
@@ -3,11 +3,13 @@ package channel
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/opentalon/opentalon/internal/profile"
+	"github.com/opentalon/opentalon/internal/state"
 	pkg "github.com/opentalon/opentalon/pkg/channel"
 )
 
@@ -38,22 +40,27 @@ func (e *echoRunner) Run(_ context.Context, _ string, content string, _ ...pkg.F
 	return "echo: " + content, "", nil, nil
 }
 
-func newTestHandler(verifier ProfileVerifier, checker LimitChecker) pkg.MessageHandler {
-	loadSession := func(_ string) error { return nil }
-	createSession := func(_, _, _ string) {}
-	noAction := func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
-		return "", errors.New("no actions")
-	}
-	hasAction := func(_, _ string) bool { return false }
-	return NewMessageHandler(HandlerConfig{
-		LoadSession:   loadSession,
-		CreateSession: createSession,
+// baseHandlerConfig returns the shared no-op session/action stubs every
+// handler test needs. Individual tests override fields they care about
+// (ResumeSession/CreateSession for routing tests, Verifier/LimitChecker
+// for auth tests) and re-pass the config to NewMessageHandler.
+func baseHandlerConfig() HandlerConfig {
+	return HandlerConfig{
+		ResumeSession: func(_ string) error { return nil },
+		CreateSession: func(_, _, _ string) {},
 		Runner:        &echoRunner{},
-		RunAction:     noAction,
-		HasAction:     hasAction,
-		Verifier:      verifier,
-		LimitChecker:  checker,
-	})
+		RunAction: func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
+			return "", errors.New("no actions")
+		},
+		HasAction: func(_, _ string) bool { return false },
+	}
+}
+
+func newTestHandler(verifier ProfileVerifier, checker LimitChecker) pkg.MessageHandler {
+	cfg := baseHandlerConfig()
+	cfg.Verifier = verifier
+	cfg.LimitChecker = checker
+	return NewMessageHandler(cfg)
 }
 
 func callHandler(h pkg.MessageHandler, meta map[string]string) pkg.OutboundMessage {
@@ -163,19 +170,18 @@ func TestHandler_NilLimitChecker_WithLimit(t *testing.T) {
 	}
 }
 
-// instrumented session pair: records every Load/Create call so a test can
+// instrumented session pair: records every Resume/Create call so a test can
 // assert which branch the handler took for a given resume_intent value.
 type sessionRecorder struct {
-	loads        []string
-	loadErrors   map[string]error
-	creates      []string
-	createCalled bool
+	resumes     []string
+	resumeError map[string]error
+	creates     []string
 }
 
-func (r *sessionRecorder) loadFunc() pkg.LoadSessionFunc {
+func (r *sessionRecorder) resumeFunc() pkg.ResumeSessionFunc {
 	return func(key string) error {
-		r.loads = append(r.loads, key)
-		if err, ok := r.loadErrors[key]; ok {
+		r.resumes = append(r.resumes, key)
+		if err, ok := r.resumeError[key]; ok {
 			return err
 		}
 		return nil
@@ -185,26 +191,18 @@ func (r *sessionRecorder) loadFunc() pkg.LoadSessionFunc {
 func (r *sessionRecorder) createFunc() pkg.CreateSessionFunc {
 	return func(key, _, _ string) {
 		r.creates = append(r.creates, key)
-		r.createCalled = true
 	}
 }
 
 func newRecordingHandler(rec *sessionRecorder) pkg.MessageHandler {
-	noAction := func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
-		return "", errors.New("no actions")
-	}
-	hasAction := func(_, _ string) bool { return false }
-	return NewMessageHandler(HandlerConfig{
-		LoadSession:   rec.loadFunc(),
-		CreateSession: rec.createFunc(),
-		Runner:        &echoRunner{},
-		RunAction:     noAction,
-		HasAction:     hasAction,
-	})
+	cfg := baseHandlerConfig()
+	cfg.ResumeSession = rec.resumeFunc()
+	cfg.CreateSession = rec.createFunc()
+	return NewMessageHandler(cfg)
 }
 
-func TestHandler_ResumeIntentTrue_CallsLoadNotCreate(t *testing.T) {
-	// Client-supplied conv-id must take the strict-load path. Auto-create
+func TestHandler_ResumeIntentTrue_CallsResumeNotCreate(t *testing.T) {
+	// Client-supplied conv-id must take the strict-resume path. Auto-create
 	// would let the UI keep its history while talking to a fresh empty
 	// server session — the original silent-drift bug.
 	rec := &sessionRecorder{}
@@ -216,17 +214,17 @@ func TestHandler_ResumeIntentTrue_CallsLoadNotCreate(t *testing.T) {
 		Metadata:       map[string]string{pkg.ResumeIntentMetadataKey: "true"},
 	}
 	_, _ = h(context.Background(), "websocket:abc", msg)
-	if len(rec.loads) != 1 || rec.loads[0] != "websocket:abc" {
-		t.Errorf("expected one Load for websocket:abc, got %v", rec.loads)
+	if len(rec.resumes) != 1 || rec.resumes[0] != "websocket:abc" {
+		t.Errorf("expected one Resume for websocket:abc, got %v", rec.resumes)
 	}
-	if rec.createCalled {
+	if len(rec.creates) != 0 {
 		t.Errorf("Create must not be called on resume_intent=true (creates=%v)", rec.creates)
 	}
 }
 
-func TestHandler_ResumeIntentMissing_CallsCreateNotLoad(t *testing.T) {
+func TestHandler_ResumeIntentMissing_CallsCreateNotResume(t *testing.T) {
 	// Channel-minted conv-id (no resume_intent) must take the idempotent
-	// create path. Load on a fresh id would always error and emit a
+	// create path. Resume on a fresh id would always error and emit a
 	// false-positive session_expired.
 	rec := &sessionRecorder{}
 	h := newRecordingHandler(rec)
@@ -240,17 +238,21 @@ func TestHandler_ResumeIntentMissing_CallsCreateNotLoad(t *testing.T) {
 	if len(rec.creates) != 1 || rec.creates[0] != "websocket:new" {
 		t.Errorf("expected one Create for websocket:new, got %v", rec.creates)
 	}
-	if len(rec.loads) != 0 {
-		t.Errorf("Load must not be called when resume_intent is absent (loads=%v)", rec.loads)
+	if len(rec.resumes) != 0 {
+		t.Errorf("Resume must not be called when resume_intent is absent (resumes=%v)", rec.resumes)
 	}
 }
 
-func TestHandler_ResumeIntentTrue_LoadFails_EmitsSessionExpired(t *testing.T) {
+func TestHandler_ResumeIntentTrue_ResumeFails_NotFound_EmitsSessionExpired(t *testing.T) {
 	// The whole point of the refactor: stale conv-id must surface as a
 	// typed error frame so the client can clear its storage and reconnect
-	// fresh. error_code is the contract — UI translates it.
+	// fresh. error_code is the contract — UI translates it. The recorder
+	// returns a wrapped state.ErrSessionNotFound so the handler discriminates
+	// this case from an infrastructure failure.
 	rec := &sessionRecorder{
-		loadErrors: map[string]error{"websocket:gone": errors.New("session \"websocket:gone\" not found")},
+		resumeError: map[string]error{
+			"websocket:gone": fmt.Errorf("session %q: %w", "websocket:gone", state.ErrSessionNotFound),
+		},
 	}
 	h := newRecordingHandler(rec)
 	msg := pkg.InboundMessage{
@@ -266,7 +268,82 @@ func TestHandler_ResumeIntentTrue_LoadFails_EmitsSessionExpired(t *testing.T) {
 	if got := out.Metadata["type"]; got != "error" {
 		t.Errorf("type = %q, want error", got)
 	}
-	if rec.createCalled {
-		t.Errorf("Create must not be called after Load failure (creates=%v)", rec.creates)
+	if len(rec.creates) != 0 {
+		t.Errorf("Create must not be called after Resume failure (creates=%v)", rec.creates)
 	}
+}
+
+func TestHandler_ResumeIntentTrue_ResumeFails_InfraError_EmitsInternalError(t *testing.T) {
+	// A transient infrastructure failure (dropped DB connection, context
+	// cancellation, etc.) must NOT masquerade as session_expired — telling
+	// the user "start a new chat" would cost them a valid conversation_id
+	// on every brief DB hiccup. The contract: only errors.Is(err,
+	// state.ErrSessionNotFound) maps to session_expired; everything else
+	// maps to internal_error so the client can retry without resetting.
+	rec := &sessionRecorder{
+		resumeError: map[string]error{"websocket:live": errors.New("database connection lost")},
+	}
+	h := newRecordingHandler(rec)
+	msg := pkg.InboundMessage{
+		ChannelID:      "websocket",
+		ConversationID: "live",
+		Content:        "ping",
+		Metadata:       map[string]string{pkg.ResumeIntentMetadataKey: "true"},
+	}
+	out, _ := h(context.Background(), "websocket:live", msg)
+	if got := out.Metadata["error_code"]; got != "internal_error" {
+		t.Errorf("error_code = %q, want internal_error (not session_expired)", got)
+	}
+	if got := out.Metadata["type"]; got != "error" {
+		t.Errorf("type = %q, want error", got)
+	}
+	if strings.Contains(out.Content, "no longer available") || strings.Contains(out.Content, "start a new chat") {
+		t.Errorf("Content = %q must not say session is gone on infra failure", out.Content)
+	}
+	if len(rec.creates) != 0 {
+		t.Errorf("Create must not be called after Resume failure (creates=%v)", rec.creates)
+	}
+}
+
+func TestHandler_NewMessageHandler_PanicsOnNilResumeSession(t *testing.T) {
+	// Boot-time misconfiguration must surface immediately at construction,
+	// not as a nil-deref under the first inbound message. The strict-session
+	// contract requires both callbacks; making one optional was the legacy
+	// "right default for console" wart that hid silent failures.
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil ResumeSession, got nothing")
+		}
+	}()
+	NewMessageHandler(HandlerConfig{
+		ResumeSession: nil,
+		CreateSession: func(_, _, _ string) {},
+		Runner:        &echoRunner{},
+	})
+}
+
+func TestHandler_NewMessageHandler_PanicsOnNilCreateSession(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil CreateSession, got nothing")
+		}
+	}()
+	NewMessageHandler(HandlerConfig{
+		ResumeSession: func(_ string) error { return nil },
+		CreateSession: nil,
+		Runner:        &echoRunner{},
+	})
+}
+
+func TestHandler_NewMessageHandler_PanicsOnNilRunner(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for nil Runner, got nothing")
+		}
+	}()
+	NewMessageHandler(HandlerConfig{
+		ResumeSession: func(_ string) error { return nil },
+		CreateSession: func(_, _, _ string) {},
+		Runner:        nil,
+	})
 }

--- a/internal/channel/handler_test.go
+++ b/internal/channel/handler_test.go
@@ -39,13 +39,15 @@ func (e *echoRunner) Run(_ context.Context, _ string, content string, _ ...pkg.F
 }
 
 func newTestHandler(verifier ProfileVerifier, checker LimitChecker) pkg.MessageHandler {
-	ensureSession := func(_, _, _ string) {}
+	loadSession := func(_ string) error { return nil }
+	createSession := func(_, _, _ string) {}
 	noAction := func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
 		return "", errors.New("no actions")
 	}
 	hasAction := func(_, _ string) bool { return false }
 	return NewMessageHandler(HandlerConfig{
-		EnsureSession: ensureSession,
+		LoadSession:   loadSession,
+		CreateSession: createSession,
 		Runner:        &echoRunner{},
 		RunAction:     noAction,
 		HasAction:     hasAction,
@@ -158,5 +160,113 @@ func TestHandler_NilLimitChecker_WithLimit(t *testing.T) {
 	out := callHandler(h, map[string]string{"profile_token": "tok"})
 	if out.Content != "echo: hello" {
 		t.Errorf("Content = %q, want passthrough when limitChecker is nil", out.Content)
+	}
+}
+
+// instrumented session pair: records every Load/Create call so a test can
+// assert which branch the handler took for a given resume_intent value.
+type sessionRecorder struct {
+	loads        []string
+	loadErrors   map[string]error
+	creates      []string
+	createCalled bool
+}
+
+func (r *sessionRecorder) loadFunc() pkg.LoadSessionFunc {
+	return func(key string) error {
+		r.loads = append(r.loads, key)
+		if err, ok := r.loadErrors[key]; ok {
+			return err
+		}
+		return nil
+	}
+}
+
+func (r *sessionRecorder) createFunc() pkg.CreateSessionFunc {
+	return func(key, _, _ string) {
+		r.creates = append(r.creates, key)
+		r.createCalled = true
+	}
+}
+
+func newRecordingHandler(rec *sessionRecorder) pkg.MessageHandler {
+	noAction := func(_ context.Context, _, _ string, _ map[string]string) (string, error) {
+		return "", errors.New("no actions")
+	}
+	hasAction := func(_, _ string) bool { return false }
+	return NewMessageHandler(HandlerConfig{
+		LoadSession:   rec.loadFunc(),
+		CreateSession: rec.createFunc(),
+		Runner:        &echoRunner{},
+		RunAction:     noAction,
+		HasAction:     hasAction,
+	})
+}
+
+func TestHandler_ResumeIntentTrue_CallsLoadNotCreate(t *testing.T) {
+	// Client-supplied conv-id must take the strict-load path. Auto-create
+	// would let the UI keep its history while talking to a fresh empty
+	// server session — the original silent-drift bug.
+	rec := &sessionRecorder{}
+	h := newRecordingHandler(rec)
+	msg := pkg.InboundMessage{
+		ChannelID:      "websocket",
+		ConversationID: "abc",
+		Content:        "hi",
+		Metadata:       map[string]string{pkg.ResumeIntentMetadataKey: "true"},
+	}
+	_, _ = h(context.Background(), "websocket:abc", msg)
+	if len(rec.loads) != 1 || rec.loads[0] != "websocket:abc" {
+		t.Errorf("expected one Load for websocket:abc, got %v", rec.loads)
+	}
+	if rec.createCalled {
+		t.Errorf("Create must not be called on resume_intent=true (creates=%v)", rec.creates)
+	}
+}
+
+func TestHandler_ResumeIntentMissing_CallsCreateNotLoad(t *testing.T) {
+	// Channel-minted conv-id (no resume_intent) must take the idempotent
+	// create path. Load on a fresh id would always error and emit a
+	// false-positive session_expired.
+	rec := &sessionRecorder{}
+	h := newRecordingHandler(rec)
+	msg := pkg.InboundMessage{
+		ChannelID:      "websocket",
+		ConversationID: "new",
+		Content:        "hi",
+		// No resume_intent key at all.
+	}
+	_, _ = h(context.Background(), "websocket:new", msg)
+	if len(rec.creates) != 1 || rec.creates[0] != "websocket:new" {
+		t.Errorf("expected one Create for websocket:new, got %v", rec.creates)
+	}
+	if len(rec.loads) != 0 {
+		t.Errorf("Load must not be called when resume_intent is absent (loads=%v)", rec.loads)
+	}
+}
+
+func TestHandler_ResumeIntentTrue_LoadFails_EmitsSessionExpired(t *testing.T) {
+	// The whole point of the refactor: stale conv-id must surface as a
+	// typed error frame so the client can clear its storage and reconnect
+	// fresh. error_code is the contract — UI translates it.
+	rec := &sessionRecorder{
+		loadErrors: map[string]error{"websocket:gone": errors.New("session \"websocket:gone\" not found")},
+	}
+	h := newRecordingHandler(rec)
+	msg := pkg.InboundMessage{
+		ChannelID:      "websocket",
+		ConversationID: "gone",
+		Content:        "are you there?",
+		Metadata:       map[string]string{pkg.ResumeIntentMetadataKey: "true"},
+	}
+	out, _ := h(context.Background(), "websocket:gone", msg)
+	if got := out.Metadata["error_code"]; got != "session_expired" {
+		t.Errorf("error_code = %q, want session_expired", got)
+	}
+	if got := out.Metadata["type"]; got != "error" {
+		t.Errorf("type = %q, want error", got)
+	}
+	if rec.createCalled {
+		t.Errorf("Create must not be called after Load failure (creates=%v)", rec.creates)
 	}
 }

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,6 +11,14 @@ import (
 	"github.com/opentalon/opentalon/internal/provider"
 	"gopkg.in/yaml.v3"
 )
+
+// ErrSessionNotFound is the canonical sentinel returned by both the in-memory
+// and DB-backed SessionStore.Get when the requested id is absent. Callers must
+// use errors.Is to distinguish a genuine miss from an infrastructure failure
+// (e.g. dropped DB connection): only the former should surface to the user as
+// "session expired"; the latter is a transient internal error and must not
+// cause the client to discard a valid conversation_id.
+var ErrSessionNotFound = errors.New("session not found")
 
 type Session struct {
 	ID          string             `yaml:"id"`
@@ -67,7 +76,7 @@ func (s *SessionStore) Get(id string) (*Session, error) {
 
 	sess, ok := s.sessions[id]
 	if !ok {
-		return nil, fmt.Errorf("session %q not found", id)
+		return nil, fmt.Errorf("session %q: %w", id, ErrSessionNotFound)
 	}
 	return sess, nil
 }

--- a/internal/state/session.go
+++ b/internal/state/session.go
@@ -35,9 +35,19 @@ func NewSessionStore(dir string) *SessionStore {
 	}
 }
 
+// Create returns the session for id, minting a fresh empty record if absent.
+// Idempotent on existing ids so a "fresh-intent" call from a reconnecting
+// channel can never wipe a live session's messages — matches the DB-backed
+// store's on-conflict behaviour (see store/session.go Create) and removes
+// a silent-data-loss footgun that surfaced when channels routed a stale
+// conversation_id into the create path instead of the load path.
 func (s *SessionStore) Create(id, _, _ string) *Session {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	if existing, ok := s.sessions[id]; ok {
+		return existing
+	}
 
 	now := time.Now()
 	sess := &Session{

--- a/internal/state/session_test.go
+++ b/internal/state/session_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/provider"
@@ -43,7 +44,13 @@ func TestSessionGetNotFound(t *testing.T) {
 	store := NewSessionStore("")
 	_, err := store.Get("nonexistent")
 	if err == nil {
-		t.Error("expected error for nonexistent session")
+		t.Fatal("expected error for nonexistent session")
+	}
+	// The handler's session_expired vs internal_error branch hinges on
+	// errors.Is(err, ErrSessionNotFound). Verify the contract holds for
+	// the in-memory store; the DB-backed store has its own coverage.
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("err = %v, want errors.Is(err, ErrSessionNotFound)", err)
 	}
 }
 

--- a/internal/state/session_test.go
+++ b/internal/state/session_test.go
@@ -21,6 +21,24 @@ func TestSessionCreate(t *testing.T) {
 	}
 }
 
+func TestSessionCreateIdempotent(t *testing.T) {
+	// A second Create with the same id must return the existing session, not
+	// overwrite it. Channels with stale conversation_ids must never silently
+	// wipe live message history.
+	store := NewSessionStore("")
+	first := store.Create("sess1", "", "")
+	_ = store.AddMessage("sess1", provider.Message{Role: provider.RoleUser, Content: "alive"})
+
+	again := store.Create("sess1", "", "")
+	if again != first {
+		t.Errorf("Create returned a different pointer on second call; expected idempotent reuse")
+	}
+	got, _ := store.Get("sess1")
+	if len(got.Messages) != 1 || got.Messages[0].Content != "alive" {
+		t.Errorf("messages were wiped by second Create: got %#v", got.Messages)
+	}
+}
+
 func TestSessionGetNotFound(t *testing.T) {
 	store := NewSessionStore("")
 	_, err := store.Get("nonexistent")

--- a/internal/state/store/session.go
+++ b/internal/state/store/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -39,6 +40,10 @@ func NewSessionStore(db *DB, maxMessages, maxIdleDays int) *SessionStore {
 }
 
 // Get loads a session by id. Messages are loaded from the messages table.
+// Returns a wrapped state.ErrSessionNotFound when the row is genuinely absent
+// (sql.ErrNoRows), and a wrapped infrastructure error otherwise — preserving
+// that distinction is what lets the channel handler decide between "tell the
+// user their conversation expired" and "tell the user to retry".
 func (s *SessionStore) Get(id string) (*state.Session, error) {
 	d := s.db.Dialect()
 	var summary, title, activeModel, metadataJSON, createdAt, updatedAt string
@@ -47,7 +52,10 @@ func (s *SessionStore) Get(id string) (*state.Session, error) {
 		id,
 	).Scan(&summary, &title, &activeModel, &metadataJSON, &createdAt, &updatedAt)
 	if err != nil {
-		return nil, fmt.Errorf("session %q not found", id)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, fmt.Errorf("session %q: %w", id, state.ErrSessionNotFound)
+		}
+		return nil, fmt.Errorf("session %q load: %w", id, err)
 	}
 
 	messages, err := s.loadMessages(id)

--- a/internal/state/store/session_test.go
+++ b/internal/state/store/session_test.go
@@ -2,9 +2,11 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/opentalon/opentalon/internal/provider"
+	"github.com/opentalon/opentalon/internal/state"
 	"github.com/opentalon/opentalon/internal/state/store/events"
 )
 
@@ -117,6 +119,26 @@ func TestSessionStore_ClearMessagesPreservesIdentityAndEvents(t *testing.T) {
 	if len(eventsAfter) != len(eventsBefore) {
 		t.Errorf("session_events len = %d after clear, want %d (audit trail must survive)",
 			len(eventsAfter), len(eventsBefore))
+	}
+}
+
+// TestSessionStore_GetMissingReturnsErrSessionNotFound pins the contract the
+// channel handler's session_expired vs internal_error split depends on: an
+// absent row must surface as a wrapped state.ErrSessionNotFound so the
+// handler can route it to error_code=session_expired. Anything else (e.g.
+// dropped DB connection — not exercised here as it needs fault injection)
+// must NOT match, so it falls through to internal_error and the client
+// keeps its conversation_id across a retry.
+func TestSessionStore_GetMissingReturnsErrSessionNotFound(t *testing.T) {
+	db := openTestDB(t)
+	store := NewSessionStore(db, 0, 0)
+
+	_, err := store.Get("nope")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session")
+	}
+	if !errors.Is(err, state.ErrSessionNotFound) {
+		t.Errorf("err = %v, want errors.Is(err, state.ErrSessionNotFound)", err)
 	}
 }
 

--- a/pkg/channel/types.go
+++ b/pkg/channel/types.go
@@ -177,21 +177,25 @@ type HasActionFunc func(plugin, action string) bool
 // before it is sent to the Runner. Channels register their preparer via RegisterContentPreparer in init().
 type ContentPreparer func(ctx context.Context, content string, runAction RunActionFunc, hasAction HasActionFunc) string
 
-// LoadSessionFunc validates that a session exists for sessionKey. It returns
-// nil when the session is present in the store and an error when it is not
-// (expired, pruned, never existed). The handler calls Load on inbound messages
-// flagged with metadata "resume_intent=true" — i.e. the channel passed a
-// client-supplied conversation_id. A failure must propagate as a typed error
-// frame to the client (error_code=session_expired) so the UI can drop its
-// stale conversation_id and reconnect fresh instead of silently drifting
-// against a server that quietly minted a different session.
-type LoadSessionFunc func(sessionKey string) error
+// ResumeSessionFunc validates that a session exists for sessionKey. It returns
+// nil when the session is present in the store. The handler distinguishes two
+// failure modes via errors.Is against state.ErrSessionNotFound: a wrapped
+// ErrSessionNotFound means the row is genuinely absent (expired, pruned,
+// never existed) and surfaces as error_code=session_expired so the UI drops
+// its stale conversation_id and reconnects fresh; any other error is treated
+// as an infrastructure failure (e.g. dropped DB connection) and surfaces as
+// error_code=internal_error so a valid conversation_id is preserved across
+// a retry. Implementations MUST preserve this distinction — collapsing both
+// onto a generic error reintroduces the silent-drift bug this contract
+// exists to prevent. Named Resume rather than Load to avoid colliding with
+// SessionStore.Load (the yaml-from-disk method on the in-memory store).
+type ResumeSessionFunc func(sessionKey string) error
 
 // CreateSessionFunc registers (or returns) a session row for sessionKey,
 // entityID, groupID. Idempotent: an existing session is returned untouched,
 // never wiped. The handler calls Create on messages NOT flagged with
 // resume_intent — i.e. the channel did not have a client-supplied id and
-// just minted one for this connection. Splitting Load/Create replaces the
+// just minted one for this connection. Splitting Resume/Create replaces the
 // previous EnsureSessionFunc which conflated the two paths and silently
 // auto-created on any cache miss.
 type CreateSessionFunc func(sessionKey, entityID, groupID string)
@@ -199,7 +203,15 @@ type CreateSessionFunc func(sessionKey, entityID, groupID string)
 // ResumeIntentMetadataKey is the InboundMessage metadata key channels set
 // to "true" when the conversation_id on the message came from the client
 // (resume) rather than being server-minted on this connection (fresh).
-// Handlers route Load vs Create based on this flag.
+// Handlers route Resume vs Create based on this flag.
+//
+// Trust boundary: this key is client-trustable because session_key is
+// always entity-scoped at handler.go (sessionKey = p.EntityID + ":" + key)
+// before either Resume or Create is invoked. A malicious client cannot
+// resume a session belonging to another entity by forging this metadata —
+// any guessed conversation_id is prefixed with the verified profile's
+// EntityID, so cross-tenant lookup is structurally unreachable. Removing
+// or reshaping that prefix in handler.go would re-open this surface.
 const ResumeIntentMetadataKey = "resume_intent"
 
 // MessageHandler is called when an inbound message arrives. The implementation

--- a/pkg/channel/types.go
+++ b/pkg/channel/types.go
@@ -177,9 +177,30 @@ type HasActionFunc func(plugin, action string) bool
 // before it is sent to the Runner. Channels register their preparer via RegisterContentPreparer in init().
 type ContentPreparer func(ctx context.Context, content string, runAction RunActionFunc, hasAction HasActionFunc) string
 
-// EnsureSessionFunc is called to ensure a session exists for the given key before running.
-// entityID and groupID are stored alongside the session for ownership queries.
-type EnsureSessionFunc func(sessionKey, entityID, groupID string)
+// LoadSessionFunc validates that a session exists for sessionKey. It returns
+// nil when the session is present in the store and an error when it is not
+// (expired, pruned, never existed). The handler calls Load on inbound messages
+// flagged with metadata "resume_intent=true" — i.e. the channel passed a
+// client-supplied conversation_id. A failure must propagate as a typed error
+// frame to the client (error_code=session_expired) so the UI can drop its
+// stale conversation_id and reconnect fresh instead of silently drifting
+// against a server that quietly minted a different session.
+type LoadSessionFunc func(sessionKey string) error
+
+// CreateSessionFunc registers (or returns) a session row for sessionKey,
+// entityID, groupID. Idempotent: an existing session is returned untouched,
+// never wiped. The handler calls Create on messages NOT flagged with
+// resume_intent — i.e. the channel did not have a client-supplied id and
+// just minted one for this connection. Splitting Load/Create replaces the
+// previous EnsureSessionFunc which conflated the two paths and silently
+// auto-created on any cache miss.
+type CreateSessionFunc func(sessionKey, entityID, groupID string)
+
+// ResumeIntentMetadataKey is the InboundMessage metadata key channels set
+// to "true" when the conversation_id on the message came from the client
+// (resume) rather than being server-minted on this connection (fresh).
+// Handlers route Load vs Create based on this flag.
+const ResumeIntentMetadataKey = "resume_intent"
 
 // MessageHandler is called when an inbound message arrives. The implementation
 // feeds the message to the orchestrator and returns the response.


### PR DESCRIPTION
## What

Channels now signal "resume vs fresh" via a new metadata flag (`resume_intent`). The handler routes a **client-supplied** conversation_id through `LoadSession` — a strict path that errors back to the channel as `error_code=session_expired` when the row is gone — and a **server-minted** one through the idempotent `CreateSession`.

Removes the `EnsureSession` closure (`main.go:777-781`) that silently auto-created on any cache miss. That was the root cause of a UI/server drift after standby/wake: the chat widget kept yesterday's history while talking to a brand-new server-side session because the cached `sessionKey` no longer mapped and the closure quietly minted a fresh row under the same key.

In-memory `SessionStore.Create` is now idempotent too, matching the DB-backed on-conflict behaviour and closing a parallel silent-wipe path on fallback deployments without a DB.

## Why

Three things converged into one architectural footgun:

1. The handler had no idea whether the inbound `conversation_id` came from the client (resume intent) or was server-minted (fresh intent). Without that signal, it had to fall back on "if Get fails → Create", which silently produces a different session under the same key.
2. The in-memory `SessionStore.Create` overwrote existing rows rather than being idempotent, so even when the in-memory map momentarily lost a row (no TTL, but pruning runs at startup), a Create call would wipe history.
3. There was no client-facing recovery contract: when the server "lost" a session the channel emitted nothing typed, so the UI couldn't react.

The split-Load-Create design makes the intent explicit at the call site, surfaces resume-misses as a typed error frame the channel can propagate, and makes Create safe to call repeatedly.

## Breaking

`pkg/channel.EnsureSessionFunc` is removed in favour of `HandlerConfig{LoadSession, CreateSession}`.

- **websocket-channel**: needs the resume_intent metadata wiring (separate PR, opentalon/websocket-channel — to be opened after this merges).
- **Other channels** (console-channel, slack-channel, yaml-channel and any in-house plugins): do **not** reference `EnsureSession` and stay compatible. They simply never set `resume_intent` and route through `CreateSession` — same effective behaviour as before, just via a cleaner type.

Verified via grep across sibling checkouts; zero hits outside opentalon itself.

## Test coverage

- `internal/channel/handler_test.go`: three new tests — `Load` is called on `resume_intent=true`, `Create` is called on absence, `session_expired` frame is emitted when Load fails.
- `internal/state/session_test.go`: idempotent Create — second `Create("sess1", ...)` returns the existing pointer with messages preserved.

Existing tests updated to use the new `HandlerConfig` field names.

## End-to-end verification

Tested locally with `opentalon-local-dev` against the production code path (Timly Rails UI ↔ websocket-channel ↔ this branch, PostgreSQL-backed SessionStore):

| Scenario | Path | Outcome |
|---|---|---|
| Existing DB session, send via WS resume | LoadSession finds row | ✅ Same conv-id, normal answer |
| Session row DELETEd from DB, send via WS | LoadSession errors → `error_code=session_expired` | ✅ Client clears storage, reconnects fresh |
| Fresh handshake (no client conv-id), send | CreateSession mints | ✅ New session row, normal answer |

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green)
- [x] Manual E2E via opentalon-local-dev (3 scenarios above)
- [ ] CI green on this PR
- [ ] Coordinated merge with websocket-channel PR (to be opened post-merge here)