### PR TITLE
ci: fix Redis Sentinel service container (empty password + digest pin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,19 @@ jobs:
           --health-timeout 3s
           --health-retries 5
       sentinel:
-        image: bitnami/redis-sentinel:latest
+        # Digest-pinned: Bitnami's secure-images migration dropped versioned
+        # tags from the free Docker Hub catalog, so only the floating `latest`
+        # and bare digests remain. Pinning the digest keeps CI reproducible and
+        # immune to `latest` drift (a drift on 2026-06-03 is what required the
+        # ALLOW_EMPTY_PASSWORD flag below). Bump the digest deliberately.
+        image: bitnami/redis-sentinel@sha256:ffa20700e642abc61f0d23b174b32dc923ee3e49aebe890f5b9a1f2c94bcfc4a
         ports:
           - 26379:26379
         env:
+          # Newer Bitnami images refuse to boot without a password unless this
+          # dev-mode flag is set explicitly. CI runs a throwaway sentinel with
+          # no auth, so an empty password is intentional here.
+          ALLOW_EMPTY_PASSWORD: "yes"
           REDIS_SENTINEL_ANNOUNCE_IP: "127.0.0.1"
           REDIS_MASTER_HOST: "redis"
           REDIS_MASTER_PORT_NUMBER: "6379"


### PR DESCRIPTION
## Problem

The `Test (Redis Sentinel integration)` job started failing on 2026-06-03 (master was green on 2026-06-02). The service container never initialized:

```
redis-sentinel ERROR ==> The REDIS_SENTINEL_PASSWORD environment variable is empty or not set.
   Set ALLOW_EMPTY_PASSWORD=yes to allow the container to be started with blank passwords.
##[error]Failed to initialize container bitnami/redis-sentinel:latest
```

`bitnami/redis-sentinel:latest` drifted: newer Bitnami images refuse to boot without a password. The failure is environmental (third-party image drift), not from any code change, and it now hits every PR and master push.

## Fix

- **`ALLOW_EMPTY_PASSWORD: "yes"`** — CI runs a throwaway sentinel with no auth, so an empty password is intentional (the documented Bitnami dev-mode flag).
- **Digest-pin the image.** Bitnami's secure-images migration dropped versioned tags from the free Docker Hub catalog (only floating `latest` + bare digests remain), so a digest pin is the only way to keep CI reproducible and immune to further `latest` drift.

## Verification

Ran the pinned digest locally with `ALLOW_EMPTY_PASSWORD=yes`: boots in sentinel mode, listens on 26379, and monitors the master (`+monitor master mymaster`) — so the service container's healthcheck (`redis-cli -p 26379 ping`) passes.