### PR TITLE
Make the profile language a soft fallback; add optional user-name addressing

### DIFF
--- a/cmd/opentalon/main.go
+++ b/cmd/opentalon/main.go
@@ -549,6 +549,7 @@ func main() {
 			LimitField:        cfg.Profiles.WhoAmI.LimitField,
 			LimitTimeField:    cfg.Profiles.WhoAmI.LimitTimeField,
 			LanguageField:     cfg.Profiles.WhoAmI.LanguageField,
+			NameField:         cfg.Profiles.WhoAmI.NameField,
 			ExtraHeaders:      cfg.Profiles.WhoAmI.ExtraHeaders,
 			MetadataHeaders:   cfg.Profiles.WhoAmI.MetadataHeaders,
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,6 +114,7 @@ type WhoAmIConfig struct {
 	LimitTimeField    string            `yaml:"limit_time_field"`        // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
 	CredentialsField  string            `yaml:"credentials_field"`       // optional JSON field for per-MCP-server tokens map; default "credentials"
 	LanguageField     string            `yaml:"language_field"`          // optional JSON field for user language; default "language"
+	NameField         string            `yaml:"name_field"`              // optional JSON field for user display name; default "name"
 	ExtraHeaders      map[string]string `yaml:"extra_headers,omitempty"` // static headers added to every WhoAmI call; values support ${ENV_VAR}
 	// MetadataHeaders maps an inbound message metadata key to an outbound HTTP
 	// header name. For each entry, the verifier reads msg.Metadata[key] and

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3724,6 +3724,11 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 		fmt.Fprintf(&sb, "Reply in the language of the user's most recent message, judged from the words and script they actually use. Only if that message is too short or ambiguous to identify a language, default to %s. When unsure between the message language and %s, follow the message.\n\n", p.Language, p.Language)
 	}
 
+	if p := profile.FromContext(ctx); p != nil && p.Name != "" {
+		sb.WriteString("## User\n")
+		fmt.Fprintf(&sb, "The user's name is %s. Address them by name where it feels natural; do not force it into every message.\n\n", p.Name)
+	}
+
 	return sb.String()
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3721,7 +3721,7 @@ func (o *Orchestrator) buildSystemPrompt(ctx context.Context, userMessage string
 
 	if p := profile.FromContext(ctx); p != nil && p.Language != "" {
 		sb.WriteString("## Language\n")
-		fmt.Fprintf(&sb, "IMPORTANT: You MUST respond in %s. All your replies, explanations, and summaries must be written in %s.\n\n", p.Language, p.Language)
+		fmt.Fprintf(&sb, "Reply in the language of the user's most recent message, judged from the words and script they actually use. Only if that message is too short or ambiguous to identify a language, default to %s. When unsure between the message language and %s, follow the message.\n\n", p.Language, p.Language)
 	}
 
 	return sb.String()

--- a/internal/pipeline/planner.go
+++ b/internal/pipeline/planner.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/opentalon/opentalon/internal/profile"
 	"github.com/opentalon/opentalon/internal/prompts"
 )
 
@@ -101,11 +100,7 @@ const DefaultPlanTimeout = 15 * time.Second
 // conversationContext is an optional summary of prior turns so the planner understands
 // follow-up messages (e.g. "Item" after "Create some arbitrary test object").
 func (p *Planner) Plan(ctx context.Context, message string, capabilities []CapabilityInfo, conversationContext string) (*PlanResult, error) {
-	lang := ""
-	if prof := profile.FromContext(ctx); prof != nil {
-		lang = prof.Language
-	}
-	systemPrompt := buildPlannerPrompt(capabilities, lang)
+	systemPrompt := buildPlannerPrompt(capabilities)
 	slog.Debug("planner system prompt", "prompt", systemPrompt)
 
 	// Prepend conversation context so the planner can interpret follow-up messages.
@@ -133,7 +128,7 @@ func (p *Planner) Plan(ctx context.Context, message string, capabilities []Capab
 	return parsePlanResponse(resp.Content)
 }
 
-func buildPlannerPrompt(capabilities []CapabilityInfo, language string) string {
+func buildPlannerPrompt(capabilities []CapabilityInfo) string {
 	var sb strings.Builder
 	sb.WriteString(prompts.PlannerPreamble)
 	for _, cap := range capabilities {
@@ -151,9 +146,6 @@ func buildPlannerPrompt(capabilities []CapabilityInfo, language string) string {
 				fmt.Fprintf(&sb, "  - %s: %s%s\n", param.Name, truncatePlannerDescription(param.Description, 80), req)
 			}
 		}
-	}
-	if language != "" {
-		fmt.Fprintf(&sb, "\nThe step names and descriptions must be written in %s.\n", language)
 	}
 	sb.WriteString("\n")
 	sb.WriteString(prompts.PlannerSuffix)
@@ -332,10 +324,6 @@ func repairJSON(s string) string {
 // and invite the user to confirm or cancel. userMessage is optional; when set,
 // the LLM uses it to detect the user's language and respond accordingly.
 func (p *Planner) NarratePlan(ctx context.Context, steps []*Step, userMessage ...string) (string, error) {
-	lang := ""
-	if prof := profile.FromContext(ctx); prof != nil {
-		lang = prof.Language
-	}
 	var sb strings.Builder
 	if len(userMessage) > 0 && userMessage[0] != "" {
 		fmt.Fprintf(&sb, "User's original request: %s\n\n", userMessage[0])
@@ -349,9 +337,6 @@ func (p *Planner) NarratePlan(ctx context.Context, steps []*Step, userMessage ..
 		sb.WriteString("\n")
 	}
 	systemContent := prompts.PlannerNarrate
-	if lang != "" {
-		systemContent += fmt.Sprintf(" Respond in %s.", lang)
-	}
 	resp, err := p.llm.Complete(ctx, &CompletionRequest{
 		Messages: []Message{
 			{Role: "system", Content: systemContent},
@@ -368,10 +353,6 @@ func (p *Planner) NarratePlan(ctx context.Context, steps []*Step, userMessage ..
 // hiding plugin/action names. userMessage is optional; when set, the LLM uses it
 // to detect the user's language.
 func (p *Planner) NarrateToolCall(ctx context.Context, action string, args map[string]string, userMessage ...string) (string, error) {
-	lang := ""
-	if prof := profile.FromContext(ctx); prof != nil {
-		lang = prof.Language
-	}
 	var sb strings.Builder
 	if len(userMessage) > 0 && userMessage[0] != "" {
 		fmt.Fprintf(&sb, "User's original request: %s\n\n", userMessage[0])
@@ -384,9 +365,6 @@ func (p *Planner) NarrateToolCall(ctx context.Context, action string, args map[s
 		}
 	}
 	systemContent := prompts.PlannerNarrateTool
-	if lang != "" {
-		systemContent += fmt.Sprintf(" Respond in %s.", lang)
-	}
 	resp, err := p.llm.Complete(ctx, &CompletionRequest{
 		Messages: []Message{
 			{Role: "system", Content: systemContent},

--- a/internal/pipeline/planner_test.go
+++ b/internal/pipeline/planner_test.go
@@ -221,7 +221,7 @@ func TestBuildPlannerPrompt(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildPlannerPrompt(caps, "")
+	prompt := buildPlannerPrompt(caps)
 	if prompt == "" {
 		t.Error("expected non-empty prompt")
 	}
@@ -240,7 +240,7 @@ func TestBuildPlannerPrompt(t *testing.T) {
 // `containers[]`/`items[]`), and the executor's substitution layer is
 // only useful if the planner emits paths it can actually resolve.
 func TestBuildPlannerPrompt_DocumentsChainingSyntax(t *testing.T) {
-	prompt := buildPlannerPrompt(nil, "")
+	prompt := buildPlannerPrompt(nil)
 	for _, want := range []string{
 		"Referencing prior step output",
 		"{{<step-id>.output.<json-path>}}",
@@ -269,7 +269,7 @@ func TestBuildPlannerPromptMCPDotActions(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildPlannerPrompt(caps, "")
+	prompt := buildPlannerPrompt(caps)
 
 	// The explicit format must appear so the LLM knows plugin="mcp", not "mcp.appsignal".
 	if !containsStr(prompt, "plugin=mcp | action=appsignal.get_applications") {
@@ -296,7 +296,7 @@ func TestBuildPlannerPrompt_ExcludesServerInstructions(t *testing.T) {
 			},
 		},
 	}
-	prompt := buildPlannerPrompt(caps, "")
+	prompt := buildPlannerPrompt(caps)
 
 	// Server instructions must NOT be in the planner prompt — it only decides
 	// direct vs pipeline. The main LLM system prompt has them.
@@ -306,24 +306,6 @@ func TestBuildPlannerPrompt_ExcludesServerInstructions(t *testing.T) {
 	// Tool definitions must still be present.
 	if !containsStr(prompt, "plugin=inventory | action=list-items") {
 		t.Error("planner prompt must include tool definitions")
-	}
-}
-
-func TestBuildPlannerPromptWithLanguage(t *testing.T) {
-	caps := []CapabilityInfo{
-		{Name: "jira", Description: "Jira", Actions: []ActionInfo{
-			{Name: "create_issue", Description: "Create issue"},
-		}},
-	}
-	prompt := buildPlannerPrompt(caps, "English")
-	if !containsStr(prompt, "English") {
-		t.Error("prompt should contain language instruction for English")
-	}
-
-	// Without language, no language instruction should appear.
-	promptNoLang := buildPlannerPrompt(caps, "")
-	if containsStr(promptNoLang, "must be written in") {
-		t.Error("prompt without language should not contain language instruction")
 	}
 }
 

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -25,6 +25,7 @@ type Profile struct {
 	Model        string                      // optional model override returned by WhoAmI (e.g. "anthropic/claude-3-5-sonnet-20241022")
 	ChannelType  string                      // optional channel type returned by WhoAmI (e.g. "slack", "web", "api")
 	Language     string                      // optional response language from WhoAmI (e.g. "German", "English")
+	Name         string                      // optional display name from WhoAmI, used to address the user (empty = unknown)
 	Limit        int                         // token spend limit per LimitWindow (0 = unlimited)
 	LimitWindow  time.Duration               // rolling window for Limit (0 = unlimited)
 	BudgetTokens int                         // reasoning budget tokens from WhoAmI (0 = provider default)

--- a/internal/profile/verifier.go
+++ b/internal/profile/verifier.go
@@ -48,6 +48,7 @@ type VerifierConfig struct {
 	LimitTimeField    string            // optional JSON field for limit window duration (e.g. "1h"); default "limit_time"
 	CredentialsField  string            // optional JSON field for per-MCP-server credential headers; default "credentials"
 	LanguageField     string            // optional JSON field for user language; default "language"
+	NameField         string            // optional JSON field for user display name; default "name"
 	BudgetTokensField string            // optional JSON field for reasoning budget tokens; default "budget_tokens"
 	ExtraHeaders      map[string]string // static headers sent on every WhoAmI call; ${ENV_VAR} expanded once at construction
 	// MetadataHeaders maps an inbound metadata key to an outbound HTTP header
@@ -124,6 +125,9 @@ func (c *VerifierConfig) setDefaults() {
 	}
 	if c.LanguageField == "" {
 		c.LanguageField = "language"
+	}
+	if c.NameField == "" {
+		c.NameField = "name"
 	}
 	if c.BudgetTokensField == "" {
 		c.BudgetTokensField = "budget_tokens"
@@ -429,6 +433,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string, me
 	model := jsonString(raw[v.cfg.ModelField])
 	channelTypeResp := jsonString(raw[v.cfg.ChannelTypeField])
 	language := jsonString(raw[v.cfg.LanguageField])
+	name := jsonString(raw[v.cfg.NameField])
 
 	var limit int
 	if lraw, ok := raw[v.cfg.LimitField]; ok {
@@ -468,6 +473,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string, me
 		Model:        model,
 		ChannelType:  channelTypeResp,
 		Language:     language,
+		Name:         name,
 		Limit:        limit,
 		LimitWindow:  limitWindow,
 		BudgetTokens: budgetTokens,
@@ -480,6 +486,7 @@ func (v *Verifier) callServer(ctx context.Context, token, channelType string, me
 		"model", p.Model,
 		"channel_type", p.ChannelType,
 		"language", p.Language,
+		"name", p.Name,
 	)
 	return p, nil
 }

--- a/internal/profile/verifier_test.go
+++ b/internal/profile/verifier_test.go
@@ -568,6 +568,53 @@ func TestVerifier_Language_CustomField(t *testing.T) {
 	}
 }
 
+// TestVerifier_Name verifies that the name field from the WhoAmI response is
+// stored on the profile.
+func TestVerifier_Name(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"entity_id": "u1",
+			"group":     "g1",
+			"name":      "Alex",
+		})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
+	defer v.Close()
+
+	p, err := v.Verify(context.Background(), "tok", "", nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if p.Name != "Alex" {
+		t.Errorf("Name = %q, want Alex", p.Name)
+	}
+}
+
+// TestVerifier_Name_Missing verifies that an absent name field results in an
+// empty string.
+func TestVerifier_Name_Missing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"entity_id": "u1",
+			"group":     "g1",
+		})
+	}))
+	defer srv.Close()
+
+	v := NewVerifier(VerifierConfig{URL: srv.URL}, nil, nil)
+	defer v.Close()
+
+	p, err := v.Verify(context.Background(), "tok", "", nil)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if p.Name != "" {
+		t.Errorf("Name = %q, want empty when not provided", p.Name)
+	}
+}
+
 // TestVerifier_MetadataHeaders_Forwarded verifies that values from the
 // inbound metadata map configured under MetadataHeaders are sent as outbound
 // HTTP headers on every WhoAmI request.


### PR DESCRIPTION
## What

Two related changes to how the WhoAmI profile shapes the agent's replies.

1. **Language becomes a soft fallback, not a session-wide pin.** The system prompt previously forced the whole session into the profile language (`You MUST respond in <lang>`). It now tells the model to reply in the language of the user's most recent message, judged from the words and script they use, and to fall back to the profile language only when that message is too short or ambiguous to identify a language. The planner's profile-forced language clauses are removed too — the narration base prompts already say "respond in the same language the user wrote in".

2. **Optional user name + addressing.** WhoAmI responses can carry a `name` field (configurable via `name_field`, default `name`). When present it lands in `Profile.Name`, and the system prompt asks the model to address the user by name where natural — soft, not forced into every message.

## Why

The hard per-profile language directive conflicted with deployments whose own rules already say "respond in the language the user writes in": both instructions landed in the same prompt with no precedence, so the model effectively guessed, and a user who switched languages mid-session could stay pinned to their profile language. Making the profile language a fallback lets a session follow the user.

## Compatibility

- No config changes required. `name_field` defaults to `name`; an absent name → empty `Profile.Name` → no addressing block, so existing deployments are unaffected.
- A deployment that wants a fixed reply language can express it via its own rules/prompt.
- `prompts.Hash()` is unchanged (the language/user blocks are inline, not embedded prompt files), so the VCR cassettes replay green.

## Tests

`go build ./...` and `go test ./...` pass. Added verifier tests for name present/absent; removed the planner test that asserted the deleted language clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
