### PR TITLE
fix(orchestrator): sanitizeHistory must not erase clarification dialogue

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3203,12 +3203,6 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 	}, nil
 }
 
-// sanitizeHistory removes poisoned assistant messages from session history.
-// An assistant message is "legitimate" only if it contains a [tool_call] block
-// OR is immediately preceded by a [plugin_output] (meaning it's a summary of
-// real tool results). Everything else is the LLM talking without acting —
-// hallucinated numbers, narrated intent, placeholder text — and teaches the
-// model to repeat the same bad pattern.
 // sanitizeHistory removes ONLY genuinely poisoned assistant turns from the
 // session history before it is sent to the model: a malformed [tool_call]
 // block, or a fabricated {{template}} result placeholder. A weak model imitates

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3209,38 +3209,40 @@ func (o *Orchestrator) executePipeline(ctx context.Context, sessionID string, p 
 // real tool results). Everything else is the LLM talking without acting —
 // hallucinated numbers, narrated intent, placeholder text — and teaches the
 // model to repeat the same bad pattern.
+// sanitizeHistory removes ONLY genuinely poisoned assistant turns from the
+// session history before it is sent to the model: a malformed [tool_call]
+// block, or a fabricated {{template}} result placeholder. A weak model imitates
+// such patterns from its own past turns, so they must not be fed back.
+//
+// Everything else is real conversation and is preserved verbatim — plain-text
+// answers, clarifying questions, valid tool calls and their tool results. USER
+// MESSAGES ARE NEVER DROPPED, and an assistant turn carrying a native tool call
+// is always kept (dropping it would orphan the following tool result). Context-
+// window pressure is handled separately and oldest-first by trimToContextWindow;
+// this function must never silently delete in-task history — erasing a user's
+// earlier request is exactly what breaks multi-turn tasks (the #162 over-reach:
+// it stripped every tool-less assistant turn AND its preceding user message,
+// which wiped clarification dialogues like a multi-step create-item request).
 func sanitizeHistory(msgs []provider.Message) []provider.Message {
 	out := make([]provider.Message, 0, len(msgs))
-	for i, m := range msgs {
-		if m.Role == provider.RoleAssistant {
-			// Keep assistant messages that contain VALID tool calls — they drove real actions.
-			// Drop broken tool calls like "[tool_call] ." or "[tool_call] " that were
-			// malformed by the LLM; keeping them in history teaches bad patterns.
-			if strings.Contains(m.Content, "[tool_call]") && !isBrokenToolCall(m.Content) {
-				out = append(out, m)
-				continue
-			}
-			// Keep assistant messages with native tool calls (ToolCalls field set).
-			if len(m.ToolCalls) > 0 {
-				out = append(out, m)
-				continue
-			}
-			// Keep assistant messages that follow a tool result — they summarize
-			// real data (the normal round-2 response after a tool call).
-			if i > 0 && (strings.Contains(msgs[i-1].Content, "[plugin_output]") || msgs[i-1].Role == provider.RoleTool) {
-				out = append(out, m)
-				continue
-			}
-			// Everything else is the LLM answering without calling a tool.
-			// Drop it and its orphaned preceding user message.
-			if len(out) > 0 && out[len(out)-1].Role == provider.RoleUser {
-				out = out[:len(out)-1]
-			}
+	for _, m := range msgs {
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) == 0 && isPoisonedAssistantContent(m.Content) {
 			continue
 		}
 		out = append(out, m)
 	}
 	return out
+}
+
+// isPoisonedAssistantContent reports whether a tool-less assistant turn is a
+// self-poisoning artifact that must not be replayed to the model: a broken
+// [tool_call] block, or a fabricated {{template}} result placeholder. Legitimate
+// text — answers, clarifying questions — returns false and is kept.
+func isPoisonedAssistantContent(content string) bool {
+	if strings.Contains(content, "[tool_call]") && isBrokenToolCall(content) {
+		return true
+	}
+	return hasHallucinatedResult(content)
 }
 
 // isBrokenToolCall returns true if the message contains a [tool_call] block

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3280,6 +3280,25 @@ func hasToolResults(msgs []provider.Message) bool {
 	return false
 }
 
+// firstNonOrphanIndex advances start past any leading tool-result messages
+// whose originating tool-call would be left behind by a cut at start. A native
+// tool result (RoleTool) or a text-format [plugin_output] message must be
+// immediately preceded by its tool-call; if a trim drops the call but keeps the
+// result, the result is orphaned — and the LLM API rejects a dangling tool
+// message. Skipping the leading orphaned results keeps the kept slice a valid
+// transcript. Returns len(msgs) only if every remaining message is a result.
+func firstNonOrphanIndex(msgs []provider.Message, start int) int {
+	for start < len(msgs) {
+		m := msgs[start]
+		if m.Role == provider.RoleTool || (m.Role == provider.RoleUser && strings.Contains(m.Content, "[plugin_output]")) {
+			start++
+			continue
+		}
+		break
+	}
+	return start
+}
+
 // applySlidingWindow keeps only the last o.contextMessages entries
 // from msgs when configured. When the cut fires, it emits one
 // messages_truncated event with the dropped index range so analytics
@@ -3297,6 +3316,9 @@ func (o *Orchestrator) applySlidingWindow(ctx context.Context, msgs []provider.M
 		return msgs
 	}
 	dropped := len(msgs) - o.contextMessages
+	// Don't cut between a tool-call and its result — advance the boundary past
+	// any leading orphaned results so the kept slice stays a valid transcript.
+	dropped = firstNonOrphanIndex(msgs, dropped)
 	// RFC #249 Pillar C: scan the dropped slice for [knowledge_context]
 	// blocks so consumers can correlate the cut with InjectionState
 	// release without re-reconciling. Visible-message scan is the same
@@ -3458,6 +3480,11 @@ func trimToContextWindow(ctx context.Context, messages []provider.Message, conte
 	for total > maxInputTokens && convStart < len(messages)-1 {
 		total -= estimateTokens(messages[convStart].Content)
 		convStart++
+	}
+	// Don't leave a tool result orphaned by dropping its tool-call — advance the
+	// boundary past any leading orphaned results (but never to an empty slice).
+	if i := firstNonOrphanIndex(messages, convStart); i < len(messages) {
+		convStart = i
 	}
 
 	trimmed := make([]provider.Message, 0, len(messages)-convStart+convStart)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3346,6 +3346,54 @@ func uniqueKnowledgeArticles(blocks []parsedKCBlock) []string {
 	return out
 }
 
+// appendConversation appends the message tail shared by buildMessages and
+// buildMessagesWithPrompt onto `messages` (which must already carry the system
+// prompt): the optional summary, the sliding-window-trimmed + sanitized +
+// knowledge-context-stripped history, the trailing format-hint and don't-repeat
+// reminders, and the final context-window trim. Extracted so the two assembly
+// paths cannot drift — the reminder strings and their gating were previously
+// duplicated verbatim in both.
+func (o *Orchestrator) appendConversation(ctx context.Context, sess *state.Session, messages []provider.Message) []provider.Message {
+	if sess.Summary != "" {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "Previous conversation summary: " + sess.Summary,
+		})
+	}
+	// Sliding-window cutter (config-driven via o.contextMessages); emits
+	// messages_truncated when it fires.
+	convMessages := o.applySlidingWindow(ctx, sess.Messages)
+	// Strip [knowledge_context] from HISTORICAL user messages only (current turn
+	// kept verbatim so preparer-injected RAG reaches the LLM), and drop genuinely
+	// poisoned assistant turns via sanitizeHistory.
+	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
+
+	// For weaker / OSS models, repeat the channel format hint as a trailing
+	// system reminder — but only after a tool result exists, so it doesn't
+	// compete with the tool-calling instruction on the first round.
+	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "[IMPORTANT — output format reminder] " + hint,
+		})
+	}
+
+	// Don't-repeat reminder, only with actual prior conversation. Placed close to
+	// the generation point where the model is most likely to follow it.
+	if len(convMessages) > 2 {
+		messages = append(messages, provider.Message{
+			Role:    provider.RoleSystem,
+			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
+		})
+	}
+
+	if o.contextWindow > 0 {
+		messages = trimToContextWindow(ctx, messages, o.contextWindow)
+	}
+
+	return messages
+}
+
 func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, userMessage string, includeServerInstructions ...bool) []provider.Message {
 	messages := make([]provider.Message, 0, len(sess.Messages)+4)
 
@@ -3364,58 +3412,7 @@ func (o *Orchestrator) buildMessages(ctx context.Context, sess *state.Session, u
 		Role:    provider.RoleSystem,
 		Content: systemPrompt,
 	})
-	if sess.Summary != "" {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "Previous conversation summary: " + sess.Summary,
-		})
-	}
-	// Apply the sliding-window cutter (config-driven via o.contextMessages)
-	// and emit messages_truncated when it fires. Both buildMessages and
-	// buildMessagesWithPrompt go through the same helper so analytics see
-	// exactly one event per cut regardless of which assembly path ran.
-	convMessages := o.applySlidingWindow(ctx, sess.Messages)
-	// Strip [knowledge_context] from HISTORICAL user messages only. The
-	// current turn's user message is preserved verbatim so preparer-injected
-	// RAG content actually reaches the LLM. Historical turns are still
-	// stripped to avoid per-turn accumulation and redundancy with the
-	// system prompt (server-instruction articles are already filtered out
-	// plugin-side via filterOutMCPItems).
-	//
-	// Also sanitize poisoned assistant messages from session history: remove
-	// hallucinated template variables and narrated tool calls that were saved
-	// before detection was in place. These teach the LLM bad patterns.
-	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
-
-	// For weaker / OSS models that tend to ignore system-prompt formatting
-	// instructions, repeat the channel format hint as a trailing system
-	// reminder. Only inject it after at least one tool-result exchange so it
-	// doesn't compete with the tool-calling instruction on the very first
-	// round — the OUTPUT FORMAT section in the system prompt is sufficient
-	// there. Once tool results are present the model switches to answer
-	// mode and benefits from the nudge.
-	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "[IMPORTANT — output format reminder] " + hint,
-		})
-	}
-
-	// Only inject the "don't repeat" reminder when there's actual prior
-	// conversation (at least one assistant reply). On the first turn there's
-	// nothing to repeat.
-	if len(convMessages) > 2 {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
-		})
-	}
-
-	if o.contextWindow > 0 {
-		messages = trimToContextWindow(ctx, messages, o.contextWindow)
-	}
-
-	return messages
+	return o.appendConversation(ctx, sess, messages)
 }
 
 // buildMessagesWithPrompt assembles the LLM message list using a pre-built
@@ -3427,40 +3424,7 @@ func (o *Orchestrator) buildMessagesWithPrompt(ctx context.Context, sess *state.
 		Role:    provider.RoleSystem,
 		Content: systemPrompt,
 	})
-	if sess.Summary != "" {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "Previous conversation summary: " + sess.Summary,
-		})
-	}
-	convMessages := o.applySlidingWindow(ctx, sess.Messages)
-	messages = appendStrippingHistoricalKC(messages, sanitizeHistory(convMessages))
-
-	if hint := channelFormatHint(ctx); hint != "" && hasToolResults(convMessages) {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "[IMPORTANT — output format reminder] " + hint,
-		})
-	}
-
-	// Trailing instruction placed close to the generation point where
-	// the model is most likely to follow it. The same instruction in the
-	// preamble (far away) gets buried under 50-100k tokens.
-	// Only inject the "don't repeat" reminder when there's actual prior
-	// conversation (at least one assistant reply). On the first turn there's
-	// nothing to repeat.
-	if len(convMessages) > 2 {
-		messages = append(messages, provider.Message{
-			Role:    provider.RoleSystem,
-			Content: "[IMPORTANT] Answer ONLY the user's last message above. Do NOT repeat or summarize any earlier answers from this conversation. Be concise.",
-		})
-	}
-
-	if o.contextWindow > 0 {
-		messages = trimToContextWindow(ctx, messages, o.contextWindow)
-	}
-
-	return messages
+	return o.appendConversation(ctx, sess, messages)
 }
 
 // estimateTokens returns a rough token count for a string.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1366,6 +1366,67 @@ func TestTrimToContextWindow_ZeroWindow(t *testing.T) {
 	}
 }
 
+func TestFirstNonOrphanIndex(t *testing.T) {
+	// Leading native result + text-format [plugin_output] are skipped; the first
+	// real message (an assistant summary here) is the boundary.
+	msgs := []provider.Message{
+		{Role: provider.RoleTool, Content: "result", ToolCallID: "c1"},
+		{Role: provider.RoleUser, Content: "[plugin_output]x[/plugin_output]"},
+		{Role: provider.RoleAssistant, Content: "summary of results"},
+		{Role: provider.RoleUser, Content: "next question"},
+	}
+	if got := firstNonOrphanIndex(msgs, 0); got != 2 {
+		t.Errorf("expected leading results skipped to index 2, got %d", got)
+	}
+
+	// No leading orphan → unchanged.
+	clean := []provider.Message{
+		{Role: provider.RoleUser, Content: "hi"},
+		{Role: provider.RoleAssistant, Content: "yo"},
+	}
+	if got := firstNonOrphanIndex(clean, 0); got != 0 {
+		t.Errorf("expected no advance, got %d", got)
+	}
+
+	// Every remaining message is a result → returns len (caller guards).
+	allOrphan := []provider.Message{{Role: provider.RoleTool, Content: "r", ToolCallID: "c1"}}
+	if got := firstNonOrphanIndex(allOrphan, 0); got != 1 {
+		t.Errorf("expected len(=1) for all-orphan, got %d", got)
+	}
+}
+
+func TestTrimToContextWindow_DoesNotOrphanToolResult(t *testing.T) {
+	// The token budget forces dropping the oldest user turn AND the assistant
+	// tool-call — which would leave the tool RESULT as the new first message: a
+	// RoleTool with no preceding call, which the LLM API rejects. The trim must
+	// advance past the orphaned result.
+	big := func(c string) string { return strings.Repeat(c, 400) } // ~100 tokens each
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: strings.Repeat("s", 40)},
+		{Role: provider.RoleUser, Content: big("a")},
+		{Role: provider.RoleAssistant, Content: big("b"), ToolCalls: []provider.ToolCall{{ID: "c1", Name: "inv.list"}}},
+		{Role: provider.RoleTool, Content: big("r"), ToolCallID: "c1"},
+		{Role: provider.RoleAssistant, Content: big("d")},
+		{Role: provider.RoleUser, Content: big("e")},
+	}
+
+	result := trimToContextWindow(context.Background(), msgs, 400) // maxInput ≈ 360 tokens
+
+	// The orphaned result (its tool-call was dropped) must not survive.
+	for i, m := range result {
+		if m.Role == provider.RoleTool {
+			t.Errorf("orphaned tool result survived at index %d: %q", i, m.Content)
+		}
+	}
+	// System preserved, most recent user turn kept.
+	if result[0].Role != provider.RoleSystem {
+		t.Errorf("first message should be system, got %s", result[0].Role)
+	}
+	if result[len(result)-1].Content != big("e") {
+		t.Error("most recent user message must be kept")
+	}
+}
+
 // --- UserOnly tests ---
 
 func setupUserOnlyOrchestrator(parser ToolCallParser) *Orchestrator {

--- a/internal/orchestrator/parser.go
+++ b/internal/orchestrator/parser.go
@@ -447,7 +447,10 @@ func hasNarratedToolCall(response string) bool {
 
 // hallucinatedResultRe matches template-like patterns the LLM fabricates when
 // pretending it already called a tool (e.g. "{{plugin_output.pagination.total}}").
-var hallucinatedResultRe = regexp.MustCompile(`\{\{[a-zA-Z_.]+(\.[\w.]+)+\}\}`)
+// The root is anchored to result-shaped identifiers so a legitimate turn that
+// merely mentions a dotted template (e.g. "{{user.name}}" in a config example)
+// is not mistaken for a fabricated tool result.
+var hallucinatedResultRe = regexp.MustCompile(`\{\{(plugin_output|pagination|result|results|data|response|output|tool_result)(\.\w+)+\}\}`)
 
 // hasHallucinatedResult returns true if the response contains fabricated
 // template variables like {{plugin_output.pagination.total}}.

--- a/internal/orchestrator/parser_test.go
+++ b/internal/orchestrator/parser_test.go
@@ -597,6 +597,12 @@ func TestHasHallucinatedResult(t *testing.T) {
 		"You have 42 items.",
 		"Here are the results.",
 		"Use {{ for templates in Go.",
+		// Legitimate dotted templates whose root is NOT a tool-result shape —
+		// must not be mistaken for a fabricated result (regression for the
+		// over-broad {{a.b}} match that stripped such turns from history).
+		"Use {{user.name}} in your config.",
+		"Set {{category.name}} on the form.",
+		"Write {{config.db.host}} into the file.",
 	}
 	for _, input := range noMatch {
 		if hasHallucinatedResult(input) {

--- a/internal/orchestrator/sanitize_history_test.go
+++ b/internal/orchestrator/sanitize_history_test.go
@@ -105,6 +105,32 @@ func TestSanitizeHistory_StripsBrokenToolCall(t *testing.T) {
 	}
 }
 
+// TestSanitizeHistory_BrokenToolCallDoesNotOrphanResult: stripping a broken
+// [tool_call] turn must not orphan the tool result that follows it — the
+// plugin_output message and the summary that reads it both survive.
+func TestSanitizeHistory_BrokenToolCallDoesNotOrphanResult(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "how many items?"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] ."}, // broken → dropped
+		{Role: provider.RoleUser, Content: "[plugin_output]{\"pagination\":{\"total\":5}}[/plugin_output]"},
+		{Role: provider.RoleAssistant, Content: "You have 5 items."},
+	}
+	got := sanitizeHistory(msgs)
+	want := []string{
+		"how many items?",
+		"[plugin_output]{\"pagination\":{\"total\":5}}[/plugin_output]",
+		"You have 5 items.",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("broken turn dropped but result+summary must survive: got %d, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Content != want[i] {
+			t.Errorf("message %d = %q, want %q", i, got[i].Content, want[i])
+		}
+	}
+}
+
 // TestSanitizeHistory_KeepsFabricatedTextAnswer: a plain (even if factually
 // wrong) text answer with NO template/broken-tool-call poison is kept now —
 // conversation integrity beats over-eager scrubbing. Native tool calling plus

--- a/internal/orchestrator/sanitize_history_test.go
+++ b/internal/orchestrator/sanitize_history_test.go
@@ -6,45 +6,141 @@ import (
 	"github.com/opentalon/opentalon/internal/provider"
 )
 
-func TestSanitizeHistory_RemovesHallucinatedText(t *testing.T) {
+// Essential requirement (the contract these tests pin down):
+//
+// A session's conversation history must reach the model intact. sanitizeHistory
+// may strip ONLY genuinely poisoned assistant turns — a malformed [tool_call]
+// block, or a fabricated {{template}} result placeholder. It must NEVER drop a
+// user message, must keep legitimate text answers and clarifying questions, and
+// must keep assistant turns that carry a native tool call. Context-window
+// trimming is a separate, oldest-first concern (trimToContextWindow); nothing
+// else may delete history. Losing a user's earlier request is what breaks
+// multi-turn tasks — see the #162 regression that this file guards against.
+
+func userContents(msgs []provider.Message) []string {
+	var out []string
+	for _, m := range msgs {
+		if m.Role == provider.RoleUser {
+			out = append(out, m.Content)
+		}
+	}
+	return out
+}
+
+// TestSanitizeHistory_KeepsClarificationDialogue is the direct regression guard:
+// a create-item task carried across several clarifying turns. None of it is
+// poison, so every message — the user's requests AND the assistant's questions —
+// must survive unchanged.
+func TestSanitizeHistory_KeepsClarificationDialogue(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "Erstell mal schnell ein neues test item"},
+		{Role: provider.RoleAssistant, Content: "Sure! To create the test item I'll need a category."},
+		{Role: provider.RoleUser, Content: "egal"},
+		{Role: provider.RoleAssistant, Content: "Got it. Which name should it have?"},
+		{Role: provider.RoleUser, Content: "Nimm irgendwelche die wir im account haben"},
+		{Role: provider.RoleAssistant, Content: "I can use a default name like Test-Item."},
+		{Role: provider.RoleUser, Content: "egal irgendwas"},
+	}
+	got := sanitizeHistory(msgs)
+	if len(got) != len(msgs) {
+		t.Fatalf("clarification dialogue must survive intact: got %d of %d messages", len(got), len(msgs))
+	}
+	for i := range msgs {
+		if got[i].Role != msgs[i].Role || got[i].Content != msgs[i].Content {
+			t.Errorf("message %d changed: got [%s] %q, want [%s] %q",
+				i, got[i].Role, got[i].Content, msgs[i].Role, msgs[i].Content)
+		}
+	}
+}
+
+// TestSanitizeHistory_NeverDropsUserMessages: even when poison is present and
+// stripped, every user message survives in order.
+func TestSanitizeHistory_NeverDropsUserMessages(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "how many org units?"},
+		{Role: provider.RoleAssistant, Content: "You have **{{plugin_output.pagination.total}}** org-units."}, // template poison
+		{Role: provider.RoleUser, Content: "that's wrong"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] ."}, // broken tool-call poison
+		{Role: provider.RoleUser, Content: "call the tool please"},
+	}
+	got := sanitizeHistory(msgs)
+	want := []string{"how many org units?", "that's wrong", "call the tool please"}
+	gotUsers := userContents(got)
+	if len(gotUsers) != len(want) {
+		t.Fatalf("user messages must never be dropped: got %v, want %v", gotUsers, want)
+	}
+	for i := range want {
+		if gotUsers[i] != want[i] {
+			t.Errorf("user message %d = %q, want %q", i, gotUsers[i], want[i])
+		}
+	}
+}
+
+// TestSanitizeHistory_StripsHallucinatedTemplate: the {{template}} assistant turn
+// is removed, but BOTH surrounding user messages are kept.
+func TestSanitizeHistory_StripsHallucinatedTemplate(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "how many org units?"},
 		{Role: provider.RoleAssistant, Content: "You have **{{plugin_output.pagination.total}}** org-units."},
 		{Role: provider.RoleUser, Content: "that's wrong"},
 	}
 	got := sanitizeHistory(msgs)
-	if len(got) != 1 || got[0].Content != "that's wrong" {
-		t.Errorf("expected 1 message, got %d: %v", len(got), got)
+	want := []string{"how many org units?", "that's wrong"}
+	if len(got) != 2 || got[0].Content != want[0] || got[1].Content != want[1] {
+		t.Errorf("template assistant must be stripped, both users kept: got %v", got)
 	}
 }
 
-func TestSanitizeHistory_RemovesNarratedAndFabricatedAnswers(t *testing.T) {
-	// Simulates a poisoned session where the LLM keeps answering without tools
+// TestSanitizeHistory_StripsBrokenToolCall: a malformed [tool_call] turn is
+// removed; the user messages around it are kept.
+func TestSanitizeHistory_StripsBrokenToolCall(t *testing.T) {
 	msgs := []provider.Message{
-		{Role: provider.RoleUser, Content: "how many items do i have?"},
-		{Role: provider.RoleAssistant, Content: "<b>Total items:</b> 0 (the system returned no matching records)."},
-		{Role: provider.RoleUser, Content: "lies!"},
-		{Role: provider.RoleAssistant, Content: "<b>Total number of items:</b> 0 (the query returned no items)."},
-		{Role: provider.RoleUser, Content: "lies!"},
-		{Role: provider.RoleAssistant, Content: "<b>Total number of items:</b> 94 (including all item types)."},
-		{Role: provider.RoleUser, Content: "run the tools!"},
-		{Role: provider.RoleAssistant, Content: "We need to call the tool."},
-		{Role: provider.RoleUser, Content: "call please"},
-		{Role: provider.RoleAssistant, Content: "<b>Fetching the total number of items…</b>"},
-		{Role: provider.RoleUser, Content: "?"},
-		{Role: provider.RoleAssistant, Content: "<b>Retrieving item count…</b>"},
+		{Role: provider.RoleUser, Content: "list items"},
+		{Role: provider.RoleAssistant, Content: "[tool_call] ."},
 		{Role: provider.RoleUser, Content: "?"},
 	}
 	got := sanitizeHistory(msgs)
-	// ALL assistant messages should be removed (none contain [tool_call] or follow [plugin_output]).
-	// Their preceding user messages should also be removed.
-	// Only the final "?" without a preceding assistant remains.
-	if len(got) != 1 || got[0].Content != "?" {
-		t.Errorf("expected 1 message '?', got %d: %v", len(got), got)
+	if len(got) != 2 || got[0].Content != "list items" || got[1].Content != "?" {
+		t.Errorf("broken tool-call must be stripped, users kept: got %v", got)
 	}
 }
 
-func TestSanitizeHistory_KeepsToolCallAndResults(t *testing.T) {
+// TestSanitizeHistory_KeepsFabricatedTextAnswer: a plain (even if factually
+// wrong) text answer with NO template/broken-tool-call poison is kept now —
+// conversation integrity beats over-eager scrubbing. Native tool calling plus
+// generation-time template detection handle the real fabrication risk; erasing
+// the turn (and the user's question) is the worse failure.
+func TestSanitizeHistory_KeepsFabricatedTextAnswer(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "how many items?"},
+		{Role: provider.RoleAssistant, Content: "You have 0 items."},
+		{Role: provider.RoleUser, Content: "lies!"},
+	}
+	got := sanitizeHistory(msgs)
+	if len(got) != 3 {
+		t.Errorf("plain text answers (even if wrong) are kept: got %d of 3: %v", len(got), got)
+	}
+}
+
+// TestSanitizeHistory_KeepsNativeToolCallTurn: an assistant turn with a native
+// tool call (ToolCalls set, empty content) must always survive — dropping it
+// would orphan the following tool result and break native function-calling.
+func TestSanitizeHistory_KeepsNativeToolCallTurn(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "delete item 5"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "inventory.delete-item"}}},
+		{Role: provider.RoleTool, Content: "Deleted item 5.", ToolCallID: "c1"},
+		{Role: provider.RoleAssistant, Content: "Done — item 5 deleted."},
+	}
+	got := sanitizeHistory(msgs)
+	if len(got) != len(msgs) {
+		t.Errorf("native tool-call turn + result must be preserved: got %d of %d", len(got), len(msgs))
+	}
+}
+
+// TestSanitizeHistory_KeepsValidToolCallAndResults: text-format tool call + its
+// plugin_output + the summary all survive.
+func TestSanitizeHistory_KeepsValidToolCallAndResults(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "how many items?"},
 		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"inventory.list-items\"}[/tool_call]"},
@@ -57,33 +153,8 @@ func TestSanitizeHistory_KeepsToolCallAndResults(t *testing.T) {
 	}
 }
 
-func TestSanitizeHistory_KeepsMixedSession(t *testing.T) {
-	msgs := []provider.Message{
-		// First turn: hallucinated (should be removed)
-		{Role: provider.RoleUser, Content: "how many items?"},
-		{Role: provider.RoleAssistant, Content: "You have 0 items."},
-		// Second turn: real tool call (should be kept)
-		{Role: provider.RoleUser, Content: "list my items"},
-		{Role: provider.RoleAssistant, Content: "[tool_call]{\"tool\":\"inventory.list-items\"}[/tool_call]"},
-		{Role: provider.RoleUser, Content: "[plugin_output]Items: 370 total[/plugin_output]"},
-		{Role: provider.RoleAssistant, Content: "You have 370 items."},
-		// Third turn: hallucinated again (should be removed)
-		{Role: provider.RoleUser, Content: "how many persons?"},
-		{Role: provider.RoleAssistant, Content: "You have 15 persons."},
-	}
-	got := sanitizeHistory(msgs)
-	// Should keep: "list my items", tool_call, plugin_output, "You have 370 items."
-	if len(got) != 4 {
-		t.Errorf("expected 4 messages, got %d: %v", len(got), got)
-	}
-	if got[0].Content != "list my items" {
-		t.Errorf("expected 'list my items', got %q", got[0].Content)
-	}
-}
-
 func TestSanitizeHistory_EmptyHistory(t *testing.T) {
-	got := sanitizeHistory(nil)
-	if len(got) != 0 {
+	if got := sanitizeHistory(nil); len(got) != 0 {
 		t.Errorf("expected 0 messages, got %d", len(got))
 	}
 }


### PR DESCRIPTION
## What

`sanitizeHistory` was silently erasing real conversation history before it reached the model — which made the assistant look "dumb": it lost multi-turn tasks and replied as if the conversation had just started. This MR fixes that and folds in the validated, non-complexifying review findings.

## Root cause

`sanitizeHistory` dropped **every tool-less assistant turn AND its preceding user message** (the over-reach from #162). Any clarification dialogue — the most common multi-step shape — was wiped:

```
user:      Erstell ein test item            ← DROPPED
assistant: Which category?                  ← DROPPED
user:      egal                             ← DROPPED
...
user:      egal irgendwas                   (only the latest survived)
```

So on a real session the model received only unrelated tool turns + the bare latest message, with **none** of the user's actual requests.

## Commits

1. **fix: narrow sanitizeHistory** — strip ONLY genuinely poisoned assistant turns (malformed `[tool_call]`, fabricated `{{template}}`); never drop user messages; always keep native tool-call turns. Context-window pressure stays `trimToContextWindow`'s job (oldest-first). Rewritten `sanitize_history_test.go` spec.
2. **fix: drop stale doc comment + orphan-safety test** — removed the leftover pre-fix comment that contradicted the new one; test that stripping a broken `[tool_call]` doesn't orphan a following `[plugin_output]`.
3. **fix(parser): anchor hallucinated-result regex to result-shaped roots** — `hasHallucinatedResult` matched any `{{a.b}}`, so a legit `{{user.name}}` would be stripped. Anchored to result roots; existing fabrication cases still match. (Also makes the shared generation-time retry more precise.)
4. **refactor: extract shared message-assembly tail** — `buildMessages`/`buildMessagesWithPrompt` duplicated the post-system-prompt tail byte-for-byte; extracted into `appendConversation` so they can't drift. No behaviour change.
5. **fix: don't orphan a tool result when trimming oldest-first** — `applySlidingWindow`/`trimToContextWindow` weren't tool-call-pair aware; a cut between a tool-call and its result left a dangling `RoleTool` the LLM API rejects. Added `firstNonOrphanIndex`; both trimmers advance past leading orphaned results. Spec for the helper + a trim test.

## History-preservation contract (now honest)

Conversation history reaches the model intact. It is only ever reduced by: an explicit `/clear`; the **oldest-first** context-window trim (which no longer orphans tool results); and `maybeSummarizeSession`, the one **lossy** compaction — also **oldest-first** and **config-gated** (off when `summarize_after_messages`/`max_messages_after_summary` are 0), so it does not reintroduce #162. Nothing else deletes history.

## Out of scope (separate follow-up)

- **The "don't summarize earlier answers" steer:** the trailing `[IMPORTANT] … Do NOT repeat or summarize any earlier answers` instruction blocks legitimate "what did we discuss?" questions. That's a prompt-behaviour change affecting *every* response and needs its own validation (risks reintroducing the repetition it was built to prevent), so it's deliberately not bundled here.

## Tests

Full `go test ./internal/orchestrator/` green, incl. the rewritten sanitize spec, the parser false-positive regression, and the new trim orphan-safety tests. Verified end-to-end on a live stack: the create-item flow now carries the task across vague follow-ups and completes, and the model answers questions about earlier turns correctly.
