### PR TITLE
fix(channels): resolve {{enrich.<step>.<field>}} in metadata templates

### DIFF
--- a/internal/channel/yaml_enrich.go
+++ b/internal/channel/yaml_enrich.go
@@ -69,11 +69,22 @@ func (ch *YAMLChannel) runEnrich(ctx context.Context, contexts map[string]map[st
 			return out, fmt.Errorf("%w: step %q: %v", ErrEnrichmentFailed, name, err)
 		}
 		out[name] = fields
-		// Make this step's results visible to subsequent steps via the
-		// template context, so step B can reference {{enrich.stepA.field}}
-		// in its URL/body. Mutates `contexts` in place — safe because we
-		// own the snapshot built in processEvent.
-		contexts["enrich."+name] = fields
+		// Make this step's results visible to subsequent steps and to the
+		// metadata mapping via the template context, so a value can be
+		// referenced as {{enrich.<step>.<field>}}. The template regex
+		// treats the first dot as the namespace/key separator, so we
+		// must store under a single "enrich" namespace keyed by
+		// "<step>.<field>" — storing under "enrich.<step>" would never
+		// match because ns="enrich" / key="<step>.<field>" looks up
+		// contexts["enrich"], which would be missing. Mutates `contexts`
+		// in place — safe because we own the snapshot built in
+		// processEvent.
+		if contexts["enrich"] == nil {
+			contexts["enrich"] = make(map[string]string, len(fields))
+		}
+		for fk, fv := range fields {
+			contexts["enrich"][name+"."+fk] = fv
+		}
 	}
 	return out, nil
 }

--- a/internal/channel/yaml_enrich_test.go
+++ b/internal/channel/yaml_enrich_test.go
@@ -64,10 +64,19 @@ func TestRunEnrich_Success(t *testing.T) {
 	if got["user"]["real_name"] != "Alex" {
 		t.Errorf("real_name = %q, want Alex", got["user"]["real_name"])
 	}
-	// Verify the step's results are also visible under enrich.<step> in
-	// the contexts map so chained metadata templates can reference them.
-	if v := contexts["enrich.user"]["email"]; v != "alex@example.com" {
-		t.Errorf("contexts[enrich.user][email] = %q, want propagated", v)
+	// Verify the step's results are visible under the "enrich" namespace
+	// keyed by "<step>.<field>" so {{enrich.<step>.<field>}} resolves
+	// against contexts["enrich"]["<step>.<field>"] via the template regex
+	// (which splits on the first dot — see yaml_template.go).
+	if v := contexts["enrich"]["user.email"]; v != "alex@example.com" {
+		t.Errorf("contexts[enrich][user.email] = %q, want propagated", v)
+	}
+	// And the same value must round-trip through substituteTemplate so the
+	// metadata mapping in channel.yaml actually receives it. This is the
+	// load-bearing regression: a previous storage scheme stored under
+	// "enrich.user" and {{enrich.user.email}} silently resolved to "".
+	if got := substituteTemplate("{{enrich.user.email}}", contexts); got != "alex@example.com" {
+		t.Errorf("substituteTemplate({{enrich.user.email}}) = %q, want alex@example.com", got)
 	}
 	if atomic.LoadInt32(&calls) != 1 {
 		t.Errorf("server calls = %d, want 1", atomic.LoadInt32(&calls))


### PR DESCRIPTION
## Summary
- Inbound enrichment was storing extracted fields under `contexts["enrich.<step>"]`, but the template regex (`\{\{(\w+)\.([^}]+)\}\}`) only matches a single-word namespace and splits on the first dot.
- For `{{enrich.user.email}}` the regex yields `ns="enrich"` / `key="user.email"` and looks up `contexts["enrich"]`, which the previous storage scheme never populated — so every `{{enrich.<step>.<field>}}` reference silently resolved to `""`.
- Symptom in production: Slack `users.info` enrichment succeeded (passes the fail-closed extract check), but `msg.Metadata["user_email"]` was empty, so `verifier.go` skipped the `X-User-Email` header and the WhoAmI server saw `X-User-ID` / `X-Channel-Type` / `X-Channel-Id` but no `X-User-Email`.
- Fix: in `runEnrich`, store each extracted field under the single `enrich` namespace keyed by `"<step>.<field>"` (e.g. `contexts["enrich"]["user.email"] = "alex@example.com"`). The existing regex (and the `{{msg.metadata.ts}}`-style nested-key cases) keep working unchanged.

## Test plan
- [x] `go test ./internal/channel/...` passes (includes new regression assertion in `TestRunEnrich_Success` that round-trips `{{enrich.user.email}}` through `substituteTemplate`).
- [x] `go test ./internal/profile/...` passes.
- [x] `go build ./...` clean.
- [ ] After merge, confirm WhoAmI server logs show `X-User-Email` populated on Slack inbound traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)