### PR TITLE
feat(whoami): forward inbound metadata as configurable headers

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -549,6 +549,7 @@ func main() {
 			LimitTimeField:    cfg.Profiles.WhoAmI.LimitTimeField,
 			LanguageField:     cfg.Profiles.WhoAmI.LanguageField,
 			ExtraHeaders:      cfg.Profiles.WhoAmI.ExtraHeaders,
+			MetadataHeaders:   cfg.Profiles.WhoAmI.MetadataHeaders,
 		}
 		if d, err := time.ParseDuration(cfg.Profiles.WhoAmI.Timeout); err == nil {
 			vcfg.Timeout = d

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -68,6 +68,7 @@ profiles:
     plugins_field: plugins        # JSON key for plugin list; default "plugins"
     model_field: model            # JSON key for model override; default "model"
     extra_headers: {}             # static headers added to every WhoAmI call (see below)
+    metadata_headers: {}          # forward per-message metadata as headers (see below)
 ```
 
 ### Using platform user IDs as the token
@@ -112,6 +113,35 @@ inbound:
 ```
 
 `extra_headers` values support `${ENV_VAR}` expansion. The headers are added to every WhoAmI call alongside the main token header.
+
+### Distinguishing multiple bots of the same channel type
+
+If you run more than one bot on the same channel (e.g. an admin Slack bot and a customer Slack bot that share an opentalon deployment), the WhoAmI server needs to know which bot a request came from so it can return different groups, plugins, or limits. The token alone is the end-user's platform ID — it's the same regardless of which bot the user is talking to.
+
+Use `metadata_headers` to forward per-bot identity into WhoAmI:
+
+```yaml
+profiles:
+  who_am_i:
+    url: "https://auth.example.com/whoami"
+    metadata_headers:
+      channel_id: X-Channel-ID    # forward msg.Metadata["channel_id"] as X-Channel-ID
+```
+
+Each channel adapter declares what fills `channel_id`. For Slack, the bot's user ID is the natural identifier:
+
+```yaml
+# slack-channel/channel.yaml
+inbound:
+  mapping:
+    metadata:
+      profile_token: "user"
+      channel_id: "{{self.bot_user_id}}"   # template expands from channel state
+```
+
+WhoAmI then receives `X-Channel-ID: <bot user id>` on every call and can branch on it. The verifier cache key includes every `metadata_headers` value, so two bots that share a user token never collide on a cached profile.
+
+Metadata mapping values that contain `{{namespace.key}}` are template-expanded against channel state (`self.*`, `config.*`, `env.*`). Plain strings preserve the original behavior of naming an event field to pluck. Configured `metadata_headers` whose target header collides with `token_header`, `channel_type_header`, or any `extra_headers` entry are dropped at startup with a warning.
 
 > **TLS in production:** the shared secret prevents forged requests, but without TLS it is visible in transit and replayable. Use `https://` when the WhoAmI server is reachable from outside the cluster. Within a Kubernetes cluster (pod-to-pod over the cluster network), `http://` is acceptable — the network is already isolated and the secret never leaves the cluster.
 

--- a/internal/channel/handler.go
+++ b/internal/channel/handler.go
@@ -16,7 +16,7 @@ import (
 
 // ProfileVerifier is the subset of profile.Verifier used by the handler.
 type ProfileVerifier interface {
-	Verify(ctx context.Context, token, channelType string) (*profile.Profile, error)
+	Verify(ctx context.Context, token, channelType string, metadata map[string]string) (*profile.Profile, error)
 }
 
 // LimitChecker checks how many tokens an entity has consumed within a rolling window.
@@ -70,7 +70,7 @@ func NewMessageHandler(cfg HandlerConfig) pkg.MessageHandler {
 			if token == "" {
 				return errorFrame(msg, "profile token required", "token_required"), nil
 			}
-			p, err := cfg.Verifier.Verify(ctx, token, msg.ChannelID)
+			p, err := cfg.Verifier.Verify(ctx, token, msg.ChannelID, msg.Metadata)
 			if err != nil {
 				slog.Warn("profile verification failed", "error", err, "channel", msg.ChannelID)
 				return errorFrame(msg, "authentication failed", "auth_failed"), nil

--- a/internal/channel/handler_test.go
+++ b/internal/channel/handler_test.go
@@ -19,7 +19,7 @@ type stubVerifier struct {
 	err error
 }
 
-func (s *stubVerifier) Verify(_ context.Context, _, _ string) (*profile.Profile, error) {
+func (s *stubVerifier) Verify(_ context.Context, _, _ string, _ map[string]string) (*profile.Profile, error) {
 	return s.p, s.err
 }
 

--- a/internal/channel/yaml_ws.go
+++ b/internal/channel/yaml_ws.go
@@ -369,8 +369,21 @@ func (ch *YAMLChannel) extractMessage(event map[string]interface{}, eventCtx map
 
 	if len(ch.spec.Inbound.Mapping.Metadata) > 0 {
 		msg.Metadata = make(map[string]string, len(ch.spec.Inbound.Mapping.Metadata))
-		for metaKey, eventField := range ch.spec.Inbound.Mapping.Metadata {
-			msg.Metadata[metaKey] = getStringField(event, eventField)
+		var contexts map[string]map[string]string
+		for metaKey, spec := range ch.spec.Inbound.Mapping.Metadata {
+			// Values containing {{namespace.key}} are template-expanded
+			// against channel state (self.*, config.*, env.*) so a channel
+			// can surface its own identity (e.g. {{self.bot_user_id}}) into
+			// per-message metadata. Plain strings preserve the original
+			// behavior of naming an event field to pluck.
+			if strings.Contains(spec, "{{") {
+				if contexts == nil {
+					contexts = ch.buildContexts()
+				}
+				msg.Metadata[metaKey] = substituteTemplate(spec, contexts)
+				continue
+			}
+			msg.Metadata[metaKey] = getStringField(event, spec)
 		}
 	}
 

--- a/internal/channel/yaml_ws_test.go
+++ b/internal/channel/yaml_ws_test.go
@@ -370,3 +370,44 @@ func TestExtractMessage(t *testing.T) {
 		t.Errorf("Metadata[ts] = %q, want %q", msg.Metadata["ts"], "1234567890.123456")
 	}
 }
+
+// TestExtractMessage_MetadataTemplate verifies that a metadata mapping value
+// containing {{namespace.key}} is template-expanded against channel state
+// instead of being looked up as an event field. This is how a channel adapter
+// surfaces its own identity (e.g. {{self.bot_user_id}}) into per-message
+// metadata, which the verifier then forwards to WhoAmI.
+func TestExtractMessage_MetadataTemplate(t *testing.T) {
+	ch := &YAMLChannel{
+		spec: &YAMLChannelSpec{
+			ID: "slack",
+			Inbound: InboundSpec{
+				Mapping: MappingSpec{
+					ConversationID: MappingField{Field: "channel"},
+					SenderID:       MappingField{Field: "user"},
+					Content:        MappingField{Field: "text"},
+					Metadata: map[string]string{
+						"ts":         "ts",
+						"channel_id": "{{self.bot_user_id}}",
+					},
+				},
+			},
+		},
+		selfVars: map[string]string{"bot_user_id": "UBOTA"},
+		config:   make(map[string]string),
+	}
+
+	event := map[string]interface{}{
+		"channel": "C123",
+		"user":    "U456",
+		"text":    "hi",
+		"ts":      "1234.5678",
+	}
+	msg := ch.extractMessage(event, flattenToStringMap(event))
+
+	if got := msg.Metadata["channel_id"]; got != "UBOTA" {
+		t.Errorf("Metadata[channel_id] = %q, want UBOTA (template should expand from self)", got)
+	}
+	if got := msg.Metadata["ts"]; got != "1234.5678" {
+		t.Errorf("Metadata[ts] = %q, want 1234.5678 (plain field name should still be looked up in event)", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,6 +115,14 @@ type WhoAmIConfig struct {
 	CredentialsField  string            `yaml:"credentials_field"`       // optional JSON field for per-MCP-server tokens map; default "credentials"
 	LanguageField     string            `yaml:"language_field"`          // optional JSON field for user language; default "language"
 	ExtraHeaders      map[string]string `yaml:"extra_headers,omitempty"` // static headers added to every WhoAmI call; values support ${ENV_VAR}
+	// MetadataHeaders maps an inbound message metadata key to an outbound HTTP
+	// header name. For each entry, the verifier reads msg.Metadata[key] and
+	// sends its value under the configured header on every WhoAmI request.
+	// Example: {"channel_id": "X-Channel-ID"} forwards the per-bot identifier a
+	// channel adapter writes into msg.Metadata["channel_id"]. Values are part
+	// of the verifier cache key, so two different bot identities never share a
+	// cached profile even when the bearer token matches.
+	MetadataHeaders map[string]string `yaml:"metadata_headers,omitempty"`
 }
 
 // GroupConfig is a static baseline of plugin IDs for a group.

--- a/internal/profile/verifier.go
+++ b/internal/profile/verifier.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"os"
+	"sort"
 	"sync"
 	"time"
 )
@@ -49,6 +50,31 @@ type VerifierConfig struct {
 	LanguageField     string            // optional JSON field for user language; default "language"
 	BudgetTokensField string            // optional JSON field for reasoning budget tokens; default "budget_tokens"
 	ExtraHeaders      map[string]string // static headers sent on every WhoAmI call; ${ENV_VAR} expanded once at construction
+	// MetadataHeaders maps an inbound metadata key to an outbound HTTP header
+	// name. For each entry, Verify reads metadata[key] from its caller and
+	// sends the value under the named header. The values are also folded into
+	// the cache key so distinct identities (e.g. two Slack bots sharing a user
+	// token) never collide on a cached Profile.
+	MetadataHeaders map[string]string
+}
+
+// orderedMetadataHeaders returns the MetadataHeaders entries sorted by
+// metadata key so callers iterate in a stable order — required for the cache
+// key to be deterministic regardless of map iteration order.
+func (c *VerifierConfig) orderedMetadataHeaders() []struct{ Key, Header string } {
+	if len(c.MetadataHeaders) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(c.MetadataHeaders))
+	for k := range c.MetadataHeaders {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	out := make([]struct{ Key, Header string }, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, struct{ Key, Header string }{Key: k, Header: c.MetadataHeaders[k]})
+	}
+	return out
 }
 
 func (c *VerifierConfig) setDefaults() {
@@ -121,6 +147,38 @@ func (c *VerifierConfig) setDefaults() {
 			expanded[k] = val
 		}
 		c.ExtraHeaders = expanded
+	}
+	// Drop MetadataHeaders entries whose target header collides with TokenHeader
+	// or ChannelTypeHeader, or with any ExtraHeaders entry — silently letting
+	// these through would overwrite auth, channel-type, or static headers on
+	// every request. Canonical header keys are compared.
+	if len(c.MetadataHeaders) > 0 {
+		canonicalToken := textproto.CanonicalMIMEHeaderKey(c.TokenHeader)
+		var canonicalChannel string
+		if c.ChannelTypeHeader != "" {
+			canonicalChannel = textproto.CanonicalMIMEHeaderKey(c.ChannelTypeHeader)
+		}
+		reserved := map[string]string{canonicalToken: "token_header"}
+		if canonicalChannel != "" {
+			reserved[canonicalChannel] = "channel_type_header"
+		}
+		for k := range c.ExtraHeaders {
+			reserved[textproto.CanonicalMIMEHeaderKey(k)] = "extra_headers"
+		}
+		filtered := make(map[string]string, len(c.MetadataHeaders))
+		for metaKey, header := range c.MetadataHeaders {
+			if header == "" {
+				slog.Warn("whoami metadata_header has empty target header; ignoring", "metadata_key", metaKey)
+				continue
+			}
+			canonical := textproto.CanonicalMIMEHeaderKey(header)
+			if collides, ok := reserved[canonical]; ok {
+				slog.Warn("whoami metadata_header collides with reserved header; ignoring", "metadata_key", metaKey, "header", header, "collides_with", collides)
+				continue
+			}
+			filtered[metaKey] = header
+		}
+		c.MetadataHeaders = filtered
 	}
 }
 
@@ -197,12 +255,35 @@ func (v *Verifier) cleanupLoop() {
 	}
 }
 
+// cacheKey hashes the inputs that uniquely identify a WhoAmI request: the
+// bearer token, the channel type, and every metadata value that is configured
+// to be forwarded as a header. Folding metadata values in is what keeps two
+// bots that share a user token from colliding on a single cached Profile.
+func (v *Verifier) cacheKey(token, channelType string, metadata map[string]string) [32]byte {
+	h := sha256.New()
+	h.Write([]byte(token))
+	h.Write([]byte{0})
+	h.Write([]byte(channelType))
+	for _, mh := range v.cfg.orderedMetadataHeaders() {
+		h.Write([]byte{0})
+		h.Write([]byte(mh.Key))
+		h.Write([]byte{'='})
+		h.Write([]byte(metadata[mh.Key]))
+	}
+	var out [32]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
 // Verify returns the Profile for token, using the cache when valid.
 // channelType is the originating channel ID (e.g. "slack", "telegram") and is
 // forwarded to the WhoAmI server if ChannelTypeHeader is configured.
+// metadata is the inbound-message metadata map; values for keys configured in
+// MetadataHeaders are forwarded as HTTP headers and folded into the cache key
+// so distinct identities (e.g. two Slack bots) never share cached profiles.
 // Returns ErrAuthFailed if the server rejects the token or returns incomplete data.
-func (v *Verifier) Verify(ctx context.Context, token, channelType string) (*Profile, error) {
-	key := sha256.Sum256([]byte(token + "\x00" + channelType))
+func (v *Verifier) Verify(ctx context.Context, token, channelType string, metadata map[string]string) (*Profile, error) {
+	key := v.cacheKey(token, channelType, metadata)
 
 	v.mu.Lock()
 	if e, ok := v.cache[key]; ok && time.Now().Before(e.expiresAt) {
@@ -211,7 +292,7 @@ func (v *Verifier) Verify(ctx context.Context, token, channelType string) (*Prof
 	}
 	v.mu.Unlock()
 
-	p, err := v.callServer(ctx, token, channelType)
+	p, err := v.callServer(ctx, token, channelType, metadata)
 	if err != nil {
 		var rejected rejectedError
 		if errors.As(err, &rejected) {
@@ -266,7 +347,7 @@ func (v *Verifier) evictLocked() {
 	}
 }
 
-func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*Profile, error) {
+func (v *Verifier) callServer(ctx context.Context, token, channelType string, metadata map[string]string) (*Profile, error) {
 	req, err := http.NewRequestWithContext(ctx, v.cfg.Method, v.cfg.URL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: build request: %v", ErrAuthFailed, err)
@@ -277,6 +358,11 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string) (*
 	}
 	for k, val := range v.cfg.ExtraHeaders {
 		req.Header.Set(k, val)
+	}
+	for _, mh := range v.cfg.orderedMetadataHeaders() {
+		if val := metadata[mh.Key]; val != "" {
+			req.Header.Set(mh.Header, val)
+		}
 	}
 
 	// Log the outgoing request for debugging (token value is redacted).

--- a/internal/profile/verifier_test.go
+++ b/internal/profile/verifier_test.go
@@ -28,7 +28,7 @@ func TestVerifier_Success(t *testing.T) {
 	saver := &stubGroupSaver{saved: savedGroups}
 
 	v := NewVerifier(VerifierConfig{URL: srv.URL, CacheTTL: 100 * time.Millisecond}, saver, nil)
-	p, err := v.Verify(context.Background(), "tok1", "")
+	p, err := v.Verify(context.Background(), "tok1", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestVerifier_CacheHit(t *testing.T) {
 
 	v := NewVerifier(VerifierConfig{URL: srv.URL, CacheTTL: 10 * time.Second}, nil, nil)
 	for i := 0; i < 3; i++ {
-		if _, err := v.Verify(context.Background(), "tok", ""); err != nil {
+		if _, err := v.Verify(context.Background(), "tok", "", nil); err != nil {
 			t.Fatalf("Verify %d: %v", i, err)
 		}
 	}
@@ -73,7 +73,7 @@ func TestVerifier_AuthFailed_NonOK(t *testing.T) {
 	defer srv.Close()
 
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
-	_, err := v.Verify(context.Background(), "bad-token", "")
+	_, err := v.Verify(context.Background(), "bad-token", "", nil)
 	if !errors.Is(err, ErrAuthFailed) {
 		t.Fatalf("expected ErrAuthFailed, got %v", err)
 	}
@@ -86,7 +86,7 @@ func TestVerifier_AuthFailed_MissingEntityID(t *testing.T) {
 	defer srv.Close()
 
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
-	_, err := v.Verify(context.Background(), "tok", "")
+	_, err := v.Verify(context.Background(), "tok", "", nil)
 	if !errors.Is(err, ErrAuthFailed) {
 		t.Fatalf("expected ErrAuthFailed, got %v", err)
 	}
@@ -119,7 +119,7 @@ func TestVerifier_ExtraHeaders(t *testing.T) {
 			"X-Security-Token": "${TEST_WHOAMI_SECRET}",
 		},
 	}, nil, nil)
-	p, err := v.Verify(context.Background(), "U123", "")
+	p, err := v.Verify(context.Background(), "U123", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestVerifier_ExtraHeaders_WrongSecret(t *testing.T) {
 		TokenPrefix:  "",
 		ExtraHeaders: map[string]string{"X-Security-Token": "${TEST_WHOAMI_SECRET}"},
 	}, nil, nil)
-	_, err := v.Verify(context.Background(), "U123", "")
+	_, err := v.Verify(context.Background(), "U123", "", nil)
 	if !errors.Is(err, ErrAuthFailed) {
 		t.Fatalf("expected ErrAuthFailed, got %v", err)
 	}
@@ -173,7 +173,7 @@ func TestVerifier_ExtraHeaders_ExpandedAtConstruction(t *testing.T) {
 	defer v.Close()
 
 	// First call — env var is "initial-value" at construction time.
-	if _, err := v.Verify(context.Background(), "tok1", ""); err != nil {
+	if _, err := v.Verify(context.Background(), "tok1", "", nil); err != nil {
 		t.Fatalf("first Verify: %v", err)
 	}
 
@@ -181,7 +181,7 @@ func TestVerifier_ExtraHeaders_ExpandedAtConstruction(t *testing.T) {
 	t.Setenv("TEST_WHOAMI_HEADER", "changed-value")
 
 	// Second call with a different token (bypasses cache) — header must still be "initial-value".
-	if _, err := v.Verify(context.Background(), "tok2", ""); err != nil {
+	if _, err := v.Verify(context.Background(), "tok2", "", nil); err != nil {
 		t.Fatalf("second Verify: %v", err)
 	}
 
@@ -213,7 +213,7 @@ func TestVerifier_ExtraHeaders_UnsetVar(t *testing.T) {
 	}, nil, nil)
 	defer v.Close()
 
-	if _, err := v.Verify(context.Background(), "tok", ""); err != nil {
+	if _, err := v.Verify(context.Background(), "tok", "", nil); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestVerifier_ExtraHeaders_CollisionWithTokenHeader(t *testing.T) {
 	}, nil, nil)
 	defer v.Close()
 
-	if _, err := v.Verify(context.Background(), "real-token", ""); err != nil {
+	if _, err := v.Verify(context.Background(), "real-token", "", nil); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 
@@ -269,7 +269,7 @@ func TestVerifier_ChannelTypeHeader(t *testing.T) {
 	}, nil, nil)
 	defer v.Close()
 
-	if _, err := v.Verify(context.Background(), "tok", "slack"); err != nil {
+	if _, err := v.Verify(context.Background(), "tok", "slack", nil); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 
@@ -291,7 +291,7 @@ func TestVerifier_ChannelTypeHeader_NotSentWhenUnconfigured(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	if _, err := v.Verify(context.Background(), "tok", "slack"); err != nil {
+	if _, err := v.Verify(context.Background(), "tok", "slack", nil); err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 
@@ -316,7 +316,7 @@ func TestVerifier_LimitFields(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestVerifier_LimitFields_Missing(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestVerifier_ChannelTypeResponse(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestVerifier_CredentialHeaders(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -425,7 +425,7 @@ func TestVerifier_CredentialHeaders_Missing(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -451,7 +451,7 @@ func TestVerifier_CredentialHeaders_CustomField(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL, CredentialsField: "tokens"}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -486,7 +486,7 @@ func TestVerifier_CredentialHeaders_Malformed(t *testing.T) {
 			v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 			defer v.Close()
 
-			p, err := v.Verify(context.Background(), "tok", "")
+			p, err := v.Verify(context.Background(), "tok", "", nil)
 			if err != nil {
 				t.Fatalf("Verify: %v", err)
 			}
@@ -512,7 +512,7 @@ func TestVerifier_Language(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestVerifier_Language_Missing(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
@@ -559,12 +559,106 @@ func TestVerifier_Language_CustomField(t *testing.T) {
 	v := NewVerifier(VerifierConfig{URL: srv.URL, LanguageField: "locale"}, nil, nil)
 	defer v.Close()
 
-	p, err := v.Verify(context.Background(), "tok", "")
+	p, err := v.Verify(context.Background(), "tok", "", nil)
 	if err != nil {
 		t.Fatalf("Verify: %v", err)
 	}
 	if p.Language != "English" {
 		t.Errorf("Language = %q, want English", p.Language)
+	}
+}
+
+// TestVerifier_MetadataHeaders_Forwarded verifies that values from the
+// inbound metadata map configured under MetadataHeaders are sent as outbound
+// HTTP headers on every WhoAmI request.
+func TestVerifier_MetadataHeaders_Forwarded(t *testing.T) {
+	gotChannelID := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotChannelID <- r.Header.Get("X-Channel-ID")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"entity_id": "u1", "group": "g1"})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{
+		URL:             srv.URL,
+		MetadataHeaders: map[string]string{"channel_id": "X-Channel-ID"},
+	}, nil, nil)
+	defer v.Close()
+
+	if _, err := v.Verify(context.Background(), "tok", "", map[string]string{"channel_id": "UBOTA"}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got := <-gotChannelID; got != "UBOTA" {
+		t.Errorf("X-Channel-ID = %q, want UBOTA", got)
+	}
+}
+
+// TestVerifier_MetadataHeaders_CacheKeyIsolation is the load-bearing test for
+// the two-bots-one-token use case: the same bearer token must not return a
+// cached profile when the configured metadata-header value differs, otherwise
+// an admin bot and a customer bot would share permissions.
+func TestVerifier_MetadataHeaders_CacheKeyIsolation(t *testing.T) {
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		entity := "user-" + r.Header.Get("X-Channel-ID")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"entity_id": entity, "group": "g1"})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{
+		URL:             srv.URL,
+		CacheTTL:        10 * time.Second,
+		MetadataHeaders: map[string]string{"channel_id": "X-Channel-ID"},
+	}, nil, nil)
+	defer v.Close()
+
+	pA, err := v.Verify(context.Background(), "shared-token", "slack", map[string]string{"channel_id": "BOT_A"})
+	if err != nil {
+		t.Fatalf("Verify A: %v", err)
+	}
+	pB, err := v.Verify(context.Background(), "shared-token", "slack", map[string]string{"channel_id": "BOT_B"})
+	if err != nil {
+		t.Fatalf("Verify B: %v", err)
+	}
+	if pA.EntityID == pB.EntityID {
+		t.Fatalf("cache collision across bots: both resolved to %q", pA.EntityID)
+	}
+	if calls != 2 {
+		t.Errorf("server calls = %d, want 2 (different bots must miss cache)", calls)
+	}
+
+	// Same bot twice should hit cache.
+	if _, err := v.Verify(context.Background(), "shared-token", "slack", map[string]string{"channel_id": "BOT_A"}); err != nil {
+		t.Fatalf("Verify A repeat: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("server calls after repeat = %d, want still 2 (same bot must hit cache)", calls)
+	}
+}
+
+// TestVerifier_MetadataHeaders_CollisionDropped verifies that a metadata
+// header configured to collide with the token header is dropped at construction
+// rather than allowed to silently overwrite the auth header at request time.
+func TestVerifier_MetadataHeaders_CollisionDropped(t *testing.T) {
+	gotAuth := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth <- r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"entity_id": "u1", "group": "g1"})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{
+		URL:             srv.URL,
+		MetadataHeaders: map[string]string{"hijack": "authorization"}, // canonicalizes to Authorization
+	}, nil, nil)
+	defer v.Close()
+
+	if _, err := v.Verify(context.Background(), "real-token", "", map[string]string{"hijack": "ATTACKER"}); err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if got := <-gotAuth; got != "Bearer real-token" {
+		t.Errorf("Authorization = %q, want unchanged Bearer real-token (collision should have been dropped)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `WhoAmIConfig.metadata_headers` (map of `metadata_key → header_name`): the verifier reads `msg.Metadata[key]` and sends each entry as an outbound HTTP header on every WhoAmI call.
- Fold the forwarded metadata values into the verifier cache key, so two identities sharing a user token (e.g. an admin Slack bot and a customer Slack bot) never collide on a cached `Profile`.
- Extend inbound `mapping.metadata` value parsing: values containing `{{namespace.key}}` are template-expanded against channel state (`self.*`, `config.*`, `env.*`). Plain strings preserve the original event-field-name behavior, so a channel can surface its own identity into per-message metadata without any new schema.
- Reserved-header collisions (`token_header`, `channel_type_header`, any `extra_headers` entry) are dropped at startup with a warning rather than silently overwriting auth.

Why: a single opentalon deployment can serve multiple bots on the same channel type (admin Slack bot + customer Slack bot). The platform user ID alone doesn't distinguish them, so WhoAmI cannot grant different groups/plugins/limits per bot. The companion change in `opentalon/slack-channel` declares `channel_id: "{{self.bot_user_id}}"` so each bot surfaces its own identifier; this PR is the generic forwarding mechanism.

## Test plan
- [x] `make lint` — 0 issues
- [x] `make test` — full suite green with `-race`
- [x] New: `TestVerifier_MetadataHeaders_Forwarded` — value reaches the configured header
- [x] New: `TestVerifier_MetadataHeaders_CacheKeyIsolation` — same token + different `channel_id` → two cache entries, not one
- [x] New: `TestVerifier_MetadataHeaders_CollisionDropped` — `metadata_headers` entry canonicalizing to `Authorization` is dropped, real token survives
- [x] New: `TestExtractMessage_MetadataTemplate` — `{{self.X}}` in metadata mapping expands; plain field names still pluck from event
- [x] VCR cassettes untouched (no prompt/scenario changes)

Pairs with `opentalon/slack-channel#<pending>` which adds `channel_id: "{{self.bot_user_id}}"` to `channel.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)