### PR TITLE
docs: document http-channel in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -140,6 +140,21 @@ channels:
     # ref: "master"
     config: {}
 
+  # Synchronous HTTP request/response channel — POST a message with a profile
+  # token (same auth model as websocket-channel) and get the LLM's reply in the
+  # HTTP response body. Useful for curl, server-side cron, and backend services
+  # that prefer REST over a streaming socket. See: opentalon/http-channel.
+  # http:
+  #   enabled: true
+  #   github: "opentalon/http-channel"
+  #   ref: "master"
+  #   config:
+  #     addr: "0.0.0.0:9100"   # host:port to listen on
+  #     path: "/chat"           # endpoint path (set "/" when an ingress strips the prefix upstream)
+  #     timeout: "120s"         # max wait per request for the LLM response
+  #     cors_origins:           # omit to allow all (dev only)
+  #       - "https://mysite.com"
+
   # YAML-driven channels (no compiled binary — run in-process from channel.yaml spec)
   # slack:
   #   enabled: true


### PR DESCRIPTION
## Summary

Adds the new `http` channel (https://github.com/opentalon/http-channel) to `config.example.yaml` as a commented-out option, alongside the existing console / slack / telegram blocks.

The http-channel is a synchronous request/response channel that reuses the same profile-token auth as websocket-channel: clients POST a message with `Authorization: Bearer <profile_token>` (or `?token=`) and get the LLM's reply in the response body. The full flow (verifier, session, memory, tools, spend limit) runs through the same orchestrator path every other channel uses — `internal/channel/handler.go` already handles it without any code change.

This is a docs-only change. No code, no schema, no behaviour.

## Test plan

- [x] Visual diff review — the new block follows the same comment/style convention as the surrounding channel entries
- [ ] Optional: copy the block into a local config.yaml uncommented and verify the channel starts (requires the http-channel binary built locally or fetched via the `github:` ref)