### PR TITLE
feat(config): make every built-in prompt overridable via config

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/opentalon/opentalon/internal/pipeline"
 	"github.com/opentalon/opentalon/internal/plugin"
 	"github.com/opentalon/opentalon/internal/profile"
+	"github.com/opentalon/opentalon/internal/prompts"
 	"github.com/opentalon/opentalon/internal/provider"
 	"github.com/opentalon/opentalon/internal/redisclient"
 	"github.com/opentalon/opentalon/internal/reminder"
@@ -579,6 +580,21 @@ func main() {
 	// rebuilding either consumer. Created here to break the
 	// orch ← ChannelSender ← notifier ← reg ← handler ← orch cycle.
 	notifier := &channelNotifier{reg: nil}
+
+	// Apply built-in prompt overrides from config before the orchestrator is
+	// built (NewWithRules reads the default/scheduling rules). Unknown keys are
+	// surfaced as a warning rather than a hard failure so a typo doesn't block
+	// startup. This only swaps the embedded prompt defaults; plugin/MCP server
+	// instructions are still appended to the system prompt as before.
+	if len(cfg.Orchestrator.PromptOverrides) > 0 {
+		applied, unknown := prompts.ApplyOverrides(cfg.Orchestrator.PromptOverrides)
+		if len(applied) > 0 {
+			slog.Info("prompt overrides applied", "prompts", applied)
+		}
+		if len(unknown) > 0 {
+			slog.Warn("ignoring unknown prompt override keys", "keys", unknown, "valid", prompts.OverridableNames())
+		}
+	}
 
 	orch := orchestrator.NewWithRules(llm, orchestrator.DefaultParser, toolRegistry, memory, sessions, orchestrator.OrchestratorOpts{
 		CustomRules:             cfg.Orchestrator.Rules,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,6 +40,21 @@ routing:
 
 orchestrator:
   rules: []
+  # Override any built-in prompt. Key = canonical name (the .txt filename under
+  # internal/prompts/ without the extension); omit a key to keep its embedded
+  # default; set an empty value to blank that block entirely. Plugin/MCP server
+  # instructions are still appended to the system prompt regardless.
+  # Valid keys: orchestrator_preamble, orchestrator_preamble_native,
+  # orchestrator_subprocess, subprocess_preamble, planner_preamble,
+  # planner_suffix, planner_narrate, planner_narrate_tool,
+  # orchestrator_summarize, orchestrator_summarize_update,
+  # orchestrator_session_title, rules_default, rules_scheduling,
+  # format_slack, format_markdown, format_html, format_telegram, format_teams,
+  # format_whatsapp, format_discord, format_text
+  # prompt_overrides:
+  #   orchestrator_preamble_native: |
+  #     You are a focused assistant for ACME. Call tools to act; never guess.
+  #   rules_scheduling: ""   # remove the scheduler rules where no scheduler plugin is loaded
   # permission_plugin: permission   # optional; core calls this plugin with action "check"(actor, plugin) before running a tool
   # debounce_window: "800ms"       # merge rapid messages into one LLM call (default "0" = disabled)
   # Run these plugin actions before the first LLM call; their output becomes the user message (or they can block with send_to_llm: false).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -323,6 +323,7 @@ type KnowledgeConfig struct {
 
 type OrchestratorConfig struct {
 	Rules                 []string                     `yaml:"rules"`
+	PromptOverrides       map[string]string            `yaml:"prompt_overrides,omitempty"` // override built-in prompts by canonical name (.txt filename without extension); omitted key = embedded default, empty value = blank it. See prompts.OverridableNames().
 	ContentPreparers      []ContentPreparerEntry       `yaml:"content_preparers,omitempty"`
 	ResponseFormatters    []ResponseFormatterEntry     `yaml:"response_formatters,omitempty"`
 	PermissionPlugin      string                       `yaml:"permission_plugin,omitempty"`       // if set, core calls this plugin with action "check" (actor, plugin) before running a tool

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -144,4 +145,71 @@ func splitLines(s string) []string {
 		}
 	}
 	return out
+}
+
+// promptSetters maps each built-in prompt's canonical name — its .txt filename
+// without the extension — to a function that overrides the corresponding
+// exported value, applying the same post-processing the embedded default gets
+// (raw, trailing-newline-trimmed, or line-split). ApplyOverrides uses it so
+// every built-in prompt is configurable without touching any call site.
+var promptSetters = map[string]func(string){
+	"orchestrator_preamble":         func(s string) { OrchestratorPreamble = s },
+	"orchestrator_preamble_native":  func(s string) { OrchestratorPreambleNative = s },
+	"orchestrator_subprocess":       func(s string) { OrchestratorSubprocess = s },
+	"subprocess_preamble":           func(s string) { SubprocessPreamble = s },
+	"planner_preamble":              func(s string) { PlannerPreamble = s },
+	"planner_suffix":                func(s string) { PlannerSuffix = strings.TrimRight(s, "\n") },
+	"planner_narrate":               func(s string) { PlannerNarrate = strings.TrimRight(s, "\n") },
+	"planner_narrate_tool":          func(s string) { PlannerNarrateTool = strings.TrimRight(s, "\n") },
+	"orchestrator_summarize":        func(s string) { SummarizeDefault = strings.TrimRight(s, "\n") },
+	"orchestrator_summarize_update": func(s string) { SummarizeUpdate = strings.TrimRight(s, "\n") },
+	"orchestrator_session_title":    func(s string) { SessionTitle = strings.TrimRight(s, "\n") },
+	"rules_default":                 func(s string) { DefaultRules = splitLines(s) },
+	"rules_scheduling":              func(s string) { SchedulingRules = splitLines(s) },
+	"format_slack":                  func(s string) { FormatSlack = strings.TrimRight(s, "\n") },
+	"format_markdown":               func(s string) { FormatMarkdown = strings.TrimRight(s, "\n") },
+	"format_html":                   func(s string) { FormatHTML = strings.TrimRight(s, "\n") },
+	"format_telegram":               func(s string) { FormatTelegram = strings.TrimRight(s, "\n") },
+	"format_teams":                  func(s string) { FormatTeams = strings.TrimRight(s, "\n") },
+	"format_whatsapp":               func(s string) { FormatWhatsApp = strings.TrimRight(s, "\n") },
+	"format_discord":                func(s string) { FormatDiscord = strings.TrimRight(s, "\n") },
+	"format_text":                   func(s string) { FormatText = strings.TrimRight(s, "\n") },
+}
+
+// OverridableNames returns the sorted canonical names ApplyOverrides accepts —
+// one per built-in prompt. Useful for config validation and documentation.
+func OverridableNames() []string {
+	names := make([]string, 0, len(promptSetters))
+	for name := range promptSetters {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// ApplyOverrides replaces built-in prompt defaults with values supplied from
+// config, keyed by canonical prompt name (the .txt filename without extension).
+// Every key present is applied, including an empty value — that blanks the
+// prompt, which is how a deployment removes a built-in block it does not want
+// (e.g. set "rules_scheduling" to "" where no scheduler plugin is loaded). To
+// keep a default, omit its key. Unknown keys are returned (sorted) so the caller
+// can warn about typos; applied keys are returned for logging.
+//
+// It mutates package-level defaults, so call it once at startup before the
+// orchestrator serves traffic — it is not safe to run concurrently with prompt
+// reads. It does NOT change how plugin / MCP server instructions get appended to
+// the system prompt; the orchestrator adds those separately at request time.
+func ApplyOverrides(overrides map[string]string) (applied, unknown []string) {
+	for name, text := range overrides {
+		setter, ok := promptSetters[name]
+		if !ok {
+			unknown = append(unknown, name)
+			continue
+		}
+		setter(text)
+		applied = append(applied, name)
+	}
+	sort.Strings(applied)
+	sort.Strings(unknown)
+	return applied, unknown
 }

--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -38,3 +38,76 @@ func TestHashCoversAllFiles(t *testing.T) {
 		t.Fatal("no .txt files found in embedded FS")
 	}
 }
+
+func TestApplyOverrides_AppliesWithTransforms(t *testing.T) {
+	origNative, origSched, origSuffix := OrchestratorPreambleNative, SchedulingRules, PlannerSuffix
+	t.Cleanup(func() {
+		OrchestratorPreambleNative, SchedulingRules, PlannerSuffix = origNative, origSched, origSuffix
+	})
+
+	applied, unknown := ApplyOverrides(map[string]string{
+		"orchestrator_preamble_native": "RAW PREAMBLE",         // raw, no transform
+		"rules_scheduling":             "rule one\nrule two\n", // splitLines
+		"planner_suffix":               "suffix text\n",        // trailing newline trimmed
+	})
+
+	if len(unknown) != 0 {
+		t.Fatalf("unexpected unknown keys: %v", unknown)
+	}
+	if got, want := strings.Join(applied, ","), "orchestrator_preamble_native,planner_suffix,rules_scheduling"; got != want {
+		t.Errorf("applied = %q, want sorted %q", got, want)
+	}
+	if OrchestratorPreambleNative != "RAW PREAMBLE" {
+		t.Errorf("raw preamble not applied: %q", OrchestratorPreambleNative)
+	}
+	if len(SchedulingRules) != 2 || SchedulingRules[0] != "rule one" || SchedulingRules[1] != "rule two" {
+		t.Errorf("scheduling rules not line-split: %v", SchedulingRules)
+	}
+	if PlannerSuffix != "suffix text" {
+		t.Errorf("planner suffix not trimmed: %q", PlannerSuffix)
+	}
+}
+
+func TestApplyOverrides_EmptyValueBlanks(t *testing.T) {
+	orig := SchedulingRules
+	t.Cleanup(func() { SchedulingRules = orig })
+
+	ApplyOverrides(map[string]string{"rules_scheduling": ""})
+	if len(SchedulingRules) != 0 {
+		t.Errorf("empty value should blank the prompt, got %v", SchedulingRules)
+	}
+}
+
+func TestApplyOverrides_UnknownKeysReportedSorted(t *testing.T) {
+	applied, unknown := ApplyOverrides(map[string]string{"zzz_typo": "x", "aaa_typo": "y"})
+	if len(applied) != 0 {
+		t.Errorf("no known keys; applied should be empty, got %v", applied)
+	}
+	if got, want := strings.Join(unknown, ","), "aaa_typo,zzz_typo"; got != want {
+		t.Errorf("unknown = %q, want sorted %q", got, want)
+	}
+}
+
+// TestPromptSettersCoverAllEmbedded is the guardrail: every embedded *.txt must
+// be overridable, and every setter must have a backing file. A new prompt added
+// without a setter (or a renamed file) fails here.
+func TestPromptSettersCoverAllEmbedded(t *testing.T) {
+	entries, err := promptFS.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".txt") {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".txt")
+		if _, ok := promptSetters[name]; !ok {
+			t.Errorf("embedded prompt %q has no override setter — add it to promptSetters", e.Name())
+		}
+	}
+	for name := range promptSetters {
+		if _, err := promptFS.ReadFile(name + ".txt"); err != nil {
+			t.Errorf("promptSetters has %q but no %s.txt is embedded", name, name)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Only a handful of sub-prompts (`summarize_prompt`, `session_title_prompt`) are configurable today. The **orchestrator preamble**, the **default safety rules**, the **scheduling rules**, the planner/subprocess preambles and the channel format prompts are hardcoded (embedded `.txt`) — changing them means editing source + rebuilding. Deployments that don't use a feature (e.g. no scheduler plugin) still ship its rules in every system prompt as dead weight.

## What

A generic `orchestrator.prompt_overrides` map, keyed by each prompt's **canonical name** (its `.txt` filename under `internal/prompts/` without the extension):

```yaml
orchestrator:
  prompt_overrides:
    orchestrator_preamble_native: |
      You are a focused assistant for ACME. Call tools to act; never guess.
    rules_scheduling: ""   # blank it where no scheduler plugin is loaded
```

- **Omitted key** → embedded default (unchanged behaviour).
- **Empty value** → blanks that prompt (how you remove an unwanted built-in block).
- **Unknown key** → logged as a startup `WARN` (with the valid name list), not a hard failure.

`prompts.ApplyOverrides` swaps the embedded defaults **once at startup**, before the orchestrator is built (so `NewRulesConfig` picks up overridden default/scheduling rules).

## Scope guarantee

This only swaps the **embedded prompt defaults**. It does **not** change how plugin / MCP server instructions are appended to the system prompt — those are still added by the orchestrator at request time, exactly as before.

## Coverage / safety

`TestPromptSettersCoverAllEmbedded` asserts every embedded `*.txt` has a matching setter (and every setter a backing file), so a newly added prompt can't silently become non-overridable.

## Validation

`gofmt` ✅ · `go vet` ✅ · `go build ./...` ✅ · `go test ./internal/prompts/... ./internal/orchestrator/... ./internal/config/...` ✅

Draft — opening for review; not merging.