### PR TITLE
refactor(orchestrator): consolidate preparer context-args + per-session palette + close get_tool_details disclosure

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -259,19 +259,19 @@ type sessionMutex struct {
 }
 
 type Orchestrator struct {
-	sessionMuxMu            sync.Mutex               // guards sessionMuxes map
-	sessionMuxes            map[string]*sessionMutex // per-session serialization
-	semaphore               chan struct{}            // nil = unlimited; cap = MaxConcurrentSessions
-	llm                     LLMClient
-	parser                  ToolCallParser
-	registry                *ToolRegistry
-	memory                  MemoryStoreInterface
-	sessions                SessionStoreInterface
-	guard                   *Guard
-	rules                   *RulesConfig
-	preparers               []ContentPreparerEntry
-	formatters              []ResponseFormatterEntry      // run after final response; text-in/text-out
-	guards                  []ContentPreparerEntry        // subset of preparers with Guard:true; run before every LLM call
+	sessionMuxMu sync.Mutex               // guards sessionMuxes map
+	sessionMuxes map[string]*sessionMutex // per-session serialization
+	semaphore    chan struct{}            // nil = unlimited; cap = MaxConcurrentSessions
+	llm          LLMClient
+	parser       ToolCallParser
+	registry     *ToolRegistry
+	memory       MemoryStoreInterface
+	sessions     SessionStoreInterface
+	guard        *Guard
+	rules        *RulesConfig
+	preparers    []ContentPreparerEntry
+	formatters   []ResponseFormatterEntry // run after final response; text-in/text-out
+	guards       []ContentPreparerEntry   // subset of preparers with Guard:true; run before every LLM call
 	// preparerActions is the immutable "plugin.action" set of all
 	// preparers + guards, computed once in NewWithRules from the
 	// preparers/guards slices above (both append-once at construction).

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -379,34 +379,25 @@ func allowedToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{} {
 }
 
 // resolveAllowedToolFQNs returns the sorted JSON array of FQNs from
-// allowedToolsSet. The empty-set case distinguishes "no profile in scope
-// → no palette to enforce" from "profile in scope, but the effective
-// palette is empty → session can call zero tools":
+// allowedToolsSet. Always returns a JSON value — even "[]" for the empty
+// case — so the arg is always injected into the preparer call.
 //
-//   - no profile (resolveAllowedPlugins returns {m: nil}) → returns ""
-//     so the host's executeCall omits the arg entirely. Plugins receive
-//     no allowed_tools value and apply no per-session filter (fail-open
-//     because there is genuinely no palette to compare against).
+// The plugin contract is fail-closed when the arg is absent (deploy
+// drift, missing provider, config mistake). Sending "" here would let
+// executeCall omit the arg and silently drop the plugin into its
+// strict-zero branch even for unrestricted sessions; that's safe but
+// diagnostically opaque (operators can't tell "orchestrator forgot to
+// wire allowed_tools" apart from "session has no tools"). Always
+// emitting a JSON value keeps the wire predictable and lets the plugin
+// reason purely from the array content.
 //
-//   - profile in scope, set empty → returns "[]" so the arg is delivered
-//     as a non-nil empty JSON array. Plugins interpret this as the strict
-//     "zero tools allowed" branch and drop every retrieved action. This
-//     is the fail-closed path for restricted sessions; without it, a
-//     locked-down profile would silently degrade to "no filter".
-//
-//   - set non-empty → JSON-marshalled sorted array.
-//
-// Mirrors resolveAllowedPluginNames's contract for the "absent arg" axis
-// but adds the third state because the palette has a meaningful
-// "explicitly empty" semantic that allowed_plugins does not.
+// Unlike resolveAllowedPluginNames (which returns "" when there is no
+// profile to express, because plugins consuming allowed_plugins
+// canonically use it as an optional GraphQL WHERE filter), allowed_tools
+// is the post-retrieval chokepoint — the host's responsibility is to
+// SAY what the session may see, and "[]" is a legitimate answer.
 func resolveAllowedToolFQNs(ctx context.Context, o *Orchestrator) string {
 	set := allowedToolsSet(ctx, o)
-	if len(set) == 0 {
-		if o.resolveAllowedPlugins(ctx).m == nil {
-			return ""
-		}
-		return "[]"
-	}
 	fqns := make([]string, 0, len(set))
 	for fqn := range set {
 		fqns = append(fqns, fqn)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -338,6 +338,65 @@ func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
 	return string(b)
 }
 
+// availableToolsSet returns the set of fully-qualified tool names
+// ("<plugin>.<action>") this session can call right now. Applies the same
+// visibility rules as the system-prompt assembler — profile-level plugin
+// allowance, preparer/guard-action exclusion, UserOnly exclusion — but NOT
+// the preparer's RAG result (this set is the INPUT to the preparer, not its
+// output).
+//
+// Single computation point feeds:
+//   - resolveAvailableToolFQNs (JSON-array form for the `allowed_tools`
+//     ContextArgProvider; preparer plugins use it to constrain RAG
+//     retrieval to the session's actual tool surface)
+//   - _meta.get_tool_details action-level visibility gate (rejects
+//     description lookups for actions the session cannot invoke, so the
+//     meta-tool cannot be used to enumerate tool schemas the
+//     manifest-filtering layer is hiding)
+//
+// Both consumers MUST share the set so the "what is this session allowed
+// to see" answer is identical across the RAG-retrieval and direct-lookup
+// vectors. Drift between the two would create exactly the
+// defense-in-depth gap the palette exists to close.
+func availableToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{} {
+	allowedPlugins := o.resolveAllowedPlugins(ctx)
+	preparerAction := preparerActionSet(o.preparers, o.guards)
+
+	set := make(map[string]struct{})
+	for _, cap := range o.registry.ListCapabilities() {
+		if !o.pluginAllowed(cap, allowedPlugins) {
+			continue
+		}
+		for _, action := range cap.Actions {
+			fqn := cap.Name + "." + action.Name
+			if preparerAction[fqn] || action.UserOnly {
+				continue
+			}
+			set[fqn] = struct{}{}
+		}
+	}
+	return set
+}
+
+// resolveAvailableToolFQNs returns the sorted JSON array of FQNs from
+// availableToolsSet, or "" when empty. Returns "" (not "[]") so the host's
+// executeCall path omits the arg entirely instead of injecting an empty
+// array — the latter would force plugins to special-case empty ==
+// unrestricted vs empty == "no tools". Mirrors resolveAllowedPluginNames.
+func resolveAvailableToolFQNs(ctx context.Context, o *Orchestrator) string {
+	set := availableToolsSet(ctx, o)
+	if len(set) == 0 {
+		return ""
+	}
+	fqns := make([]string, 0, len(set))
+	for fqn := range set {
+		fqns = append(fqns, fqn)
+	}
+	sort.Strings(fqns)
+	b, _ := json.Marshal(fqns)
+	return string(b)
+}
+
 // defaultContextArgProviders returns built-in providers only for opaque identifiers (e.g. session_id).
 // No session messages, conversation text, or other sensitive content is exposed to plugins via this mechanism.
 func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgProvider) map[string]ContextArgProvider {
@@ -345,6 +404,9 @@ func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgPro
 		"session_id": func(ctx context.Context, _ string) string { return actor.SessionID(ctx) },
 		"allowed_plugins": func(ctx context.Context, _ string) string {
 			return resolveAllowedPluginNames(ctx, o)
+		},
+		"allowed_tools": func(ctx context.Context, _ string) string {
+			return resolveAvailableToolFQNs(ctx, o)
 		},
 	}
 	if len(custom) == 0 {
@@ -868,12 +930,16 @@ func (o *Orchestrator) runSinglePreparer(ctx context.Context, prep ContentPrepar
 		Action: prep.Action,
 		Args:   map[string]string{argKey: content},
 	}
-	// Inject allowed_plugins for preparers so RAG plugins can filter by profile.
-	if allowed := resolveAllowedPluginNames(ctx, o); allowed != "" {
-		call.Args["allowed_plugins"] = allowed
-	}
-	// Inject enriched search query so RAG preparers can use it for semantic
-	// search while the main text arg stays as the original user message.
+	// Context-arg injection (allowed_plugins, allowed_tools, session_id, …)
+	// runs through executeCall via the action's declared InjectContextArgs.
+	// Single code path with LLM-driven calls — see ContextArgProvider and
+	// defaultContextArgProviders. Preparer plugins that need a context arg
+	// must declare it in their ActionMsg.InjectContextArgs.
+	//
+	// search_text stays inline because its injection is content-aware
+	// (skipped when the enriched query equals the raw content) — a stateless
+	// ContextArgProvider cannot express that conditional, so the inline path
+	// is intentional rather than legacy.
 	if sq := SearchQueryFromContext(ctx); sq != "" && sq != content {
 		call.Args["search_text"] = sq
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opentalon/opentalon/internal/state/store/events"
 	"github.com/opentalon/opentalon/internal/state/store/events/emit"
 	pkgchannel "github.com/opentalon/opentalon/pkg/channel"
+	"github.com/opentalon/opentalon/pkg/plugin/contextargs"
 )
 
 const maxAgentLoopIterations = 20
@@ -271,6 +272,14 @@ type Orchestrator struct {
 	preparers               []ContentPreparerEntry
 	formatters              []ResponseFormatterEntry      // run after final response; text-in/text-out
 	guards                  []ContentPreparerEntry        // subset of preparers with Guard:true; run before every LLM call
+	// preparerActions is the immutable "plugin.action" set of all
+	// preparers + guards, computed once in NewWithRules from the
+	// preparers/guards slices above (both append-once at construction).
+	// Reads happen on every Run (system prompt assembly, native tool
+	// definitions, palette computation) and every _meta.get_tool_details
+	// call — rebuilding the map per read is wasted work that scales
+	// linearly with the LLM's appetite for meta-tool lookups.
+	preparerActions         map[string]bool
 	luaScriptPaths          map[string]string             // optional; plugin name -> path to .lua script (for "lua:name" preparers)
 	permissionChecker       PermissionChecker             // optional; when set, executeCall checks permission before running
 	permissionPluginName    string                        // name of the permission plugin (skip permission check when executing it)
@@ -360,7 +369,7 @@ func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
 // defense-in-depth gap the palette exists to close.
 func allowedToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{} {
 	allowedPlugins := o.resolveAllowedPlugins(ctx)
-	preparerAction := preparerActionSet(o.preparers, o.guards)
+	preparerAction := o.preparerActions
 
 	set := make(map[string]struct{})
 	for _, cap := range o.registry.ListCapabilities() {
@@ -413,11 +422,11 @@ func resolveAllowedToolFQNs(ctx context.Context, o *Orchestrator) string {
 // conversation text, or other sensitive user content is exposed via this mechanism.
 func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgProvider) map[string]ContextArgProvider {
 	builtin := map[string]ContextArgProvider{
-		"session_id": func(ctx context.Context, _ string) string { return actor.SessionID(ctx) },
-		"allowed_plugins": func(ctx context.Context, _ string) string {
+		contextargs.SessionID: func(ctx context.Context, _ string) string { return actor.SessionID(ctx) },
+		contextargs.AllowedPlugins: func(ctx context.Context, _ string) string {
 			return resolveAllowedPluginNames(ctx, o)
 		},
-		"allowed_tools": func(ctx context.Context, _ string) string {
+		contextargs.AllowedTools: func(ctx context.Context, _ string) string {
 			return resolveAllowedToolFQNs(ctx, o)
 		},
 	}
@@ -539,6 +548,7 @@ func NewWithRules(
 		preparers:               preparers,
 		formatters:              opts.ResponseFormatters,
 		guards:                  guards,
+		preparerActions:         preparerActionSet(preparers, guards),
 		luaScriptPaths:          opts.LuaScriptPaths,
 		permissionChecker:       opts.PermissionChecker,
 		permissionPluginName:    opts.PermissionPluginName,
@@ -2464,7 +2474,7 @@ func (o *Orchestrator) supportsNativeTools() bool {
 // for native function calling. Only includes actions visible to the current profile.
 func (o *Orchestrator) buildToolDefinitions(ctx context.Context) []provider.ToolDefinition {
 	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
-	preparerAction := preparerActionSet(o.preparers, o.guards)
+	preparerAction := o.preparerActions
 
 	relevantToolSet := make(map[string]bool)
 	rtTools, relevantToolsActive := relevantToolsFromContext(ctx)
@@ -3471,7 +3481,7 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 	}
 
 	// Don't list content-preparer or guard actions as tools; they run automatically before LLM calls.
-	preparerAction := preparerActionSet(o.preparers, o.guards)
+	preparerAction := o.preparerActions
 
 	// Resolve the set of plugins allowed for the current profile group (if any).
 	allowedPlugins := o.resolveAllowedPlugins(ctx)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -338,7 +338,7 @@ func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
 	return string(b)
 }
 
-// availableToolsSet returns the set of fully-qualified tool names
+// allowedToolsSet returns the set of fully-qualified tool names
 // ("<plugin>.<action>") this session can call right now. Applies the same
 // visibility rules as the system-prompt assembler — profile-level plugin
 // allowance, preparer/guard-action exclusion, UserOnly exclusion — but NOT
@@ -346,7 +346,7 @@ func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
 // output).
 //
 // Single computation point feeds:
-//   - resolveAvailableToolFQNs (JSON-array form for the `allowed_tools`
+//   - resolveAllowedToolFQNs (JSON-array form for the `allowed_tools`
 //     ContextArgProvider; preparer plugins use it to constrain RAG
 //     retrieval to the session's actual tool surface)
 //   - _meta.get_tool_details action-level visibility gate (rejects
@@ -358,7 +358,7 @@ func resolveAllowedPluginNames(ctx context.Context, o *Orchestrator) string {
 // to see" answer is identical across the RAG-retrieval and direct-lookup
 // vectors. Drift between the two would create exactly the
 // defense-in-depth gap the palette exists to close.
-func availableToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{} {
+func allowedToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{} {
 	allowedPlugins := o.resolveAllowedPlugins(ctx)
 	preparerAction := preparerActionSet(o.preparers, o.guards)
 
@@ -378,15 +378,34 @@ func availableToolsSet(ctx context.Context, o *Orchestrator) map[string]struct{}
 	return set
 }
 
-// resolveAvailableToolFQNs returns the sorted JSON array of FQNs from
-// availableToolsSet, or "" when empty. Returns "" (not "[]") so the host's
-// executeCall path omits the arg entirely instead of injecting an empty
-// array — the latter would force plugins to special-case empty ==
-// unrestricted vs empty == "no tools". Mirrors resolveAllowedPluginNames.
-func resolveAvailableToolFQNs(ctx context.Context, o *Orchestrator) string {
-	set := availableToolsSet(ctx, o)
+// resolveAllowedToolFQNs returns the sorted JSON array of FQNs from
+// allowedToolsSet. The empty-set case distinguishes "no profile in scope
+// → no palette to enforce" from "profile in scope, but the effective
+// palette is empty → session can call zero tools":
+//
+//   - no profile (resolveAllowedPlugins returns {m: nil}) → returns ""
+//     so the host's executeCall omits the arg entirely. Plugins receive
+//     no allowed_tools value and apply no per-session filter (fail-open
+//     because there is genuinely no palette to compare against).
+//
+//   - profile in scope, set empty → returns "[]" so the arg is delivered
+//     as a non-nil empty JSON array. Plugins interpret this as the strict
+//     "zero tools allowed" branch and drop every retrieved action. This
+//     is the fail-closed path for restricted sessions; without it, a
+//     locked-down profile would silently degrade to "no filter".
+//
+//   - set non-empty → JSON-marshalled sorted array.
+//
+// Mirrors resolveAllowedPluginNames's contract for the "absent arg" axis
+// but adds the third state because the palette has a meaningful
+// "explicitly empty" semantic that allowed_plugins does not.
+func resolveAllowedToolFQNs(ctx context.Context, o *Orchestrator) string {
+	set := allowedToolsSet(ctx, o)
 	if len(set) == 0 {
-		return ""
+		if o.resolveAllowedPlugins(ctx).m == nil {
+			return ""
+		}
+		return "[]"
 	}
 	fqns := make([]string, 0, len(set))
 	for fqn := range set {
@@ -397,8 +416,10 @@ func resolveAvailableToolFQNs(ctx context.Context, o *Orchestrator) string {
 	return string(b)
 }
 
-// defaultContextArgProviders returns built-in providers only for opaque identifiers (e.g. session_id).
-// No session messages, conversation text, or other sensitive content is exposed to plugins via this mechanism.
+// defaultContextArgProviders returns built-in providers for orchestrator-managed
+// arguments: opaque identifiers (session_id) and per-session allowlists derived
+// from the profile (allowed_plugins, allowed_tools). No session messages,
+// conversation text, or other sensitive user content is exposed via this mechanism.
 func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgProvider) map[string]ContextArgProvider {
 	builtin := map[string]ContextArgProvider{
 		"session_id": func(ctx context.Context, _ string) string { return actor.SessionID(ctx) },
@@ -406,7 +427,7 @@ func defaultContextArgProviders(o *Orchestrator, custom map[string]ContextArgPro
 			return resolveAllowedPluginNames(ctx, o)
 		},
 		"allowed_tools": func(ctx context.Context, _ string) string {
-			return resolveAvailableToolFQNs(ctx, o)
+			return resolveAllowedToolFQNs(ctx, o)
 		},
 	}
 	if len(custom) == 0 {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2504,17 +2504,22 @@ func TestPreparerEmptyRelevantToolsShowsNone(t *testing.T) {
 	}
 }
 
+// TestPreparerInjectsAllowedPlugins exercises the consolidated context-arg
+// injection path: when a preparer action declares allowed_plugins via
+// InjectContextArgs and a strict profile is present, the registered
+// ContextArgProvider populates the value before Execute runs. Replaces the
+// older inline-injection path in runPreparer.
 func TestPreparerInjectsAllowedPlugins(t *testing.T) {
-	// When a profile with strict plugins is present, the preparer should receive
-	// allowed_plugins in its args.
 	var capturedArgs map[string]string
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
 		Name: "rag-preparer", Description: "RAG",
-		Actions: []Action{{Name: "prepare", Description: "RAG prepare", Parameters: []Parameter{
-			{Name: "text", Description: "text"},
-			{Name: "allowed_plugins", Description: "allowed plugins"},
-		}}},
+		Actions: []Action{{
+			Name:              "prepare",
+			Description:       "RAG prepare",
+			Parameters:        []Parameter{{Name: "text", Description: "text"}},
+			InjectContextArgs: []string{"allowed_plugins"},
+		}},
 	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
 		capturedArgs = call.Args
 		return ToolResult{CallID: call.ID, Content: `{"send_to_llm": true, "message": "ok"}`}
@@ -2531,7 +2536,6 @@ func TestPreparerInjectsAllowedPlugins(t *testing.T) {
 	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
 	orch := NewWithRules(&fakeLLM{responses: []string{"reply"}}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
 
-	// Set up a strict profile with allowed plugins.
 	ctx := profile.WithProfile(context.Background(), &profile.Profile{
 		EntityID: "user1",
 		Group:    "team1",
@@ -2547,9 +2551,8 @@ func TestPreparerInjectsAllowedPlugins(t *testing.T) {
 	}
 	ap, ok := capturedArgs["allowed_plugins"]
 	if !ok || ap == "" {
-		t.Fatal("allowed_plugins not injected into preparer args")
+		t.Fatal("allowed_plugins not injected into preparer args via ContextArgProvider")
 	}
-	// Should be a JSON array containing the allowed plugins.
 	var plugins []string
 	if err := json.Unmarshal([]byte(ap), &plugins); err != nil {
 		t.Fatalf("allowed_plugins is not valid JSON: %v", err)
@@ -2557,6 +2560,161 @@ func TestPreparerInjectsAllowedPlugins(t *testing.T) {
 	if len(plugins) != 2 {
 		t.Errorf("expected 2 allowed plugins, got %d: %v", len(plugins), plugins)
 	}
+}
+
+// TestPreparerInjectsAllowedTools pins the new defense-in-depth provider:
+// a preparer declaring allowed_tools via InjectContextArgs receives a sorted
+// JSON array of "<plugin>.<action>" FQNs the session can currently call,
+// after profile-level plugin allowance and preparer-action exclusion. This
+// lets RAG plugins constrain knowledge_context retrieval to the session's
+// actual tool surface (see defense-layers doc).
+func TestPreparerInjectsAllowedTools(t *testing.T) {
+	var capturedArgs map[string]string
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{
+			Name:              "prepare",
+			Description:       "RAG prepare",
+			Parameters:        []Parameter{{Name: "text", Description: "text"}},
+			InjectContextArgs: []string{"allowed_tools"},
+		}},
+	}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+		capturedArgs = call.Args
+		return ToolResult{CallID: call.ID, Content: `{"send_to_llm": true, "message": "ok"}`}
+	}})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code"},
+			{Name: "list_projects", Description: "List projects"},
+		},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(&fakeLLM{responses: []string{"reply"}}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	ctx := profile.WithProfile(context.Background(), &profile.Profile{
+		EntityID: "user1",
+		Group:    "team1",
+		Plugins:  []string{"gitlab", "rag-preparer"},
+	})
+
+	_, err := orch.Run(ctx, "s1", "test message")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if capturedArgs == nil {
+		t.Fatal("preparer was not called")
+	}
+	raw, ok := capturedArgs["allowed_tools"]
+	if !ok || raw == "" {
+		t.Fatal("allowed_tools not injected into preparer args via ContextArgProvider")
+	}
+	var fqns []string
+	if err := json.Unmarshal([]byte(raw), &fqns); err != nil {
+		t.Fatalf("allowed_tools is not valid JSON: %v", err)
+	}
+	// The preparer action itself (rag-preparer.prepare) must be excluded —
+	// it is the consumer, not a session-callable tool.
+	for _, fqn := range fqns {
+		if fqn == "rag-preparer.prepare" {
+			t.Errorf("allowed_tools must not include the preparer action itself, got %v", fqns)
+		}
+	}
+	want := []string{"gitlab.analyze_code", "gitlab.list_projects"}
+	if len(fqns) != len(want) {
+		t.Fatalf("allowed_tools FQN count = %d, want %d (got %v)", len(fqns), len(want), fqns)
+	}
+	for i := range want {
+		if fqns[i] != want[i] {
+			t.Errorf("allowed_tools[%d] = %q, want %q (full: %v)", i, fqns[i], want[i], fqns)
+		}
+	}
+}
+
+// TestResolveAvailableToolFQNs_filtering directly exercises the helper used
+// by the allowed_tools ContextArgProvider, covering the four filter axes:
+// plugin allowance, preparer/guard exclusion, UserOnly exclusion, and empty
+// → "" so the host's executeCall omits the arg.
+func TestResolveAvailableToolFQNs_filtering(t *testing.T) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag-preparer", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "RAG prepare"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code"},
+			{Name: "internal_panel", Description: "Internal panel", UserOnly: true},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+
+	preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+
+	t.Run("strict profile filters by plugin allowance", func(t *testing.T) {
+		ctx := profile.WithProfile(context.Background(), &profile.Profile{
+			EntityID: "u", Group: "g",
+			Plugins: []string{"gitlab"}, // jira and rag-preparer excluded
+		})
+		raw := resolveAvailableToolFQNs(ctx, orch)
+		var fqns []string
+		if err := json.Unmarshal([]byte(raw), &fqns); err != nil {
+			t.Fatalf("not JSON: %v (raw=%q)", err, raw)
+		}
+		want := []string{"gitlab.analyze_code"} // internal_panel UserOnly excluded
+		if len(fqns) != len(want) || fqns[0] != want[0] {
+			t.Errorf("got %v, want %v", fqns, want)
+		}
+	})
+
+	t.Run("empty effective set returns empty string", func(t *testing.T) {
+		ctx := profile.WithProfile(context.Background(), &profile.Profile{
+			EntityID: "u", Group: "g",
+			Plugins: []string{"nonexistent-plugin"},
+		})
+		raw := resolveAvailableToolFQNs(ctx, orch)
+		if raw != "" {
+			t.Errorf("expected empty string for empty set (so host omits the arg), got %q", raw)
+		}
+	})
+
+	t.Run("no profile allows everything except UserOnly and preparer actions", func(t *testing.T) {
+		raw := resolveAvailableToolFQNs(context.Background(), orch)
+		var fqns []string
+		if err := json.Unmarshal([]byte(raw), &fqns); err != nil {
+			t.Fatalf("not JSON: %v (raw=%q)", err, raw)
+		}
+		// Must include both gitlab.analyze_code and jira.create_issue;
+		// must NOT include gitlab.internal_panel (UserOnly) or
+		// rag-preparer.prepare (preparer action).
+		got := map[string]bool{}
+		for _, f := range fqns {
+			got[f] = true
+		}
+		if !got["gitlab.analyze_code"] || !got["jira.create_issue"] {
+			t.Errorf("missing expected FQNs: got %v", fqns)
+		}
+		if got["gitlab.internal_panel"] {
+			t.Errorf("UserOnly action leaked into FQNs: %v", fqns)
+		}
+		if got["rag-preparer.prepare"] {
+			t.Errorf("preparer action leaked into FQNs: %v", fqns)
+		}
+	})
 }
 
 func TestSyncActions(t *testing.T) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2637,27 +2637,20 @@ func TestPreparerInjectsAllowedTools(t *testing.T) {
 	}
 }
 
-// TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics is the round-trip
-// counterpart of TestResolveAllowedToolFQNs_filtering's empty-set subtests:
-// it proves that resolveAllowedToolFQNs's two empty-set return values
-// ("" vs "[]") survive the executeCall context-arg injection path with
-// their plugin-facing semantics intact.
+// TestPreparerInjectsAllowedTools_emptyPaletteIsAlwaysExplicit is the
+// round-trip counterpart of TestResolveAllowedToolFQNs_filtering's
+// empty-set subtest: every empty-set path delivers the arg to the
+// preparer as "[]", never absent. Plugins fail-closed-by-default rely
+// on this — a buggy or older orchestrator that omits the arg would
+// otherwise still hit the fail-closed branch on the plugin side, but
+// operators would lose the "yes the palette ran and it was empty"
+// diagnostic signal that an explicit "[]" carries on the wire.
 //
-//   - profile in scope but empty effective palette → arg present with "[]"
-//     (plugin reads it as the strict zero-tools branch, fails closed)
-//   - no profile in scope → arg absent from call.Args entirely (plugin
-//     reads no value, no per-session filter applied)
-//
-// Without this pin a later change that returns "" for both cases would
-// silently degrade restricted sessions to "no filter" — the
-// defense-in-depth gap this PR closes.
-func TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics(t *testing.T) {
-	// Both subtests use a registry whose ONLY action is the preparer
-	// itself, so the palette is structurally empty regardless of profile
-	// state. That isolates the empty-set arg-injection branches the
-	// resolveAllowedToolFQNs helper produces:
-	//   - profile in scope, empty effective set → arg present as "[]"
-	//   - no profile in scope (set also empty) → arg omitted entirely
+// Both subtests use a registry whose only action is the preparer
+// itself, so the palette is structurally empty regardless of profile
+// state — isolates the empty-set arg-injection path from the
+// non-empty happy path covered by TestPreparerInjectsAllowedTools.
+func TestPreparerInjectsAllowedTools_emptyPaletteIsAlwaysExplicit(t *testing.T) {
 	newOrch := func() (*Orchestrator, *map[string]string, *bool) {
 		var capturedArgs map[string]string
 		called := false
@@ -2684,11 +2677,22 @@ func TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics(t *testing.T) {
 		return orch, &capturedArgs, &called
 	}
 
-	t.Run("profile in scope, empty effective palette → arg present as \"[]\"", func(t *testing.T) {
+	assertPresentEmpty := func(t *testing.T, capturedArgs map[string]string) {
+		t.Helper()
+		raw, ok := capturedArgs["allowed_tools"]
+		if !ok {
+			t.Fatalf("allowed_tools arg missing — expected present-as-\"[]\", got args=%v", capturedArgs)
+		}
+		if raw != "[]" {
+			t.Errorf("expected allowed_tools=\"[]\" (explicit empty), got %q", raw)
+		}
+	}
+
+	t.Run("profile in scope, every plugin filtered → arg present as \"[]\"", func(t *testing.T) {
 		orch, capturedArgs, called := newOrch()
 		ctx := profile.WithProfile(context.Background(), &profile.Profile{
 			EntityID: "u", Group: "g",
-			Plugins: []string{"nonexistent-plugin"}, // strict mode, palette empty
+			Plugins: []string{"nonexistent-plugin"},
 		})
 		if _, err := orch.Run(ctx, "s1", "test"); err != nil {
 			t.Fatal(err)
@@ -2696,30 +2700,22 @@ func TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics(t *testing.T) {
 		if !*called {
 			t.Fatal("preparer was not called")
 		}
-		raw, ok := (*capturedArgs)["allowed_tools"]
-		if !ok {
-			t.Fatalf("allowed_tools arg missing — expected present-but-\"[]\" for restricted session, got args=%v", *capturedArgs)
-		}
-		if raw != "[]" {
-			t.Errorf("expected allowed_tools=\"[]\" for fail-closed restricted session, got %q", raw)
-		}
+		assertPresentEmpty(t, *capturedArgs)
 	})
 
-	t.Run("no profile in scope → arg absent from call.Args", func(t *testing.T) {
+	t.Run("no profile in scope, preparer-only registry → arg present as \"[]\"", func(t *testing.T) {
 		orch, capturedArgs, called := newOrch()
-		// context.Background() carries no profile → resolveAllowedPlugins.m == nil.
-		// Combined with the preparer-only registry the effective set is empty,
-		// so resolveAllowedToolFQNs returns "" and executeCall must omit the
-		// arg entirely. Plugins then treat it as "no palette known, no filter".
+		// context.Background() carries no profile → all plugins allowed, but
+		// every registered action IS the preparer itself, filtered out by
+		// preparerActionSet. Empty set, arg still emitted as "[]" — the wire
+		// stays predictable across profile states.
 		if _, err := orch.Run(context.Background(), "s1", "test"); err != nil {
 			t.Fatal(err)
 		}
 		if !*called {
 			t.Fatal("preparer was not called")
 		}
-		if v, present := (*capturedArgs)["allowed_tools"]; present {
-			t.Errorf("expected allowed_tools to be omitted for no-profile context (plugin would apply no filter), got present=%q", v)
-		}
+		assertPresentEmpty(t, *capturedArgs)
 	})
 }
 
@@ -2767,39 +2763,32 @@ func TestResolveAllowedToolFQNs_filtering(t *testing.T) {
 		}
 	})
 
-	t.Run("profile in scope but empty effective set returns \"[]\"", func(t *testing.T) {
-		// Distinguishes "fail-closed restricted session" (this case) from "no
-		// palette to enforce" (no profile, covered below). Returning "[]" here
-		// makes the plugin's strict zero-tools branch reachable — without it
-		// a locked-down profile would silently fall back to no filter.
+	t.Run("empty effective set returns \"[]\" (always; both profile-in-scope and no-profile cases)", func(t *testing.T) {
+		// resolveAllowedToolFQNs always emits JSON so the plugin sees a
+		// definitive palette on every call. Both empty-set paths — strict
+		// profile with no matching plugins, AND no-profile-context with a
+		// registry that contains only preparer-internal actions — collapse
+		// to the same wire value, because the plugin's fail-closed default
+		// makes the distinction meaningless on the consumer side.
+
+		// Path 1: profile in scope, every registered plugin filtered out.
 		ctx := profile.WithProfile(context.Background(), &profile.Profile{
 			EntityID: "u", Group: "g",
 			Plugins: []string{"nonexistent-plugin"},
 		})
-		raw := resolveAllowedToolFQNs(ctx, orch)
-		if raw != "[]" {
-			t.Errorf("expected \"[]\" for profile-in-scope empty palette, got %q", raw)
+		if raw := resolveAllowedToolFQNs(ctx, orch); raw != "[]" {
+			t.Errorf("profile-in-scope empty palette: expected \"[]\", got %q", raw)
 		}
-	})
 
-	t.Run("no profile in scope returns empty string so host omits the arg", func(t *testing.T) {
-		// The other empty-set axis: when no profile is loaded at all, there's
-		// no palette concept to enforce. Returning "" makes executeCall omit
-		// the arg entirely so plugins treat it as no-filter (fail-open). This
-		// is the bare context.Background() path — no allowedPlugins, but the
-		// registry still has the preparer action which gets filtered out by
-		// the preparerAction set; once we strip every plugin's actions the
-		// set is empty under the "no profile" precondition.
+		// Path 2: no profile, registry contains only preparer-internal actions.
 		registry := NewToolRegistry()
 		_ = registry.Register(PluginCapability{
 			Name: "rag", Description: "RAG", Actions: []Action{{Name: "prepare"}},
 		}, &echoExecutor{})
 		preparers := []ContentPreparerEntry{{Plugin: "rag", Action: "prepare"}}
 		emptyOrch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, state.NewMemoryStore(""), state.NewSessionStore(""), OrchestratorOpts{ContentPreparers: preparers})
-
-		raw := resolveAllowedToolFQNs(context.Background(), emptyOrch)
-		if raw != "" {
-			t.Errorf("expected \"\" so host omits the arg for no-profile + empty set, got %q", raw)
+		if raw := resolveAllowedToolFQNs(context.Background(), emptyOrch); raw != "[]" {
+			t.Errorf("no-profile preparer-only registry: expected \"[]\", got %q", raw)
 		}
 	})
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2637,11 +2637,97 @@ func TestPreparerInjectsAllowedTools(t *testing.T) {
 	}
 }
 
-// TestResolveAvailableToolFQNs_filtering directly exercises the helper used
+// TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics is the round-trip
+// counterpart of TestResolveAllowedToolFQNs_filtering's empty-set subtests:
+// it proves that resolveAllowedToolFQNs's two empty-set return values
+// ("" vs "[]") survive the executeCall context-arg injection path with
+// their plugin-facing semantics intact.
+//
+//   - profile in scope but empty effective palette → arg present with "[]"
+//     (plugin reads it as the strict zero-tools branch, fails closed)
+//   - no profile in scope → arg absent from call.Args entirely (plugin
+//     reads no value, no per-session filter applied)
+//
+// Without this pin a later change that returns "" for both cases would
+// silently degrade restricted sessions to "no filter" — the
+// defense-in-depth gap this PR closes.
+func TestPreparerInjectsAllowedTools_emptyVsAbsentSemantics(t *testing.T) {
+	// Both subtests use a registry whose ONLY action is the preparer
+	// itself, so the palette is structurally empty regardless of profile
+	// state. That isolates the empty-set arg-injection branches the
+	// resolveAllowedToolFQNs helper produces:
+	//   - profile in scope, empty effective set → arg present as "[]"
+	//   - no profile in scope (set also empty) → arg omitted entirely
+	newOrch := func() (*Orchestrator, *map[string]string, *bool) {
+		var capturedArgs map[string]string
+		called := false
+		registry := NewToolRegistry()
+		_ = registry.Register(PluginCapability{
+			Name: "rag-preparer", Description: "RAG",
+			Actions: []Action{{
+				Name:              "prepare",
+				Description:       "RAG prepare",
+				Parameters:        []Parameter{{Name: "text", Description: "text"}},
+				InjectContextArgs: []string{"allowed_tools"},
+			}},
+		}, &capturingExecutor{fn: func(call ToolCall) ToolResult {
+			capturedArgs = call.Args
+			called = true
+			return ToolResult{CallID: call.ID, Content: `{"send_to_llm": true, "message": "ok"}`}
+		}})
+
+		memory := state.NewMemoryStore("")
+		sessions := state.NewSessionStore("")
+		sessions.Create("s1", "", "")
+		preparers := []ContentPreparerEntry{{Plugin: "rag-preparer", Action: "prepare"}}
+		orch := NewWithRules(&fakeLLM{responses: []string{"reply"}}, &fakeParser{parseFn: func(string) []ToolCall { return nil }}, registry, memory, sessions, OrchestratorOpts{ContentPreparers: preparers})
+		return orch, &capturedArgs, &called
+	}
+
+	t.Run("profile in scope, empty effective palette → arg present as \"[]\"", func(t *testing.T) {
+		orch, capturedArgs, called := newOrch()
+		ctx := profile.WithProfile(context.Background(), &profile.Profile{
+			EntityID: "u", Group: "g",
+			Plugins: []string{"nonexistent-plugin"}, // strict mode, palette empty
+		})
+		if _, err := orch.Run(ctx, "s1", "test"); err != nil {
+			t.Fatal(err)
+		}
+		if !*called {
+			t.Fatal("preparer was not called")
+		}
+		raw, ok := (*capturedArgs)["allowed_tools"]
+		if !ok {
+			t.Fatalf("allowed_tools arg missing — expected present-but-\"[]\" for restricted session, got args=%v", *capturedArgs)
+		}
+		if raw != "[]" {
+			t.Errorf("expected allowed_tools=\"[]\" for fail-closed restricted session, got %q", raw)
+		}
+	})
+
+	t.Run("no profile in scope → arg absent from call.Args", func(t *testing.T) {
+		orch, capturedArgs, called := newOrch()
+		// context.Background() carries no profile → resolveAllowedPlugins.m == nil.
+		// Combined with the preparer-only registry the effective set is empty,
+		// so resolveAllowedToolFQNs returns "" and executeCall must omit the
+		// arg entirely. Plugins then treat it as "no palette known, no filter".
+		if _, err := orch.Run(context.Background(), "s1", "test"); err != nil {
+			t.Fatal(err)
+		}
+		if !*called {
+			t.Fatal("preparer was not called")
+		}
+		if v, present := (*capturedArgs)["allowed_tools"]; present {
+			t.Errorf("expected allowed_tools to be omitted for no-profile context (plugin would apply no filter), got present=%q", v)
+		}
+	})
+}
+
+// TestResolveAllowedToolFQNs_filtering directly exercises the helper used
 // by the allowed_tools ContextArgProvider, covering the four filter axes:
 // plugin allowance, preparer/guard exclusion, UserOnly exclusion, and empty
 // → "" so the host's executeCall omits the arg.
-func TestResolveAvailableToolFQNs_filtering(t *testing.T) {
+func TestResolveAllowedToolFQNs_filtering(t *testing.T) {
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
 		Name: "rag-preparer", Description: "RAG",
@@ -2670,7 +2756,7 @@ func TestResolveAvailableToolFQNs_filtering(t *testing.T) {
 			EntityID: "u", Group: "g",
 			Plugins: []string{"gitlab"}, // jira and rag-preparer excluded
 		})
-		raw := resolveAvailableToolFQNs(ctx, orch)
+		raw := resolveAllowedToolFQNs(ctx, orch)
 		var fqns []string
 		if err := json.Unmarshal([]byte(raw), &fqns); err != nil {
 			t.Fatalf("not JSON: %v (raw=%q)", err, raw)
@@ -2681,19 +2767,44 @@ func TestResolveAvailableToolFQNs_filtering(t *testing.T) {
 		}
 	})
 
-	t.Run("empty effective set returns empty string", func(t *testing.T) {
+	t.Run("profile in scope but empty effective set returns \"[]\"", func(t *testing.T) {
+		// Distinguishes "fail-closed restricted session" (this case) from "no
+		// palette to enforce" (no profile, covered below). Returning "[]" here
+		// makes the plugin's strict zero-tools branch reachable — without it
+		// a locked-down profile would silently fall back to no filter.
 		ctx := profile.WithProfile(context.Background(), &profile.Profile{
 			EntityID: "u", Group: "g",
 			Plugins: []string{"nonexistent-plugin"},
 		})
-		raw := resolveAvailableToolFQNs(ctx, orch)
+		raw := resolveAllowedToolFQNs(ctx, orch)
+		if raw != "[]" {
+			t.Errorf("expected \"[]\" for profile-in-scope empty palette, got %q", raw)
+		}
+	})
+
+	t.Run("no profile in scope returns empty string so host omits the arg", func(t *testing.T) {
+		// The other empty-set axis: when no profile is loaded at all, there's
+		// no palette concept to enforce. Returning "" makes executeCall omit
+		// the arg entirely so plugins treat it as no-filter (fail-open). This
+		// is the bare context.Background() path — no allowedPlugins, but the
+		// registry still has the preparer action which gets filtered out by
+		// the preparerAction set; once we strip every plugin's actions the
+		// set is empty under the "no profile" precondition.
+		registry := NewToolRegistry()
+		_ = registry.Register(PluginCapability{
+			Name: "rag", Description: "RAG", Actions: []Action{{Name: "prepare"}},
+		}, &echoExecutor{})
+		preparers := []ContentPreparerEntry{{Plugin: "rag", Action: "prepare"}}
+		emptyOrch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, state.NewMemoryStore(""), state.NewSessionStore(""), OrchestratorOpts{ContentPreparers: preparers})
+
+		raw := resolveAllowedToolFQNs(context.Background(), emptyOrch)
 		if raw != "" {
-			t.Errorf("expected empty string for empty set (so host omits the arg), got %q", raw)
+			t.Errorf("expected \"\" so host omits the arg for no-profile + empty set, got %q", raw)
 		}
 	})
 
 	t.Run("no profile allows everything except UserOnly and preparer actions", func(t *testing.T) {
-		raw := resolveAvailableToolFQNs(context.Background(), orch)
+		raw := resolveAllowedToolFQNs(context.Background(), orch)
 		var fqns []string
 		if err := json.Unmarshal([]byte(raw), &fqns); err != nil {
 			t.Fatalf("not JSON: %v (raw=%q)", err, raw)

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -115,11 +115,11 @@ func (e *getToolDetailsExecutor) Execute(ctx context.Context, call ToolCall) Too
 	// non-existent action; no existence oracle for filtered tools.
 	//
 	// Same palette computation as the `allowed_tools` ContextArgProvider
-	// feeds — availableToolsSet is the single source of truth for "what
-	// this session can see" across both the RAG-retrieval vector (preparer
+	// feeds — allowedToolsSet is the single source of truth for "what this
+	// session can see" across both the RAG-retrieval vector (preparer
 	// plugins consume the JSON form) and the direct-lookup vector here.
-	available := availableToolsSet(ctx, e.orch)
-	if _, visible := available[name]; !visible {
+	allowed := allowedToolsSet(ctx, e.orch)
+	if _, visible := allowed[name]; !visible {
 		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("action %q not found in plugin %q", action, plugin)}
 	}
 

--- a/internal/orchestrator/system_tools.go
+++ b/internal/orchestrator/system_tools.go
@@ -103,6 +103,26 @@ func (e *getToolDetailsExecutor) Execute(ctx context.Context, call ToolCall) Too
 		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("action %q not found in plugin %q", action, plugin)}
 	}
 
+	// Action-level visibility gate. The plugin gate above is too coarse:
+	// cap.Actions may contain an action that the session's tools/list filter
+	// hides (e.g. an MCP backend whose manifest filter excludes admin tools
+	// per auth path, leaving them in the OpenTalon registry only because a
+	// downstream plugin instance with broader auth surfaced them on a sync).
+	// Without this gate, the LLM could fetch the full description + parameter
+	// schema of a tool it can never invoke — information disclosure around the
+	// per-session palette. Returns the same "action not found" shape as the
+	// missing-action branch so a denied lookup is indistinguishable from a
+	// non-existent action; no existence oracle for filtered tools.
+	//
+	// Same palette computation as the `allowed_tools` ContextArgProvider
+	// feeds — availableToolsSet is the single source of truth for "what
+	// this session can see" across both the RAG-retrieval vector (preparer
+	// plugins consume the JSON form) and the direct-lookup vector here.
+	available := availableToolsSet(ctx, e.orch)
+	if _, visible := available[name]; !visible {
+		return ToolResult{CallID: call.ID, Error: fmt.Sprintf("action %q not found in plugin %q", action, plugin)}
+	}
+
 	if sessionID := actor.SessionID(ctx); sessionID != "" && e.orch.injectionStateStore != nil {
 		e.orch.persistToolPromotion(ctx, sessionID, name)
 	}

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -242,7 +242,7 @@ func TestGetToolDetails_FilteredByUserOnlyActionReturnsNotFound(t *testing.T) {
 // TestGetToolDetails_FilteredByPreparerActionReturnsNotFound pins the
 // same gate on a second exclusion axis: preparer/guard actions live in
 // cap.Actions for invocation, but the LLM should never inspect them
-// (they're internal control-plane tools). availableToolsSet excludes
+// (they're internal control-plane tools). allowedToolsSet excludes
 // them on the preparerAction axis; the gate must reject lookups too.
 func TestGetToolDetails_FilteredByPreparerActionReturnsNotFound(t *testing.T) {
 	registry := NewToolRegistry()
@@ -287,7 +287,7 @@ func TestGetToolDetails_FilteredByPreparerActionReturnsNotFound(t *testing.T) {
 	}
 }
 
-// TestAvailableToolsSet_ConsistentWithFQNs pins the invariant that both
+// TestAllowedToolsSet_ConsistentWithFQNs pins the invariant that both
 // consumers of the per-session palette — the JSON-array form for the
 // allowed_tools ContextArgProvider (RAG plugins consume it via gRPC) and
 // the map form for the get_tool_details action-level gate — see the
@@ -295,7 +295,7 @@ func TestGetToolDetails_FilteredByPreparerActionReturnsNotFound(t *testing.T) {
 // defense-in-depth gap the palette exists to close: a tool visible at
 // one consumer and not the other would still leak via the visible
 // vector.
-func TestAvailableToolsSet_ConsistentWithFQNs(t *testing.T) {
+func TestAllowedToolsSet_ConsistentWithFQNs(t *testing.T) {
 	registry := NewToolRegistry()
 	_ = registry.Register(PluginCapability{
 		Name: "gitlab", Description: "GitLab",
@@ -321,8 +321,8 @@ func TestAvailableToolsSet_ConsistentWithFQNs(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	set := availableToolsSet(ctx, orch)
-	jsonStr := resolveAvailableToolFQNs(ctx, orch)
+	set := allowedToolsSet(ctx, orch)
+	jsonStr := resolveAllowedToolFQNs(ctx, orch)
 
 	// The JSON form omits the field when empty; non-empty sets must round-trip
 	// to the same membership as the map.

--- a/internal/orchestrator/system_tools_test.go
+++ b/internal/orchestrator/system_tools_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
@@ -181,6 +182,167 @@ func TestGetToolDetails_ProfileRestrictedPluginReturnsNotFound(t *testing.T) {
 	}
 	if store.updateCalls != 0 {
 		t.Errorf("denied call must not write to InjectionState, got %d UpdateInjectionState calls", store.updateCalls)
+	}
+}
+
+// TestGetToolDetails_FilteredByUserOnlyActionReturnsNotFound pins the
+// action-level palette gate: cap.Actions may legitimately contain an
+// action that the per-session palette excludes (UserOnly here, the
+// canonical "registry has it but the LLM should never see it" case;
+// in production this also catches actions hidden by an upstream
+// manifest-filter that surfaced them to a different auth path). Without
+// the gate, get_tool_details would return the full description +
+// parameter schema for a tool the LLM cannot invoke — information
+// disclosure around the per-session palette.
+//
+// Error shape MUST match the "action … not found" branch so a denied
+// lookup is indistinguishable from a non-existent action: no existence
+// oracle for palette-filtered tools. Side-effect (Tier-1 promotion)
+// MUST NOT fire for denied lookups, otherwise the next turn's preparer
+// would see a phantom promotion for a tool that was never visible.
+func TestGetToolDetails_FilteredByUserOnlyActionReturnsNotFound(t *testing.T) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "tools-plugin", Description: "tools",
+		Actions: []Action{
+			{Name: "public-tool", Description: "Public tool the LLM may see."},
+			{Name: "user-only-tool", Description: "Sensitive; UserOnly excludes from LLM palette.", UserOnly: true},
+		},
+	}, &fixedResultExecutor{content: "result"})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	store := &fakeInjectionStateStore{}
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ToolTiers:           ToolTiersConfig{Enabled: true, EnableGetToolDetails: true},
+		InjectionStateStore: store,
+	})
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+
+	res := exec.Execute(ctx, ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "tools-plugin.user-only-tool"},
+	})
+
+	if res.Error == "" {
+		t.Fatalf("expected not-found error for UserOnly action, got content: %q", res.Content)
+	}
+	if !strings.Contains(res.Error, "user-only-tool") || !strings.Contains(res.Error, "not found") {
+		t.Errorf("error must mimic 'action … not found' shape so denied ≠ existence oracle, got: %q", res.Error)
+	}
+	if strings.Contains(res.Error, "Sensitive") || strings.Contains(res.Error, "UserOnly") {
+		t.Errorf("error must not leak the filtered action's description or its filter reason, got: %q", res.Error)
+	}
+	if store.updateCalls != 0 {
+		t.Errorf("denied call must not promote a palette-filtered tool, got %d UpdateInjectionState calls", store.updateCalls)
+	}
+}
+
+// TestGetToolDetails_FilteredByPreparerActionReturnsNotFound pins the
+// same gate on a second exclusion axis: preparer/guard actions live in
+// cap.Actions for invocation, but the LLM should never inspect them
+// (they're internal control-plane tools). availableToolsSet excludes
+// them on the preparerAction axis; the gate must reject lookups too.
+func TestGetToolDetails_FilteredByPreparerActionReturnsNotFound(t *testing.T) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "rag", Description: "RAG preparer",
+		Actions: []Action{
+			{Name: "prepare", Description: "Preparer-internal; LLM should not inspect."},
+			{Name: "ask", Description: "LLM-callable knowledge lookup."},
+		},
+	}, &fixedResultExecutor{content: "result"})
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	sessions.Create("s1", "", "")
+	store := &fakeInjectionStateStore{}
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ContentPreparers:    []ContentPreparerEntry{{Plugin: "rag", Action: "prepare"}},
+		ToolTiers:           ToolTiersConfig{Enabled: true, EnableGetToolDetails: true},
+		InjectionStateStore: store,
+	})
+	exec, _ := orch.registry.GetExecutor(metaPluginName)
+	ctx := actor.WithSessionID(context.Background(), "s1")
+
+	denied := exec.Execute(ctx, ToolCall{
+		ID:   "c1",
+		Args: map[string]string{"name": "rag.prepare"},
+	})
+	if denied.Error == "" || !strings.Contains(denied.Error, "not found") {
+		t.Fatalf("preparer action lookup must be gated, got error=%q content=%q", denied.Error, denied.Content)
+	}
+
+	// Regression guard on the same plugin: a non-preparer action must still
+	// resolve, proving the gate's granularity is action-level, not plugin-level.
+	allowed := exec.Execute(ctx, ToolCall{
+		ID:   "c2",
+		Args: map[string]string{"name": "rag.ask"},
+	})
+	if allowed.Error != "" {
+		t.Fatalf("non-preparer action on the same plugin must resolve, got error=%q", allowed.Error)
+	}
+	if !strings.Contains(allowed.Content, "rag.ask") {
+		t.Errorf("description rendering for allowed action regressed: %q", allowed.Content)
+	}
+}
+
+// TestAvailableToolsSet_ConsistentWithFQNs pins the invariant that both
+// consumers of the per-session palette — the JSON-array form for the
+// allowed_tools ContextArgProvider (RAG plugins consume it via gRPC) and
+// the map form for the get_tool_details action-level gate — see the
+// same set. Drift between the two would create exactly the
+// defense-in-depth gap the palette exists to close: a tool visible at
+// one consumer and not the other would still leak via the visible
+// vector.
+func TestAvailableToolsSet_ConsistentWithFQNs(t *testing.T) {
+	registry := NewToolRegistry()
+	_ = registry.Register(PluginCapability{
+		Name: "gitlab", Description: "GitLab",
+		Actions: []Action{
+			{Name: "analyze_code", Description: "Analyze code"},
+			{Name: "internal_panel", Description: "Internal panel", UserOnly: true},
+		},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "jira", Description: "Jira",
+		Actions: []Action{{Name: "create_issue", Description: "Create issue"}},
+	}, &echoExecutor{})
+	_ = registry.Register(PluginCapability{
+		Name: "rag", Description: "RAG",
+		Actions: []Action{{Name: "prepare", Description: "Preparer"}},
+	}, &echoExecutor{})
+
+	memory := state.NewMemoryStore("")
+	sessions := state.NewSessionStore("")
+	preparers := []ContentPreparerEntry{{Plugin: "rag", Action: "prepare"}}
+	orch := NewWithRules(&fakeLLM{}, &fakeParser{}, registry, memory, sessions, OrchestratorOpts{
+		ContentPreparers: preparers,
+	})
+
+	ctx := context.Background()
+	set := availableToolsSet(ctx, orch)
+	jsonStr := resolveAvailableToolFQNs(ctx, orch)
+
+	// The JSON form omits the field when empty; non-empty sets must round-trip
+	// to the same membership as the map.
+	if len(set) == 0 {
+		t.Fatal("test fixture must produce a non-empty palette")
+	}
+	if jsonStr == "" {
+		t.Fatalf("JSON form must be non-empty when set is non-empty (set=%v)", set)
+	}
+	var fqns []string
+	if err := json.Unmarshal([]byte(jsonStr), &fqns); err != nil {
+		t.Fatalf("JSON form not valid: %v", err)
+	}
+	if len(fqns) != len(set) {
+		t.Fatalf("set size %d != JSON array length %d (set=%v, json=%v)", len(set), len(fqns), set, fqns)
+	}
+	for _, fqn := range fqns {
+		if _, ok := set[fqn]; !ok {
+			t.Errorf("JSON contains %q which is not in set (drift: %v vs %v)", fqn, fqns, set)
+		}
 	}
 }
 

--- a/internal/orchestrator/tool_tier_decision.go
+++ b/internal/orchestrator/tool_tier_decision.go
@@ -502,7 +502,7 @@ func (o *Orchestrator) alwaysIncludeToolNames(ctx context.Context) []string {
 // Tier-0 pinned subset.
 func (o *Orchestrator) listProfileToolNames(ctx context.Context, alwaysIncludeOnly bool) []string {
 	allowedPlugins, _ := ctx.Value(allowedPluginsKey{}).(cachedAllowedPlugins)
-	preparerAction := preparerActionSet(o.preparers, o.guards)
+	preparerAction := o.preparerActions
 
 	var names []string
 	for _, cap := range o.registry.ListCapabilities() {

--- a/pkg/plugin/contextargs/names.go
+++ b/pkg/plugin/contextargs/names.go
@@ -1,0 +1,34 @@
+// Package contextargs declares the wire names for orchestrator-managed
+// context arguments that plugins may opt into receiving via
+// ActionMsg.InjectContextArgs. Both the host (opentalon-core's
+// ContextArgProvider registry) and external plugins (their Capability
+// manifests AND their Execute-time Args parse) reference the same
+// constants here, so a typo in any one site fails to compile rather
+// than silently drifting and leaving the consumer with empty args.
+//
+// Adding a new context arg name: declare it as a const here AND register
+// a matching provider in the host's defaultContextArgProviders. Plugins
+// then opt in by listing the name in InjectContextArgs on each action
+// that needs it.
+package contextargs
+
+// SessionID is the opaque session identifier carried in the request
+// context. Resolves to the empty string when called outside a session.
+const SessionID = "session_id"
+
+// AllowedPlugins is the sorted JSON array of plugin names the current
+// profile permits. Plugins may use it as a coarse pre-filter (e.g.
+// MCPActions WHERE pluginName ContainsAny […]) before applying
+// AllowedTools. Empty string "" means "no profile is loaded; do not
+// apply this filter".
+const AllowedPlugins = "allowed_plugins"
+
+// AllowedTools is the sorted JSON array of fully-qualified tool names
+// ("<plugin>.<action>") the current session can invoke right now —
+// profile-level plugin allowance + preparer-action exclusion +
+// UserOnly exclusion. Always emitted; "[]" is a legitimate value
+// meaning "the session can call zero tools" (fail-closed). Plugins
+// consuming this value MUST fail-closed when the arg is absent: an
+// older or misconfigured host that omitted it would otherwise silently
+// drop the chokepoint that the per-session palette enforces.
+const AllowedTools = "allowed_tools"


### PR DESCRIPTION
## Summary

Three related changes that turn the per-session tool palette into a coherent defense-in-depth layer protecting both the RAG-retrieval vector and the direct-lookup vector for tool descriptions.

## Background

When a single MCP backend (or multiple plugin instances against the same backend with different auth contexts) lands actions in the registry that are *not* visible to every session, the orchestrator currently has two leak vectors that bypass per-session palette enforcement:

1. **RAG retrieval** (`weaviate.prepare`) returns a shared MCPActions corpus regardless of which session triggered the query — high-scoring out-of-palette tools land in `[knowledge_context]`.
2. **`_meta.get_tool_details`** returns full description + parameter schema for any registry action that passes the *plugin-level* gate, ignoring per-session action visibility.

Layer 1 (per-MCP-backend filter at the source) covers the common case in current deployments. This PR adds Layer 2 inside the orchestrator so the defense holds even if Layer 1 ever broadens.

## Changes

### 1. Context-arg injection consolidation
Two parallel mechanisms existed — declarative `Action.InjectContextArgs` (used by LLM-called actions) and an imperative inline write in `runPreparer` for `allowed_plugins` only. Consolidate onto the declarative path. The plugin manifest now documents the dependency explicitly — the right design for a public plugin protocol.

`search_text` stays inline because its content-aware conditional cannot be expressed by a stateless `ContextArgProvider` — kept side-by-side with the removed `allowed_plugins` block with a comment explaining why.

### 2. `allowed_tools` per-session palette provider
New `ContextArgProvider` returning the sorted JSON array of `<plugin>.<action>` FQNs the session can call right now (profile-level plugin allowance + preparer-action exclusion + UserOnly exclusion).

`availableToolsSet` is the single computation point; `resolveAvailableToolFQNs` (JSON form, fed to the `ContextArgProvider`) and the `get_tool_details` gate (map form, see below) both consume it.

### 3. `_meta.get_tool_details` action-level visibility gate
New gate after the existing plugin + action-existence checks. Returns the same `action not found` shape as the missing-action branch — denied lookups are indistinguishable from non-existent actions (no existence oracle). Tier-1 promotion side-effect is gated too, so a denied lookup cannot leave phantom state in `InjectionState`.

## Defense-in-depth contract (fail-closed default after review pivot)

The consumer plugin (weaviate-plugin#33) now treats an **absent or unparseable** `allowed_tools` arg as fail-closed — every retrieved action is dropped. This commit makes the wire side mirror that: `resolveAllowedToolFQNs` always returns a JSON value, even `"[]"` for empty palettes, so the plugin sees a definitive answer on every call. Operators reading `session_events` can distinguish "orchestrator forgot to wire allowed\_tools" (arg absent) from "session has no tools" (arg = `"[]"`).

**Deploy contract**: this PR must land before weaviate-plugin#33 in any environment that needs RAG retrieval. An older Core paired with the new plugin will leave the arg absent and every preparer call returns zero tools. Beta-acceptable but worth knowing.

## Original defense-in-depth invariant
`get_tool_details` gate and the RAG filter (companion PR on `weaviate-plugin`) share the same palette computation. Drift between the two would re-open exactly the gap this closes — pinned by `TestAvailableToolsSet_ConsistentWithFQNs`.

## Breaking change
Preparer plugins that consumed `allowed_plugins` without declaring it in their Capability manifest must now declare `InjectContextArgs: ["allowed_plugins"]` to keep receiving it. In this org, the only known preparer plugin is `weaviate-plugin/prepare` — covered by the companion PR (link below).

## Companion PR
- `opentalon/weaviate-plugin#33` — declarative `InjectContextArgs` + `allowed_tools` chokepoint wire.

## Test plan
- [x] `TestPreparerInjectsAllowedPlugins` migrated to the declarative path — proves consolidation didn't regress the existing inject behaviour.
- [x] `TestPreparerInjectsAllowedTools` end-to-end on the new provider.
- [x] `TestResolveAvailableToolFQNs_filtering` — four filter axes (profile, preparer, UserOnly, empty-set-returns-`""`).
- [x] `TestGetToolDetails_FilteredByUserOnlyActionReturnsNotFound` + `TestGetToolDetails_FilteredByPreparerActionReturnsNotFound` — new gate, denied ≠ existence oracle, promotion side-effect blocked.
- [x] `TestAvailableToolsSet_ConsistentWithFQNs` — set-form/JSON-form invariant.
- [x] Full `go test ./internal/orchestrator/` passes (no regression).