### PR TITLE
feat(state): add channel_id column to sessions with backfill

### DIFF
--- a/internal/state/store/migrations/012_sessions_channel_id.sql
+++ b/internal/state/store/migrations/012_sessions_channel_id.sql
@@ -1,0 +1,31 @@
+-- Per-session channel label, mirroring the channel_id already carried per LLM
+-- call in profile_usage (migration 002). Today every channel record lives in
+-- profile_usage only, so "show me HTTP-channel sessions" requires a JOIN that
+-- the api-plugin REST surface does not perform. A column on sessions makes
+-- per-channel filtering and grouping cheap and indexable for sessions/events
+-- queries — same shape entity_id and group_id already have (migration 004).
+--
+-- Backfill from profile_usage: the channel_id is per-session by construction
+-- (msg.ChannelID is stamped once per inbound message and copied into every
+-- usage row for that session), so a scalar subquery picking any matching row
+-- yields the authoritative value. LIMIT 1 is portable across SQLite and
+-- PostgreSQL. Sessions with no profile_usage rows (orchestrator failed before
+-- the first LLM call, no profile verification configured) keep the empty
+-- default — readers must treat '' as "channel unknown" rather than as a
+-- distinct group, matching how entity_id='' and group_id='' are handled today.
+--
+-- TEXT not VARCHAR for SQLite/PostgreSQL portability — matches migration 011.
+-- Column is NOT NULL with a DEFAULT '' so existing readers that SELECT * from
+-- sessions never see NULL for this field; matches the entity_id / group_id
+-- pattern from migration 004.
+ALTER TABLE sessions ADD COLUMN channel_id TEXT NOT NULL DEFAULT '';
+
+UPDATE sessions
+   SET channel_id = COALESCE(
+       (SELECT channel_id FROM profile_usage
+         WHERE profile_usage.session_id = sessions.id
+         LIMIT 1),
+       '')
+ WHERE channel_id = '';
+
+CREATE INDEX IF NOT EXISTS idx_sessions_channel_id ON sessions(channel_id);

--- a/internal/state/store/store_test.go
+++ b/internal/state/store/store_test.go
@@ -26,8 +26,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version: %v", err)
 	}
-	if v != 11 {
-		t.Errorf("schema_version = %d, want 11", v)
+	if v != 12 {
+		t.Errorf("schema_version = %d, want 12", v)
 	}
 
 	// Re-open: idempotent, no error
@@ -40,8 +40,8 @@ func TestOpenAndMigrations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read schema_version (second open): %v", err)
 	}
-	if v != 11 {
-		t.Errorf("schema_version after re-open = %d, want 11", v)
+	if v != 12 {
+		t.Errorf("schema_version after re-open = %d, want 12", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `sessions.channel_id TEXT NOT NULL DEFAULT ''` plus `idx_sessions_channel_id` (migration **012**).
- Backfills the column from `profile_usage.channel_id` so historical sessions are immediately queryable by channel.
- Bumps the schema-version test assertion from 11 → 12.

This is the schema half of the per-channel analytics work. Reader/writer wiring (`SessionStore.Create` + `pkg/channel.CreateSessionFunc` signature change) and the api-plugin filter/group endpoints are intentionally separate follow-up PRs — that change touches public API on `pkg/channel` and deserves its own review.

### Why the backfill

Every LLM call already records the channel in `profile_usage.channel_id` (migration 002). Because `msg.ChannelID` is stamped once per inbound message and copied to every usage row for that session, the channel is per-session by construction — a scalar subquery picking any matching row yields the authoritative value. `LIMIT 1` is portable across SQLite and PostgreSQL.

Sessions with no `profile_usage` rows (orchestrator failed before the first LLM call, or no profile verification configured) keep the empty default. Readers must treat `''` as "channel unknown" rather than as a distinct group — same convention as `entity_id=''` and `group_id=''` from migration 004.

### Why this column at all

Today "show me HTTP-channel sessions" requires a JOIN between `sessions` and `profile_usage`, which the api-plugin REST surface doesn't perform. With the column on `sessions`, per-channel filter/group becomes a single indexable predicate on the table consumers already query.

## Test plan

- [x] `go test ./internal/state/...` — passes; the schema-version assertion now sees v=12 on both fresh open and re-open.
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [ ] Verify migration applies cleanly on a non-empty PostgreSQL DB (CI covers SQLite; PG path uses the same correlated-subquery + LIMIT 1 syntax that already works in 006).